### PR TITLE
Fixes #41 : disabled BFormCheckbox can still be toggled

### DIFF
--- a/src/composables/useFormCheck.ts
+++ b/src/composables/useFormCheck.ts
@@ -181,8 +181,10 @@ export function useFormCheck(
   );
 
   const toggleChecked = () => {
-    isChecked.value = !isChecked.value;
-    handleUpdate(isChecked, checked, value, uncheckedValue, localChecked, emit);
+    if (!disabled) {
+      isChecked.value = !isChecked.value;
+      handleUpdate(isChecked, checked, value, uncheckedValue, localChecked, emit);
+    }
   };
   const isRequired = computed(() => {
     if (!formName) {


### PR DESCRIPTION
fixes #41 by preventing the togle on the label when disabled