### PR TITLE
remove vue-cli support; fix #33

### DIFF
--- a/docs/.vuepress/clientAppEnhance.js
+++ b/docs/.vuepress/clientAppEnhance.js
@@ -1,11 +1,11 @@
 import { defineClientAppEnhance } from '@vuepress/client'
 import 'bootstrap/dist/css/bootstrap.min.css'
-import '../../dist/bootstrap-vue-3.css';
+import '../../dist/bootstrap-vue-3.css'
 
 
 export default defineClientAppEnhance(async ({ app, router, siteData }) => {
   if (!__SSR__) {
-    const BootstrapVue = await import('../../dist/bootstrap-vue-3.common');
+    const BootstrapVue = await import('../../dist/bootstrap-vue-3.es')
     app.use(BootstrapVue.default)
   }
 })

--- a/package.json
+++ b/package.json
@@ -4,16 +4,21 @@
   "description": "Early (but lovely) implementation of Vue 3, Bootstrap 5 and Typescript",
   "version": "0.0.1-alpha.4",
   "license": "MIT",
-  "main": "dist/bootstrap-vue-3.common.js",
+  "main": "dist/bootstrap-vue-3.umd.js",
+  "module": "./dist/bootstrap-vue-3.es.js",
+  "exports": {
+    ".": {
+      "import": "./dist/bootstrap-vue-3.es.js",
+      "require": "./dist/bootstrap-vue-3.umd.js"
+    }
+  },
   "private": false,
   "scripts": {
     "audit": "improved-yarn-audit --ignore-dev-deps --min-severity moderate",
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "serve-cli": "vue-cli-service serve",
-    "build-cli": "vue-cli-service build --target lib -name bootstrap-vue-3 src/BootstrapVue.ts",
-    "lint": "vue-cli-service lint",
+    "lint": "eslint src",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:deploy": "./scripts/deploy.sh",
@@ -37,10 +42,6 @@
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "@vitejs/plugin-vue": "1.x.x",
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-plugin-eslint": "~4.5.0",
-    "@vue/cli-plugin-typescript": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
     "@vue/compiler-sfc": "^3.0.0",
     "@vue/eslint-config-typescript": "^7.0.0",
     "@vue/test-utils": "^2.0.0-rc.11",

--- a/public/index.html
+++ b/public/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <link rel="icon" href="favicon.ico">
+    <title>bootstrap-vue-3</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      We're sorry but this app doesn't work properly without JavaScript enabled. Please enable it to continue.
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,7 @@
 set -e
 
 # build library
-yarn run build-cli
+yarn run build
 
 # build
 yarn run docs:build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ const config = defineConfig({
       // into your library
       external: ['vue'],
       output: {
+        assetFileNames: `bootstrap-vue-3.[ext]`, //without this, it generates build/styles.css
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,31 +1,48 @@
 //import builtins from 'rollup-plugin-node-builtins'
 
-import { defineConfig } from "vite"
+import {defineConfig} from "vite"
 import vue from '@vitejs/plugin-vue'
-import { resolve } from "path"
+import {resolve} from "path"
 
 const config = defineConfig({
-    resolve: {
-        alias: {
-            "@": `${resolve(__dirname, "src")}`,
-        },
+  resolve: {
+    alias: {
+      "@": `${resolve(__dirname, "src")}`,
     },
+  },
 
-    build: {
-        minify: true,
+  build: {
+    minify: true,
+    lib: {
+      entry: resolve(__dirname, 'src/BootstrapVue.ts'),
+      name: 'bootstrap-vue-3',
+      fileName: (format) => `bootstrap-vue-3.${format}.js`
     },
+    rollupOptions: {
+      // make sure to externalize deps that shouldn't be bundled
+      // into your library
+      external: ['vue'],
+      output: {
+        // Provide global variables to use in the UMD build
+        // for externalized deps
+        globals: {
+          vue: 'Vue'
+        }
+      }
+    }
+  },
 
-    plugins: [
-        vue({
-            include: [/\.vue$/, /\.md$/],
-        }),
-    ],
+  plugins: [
+    vue({
+      include: [/\.vue$/, /\.md$/],
+    }),
+  ],
 
-    server: {
-        host: 'localhost', //this is the default
-        port: 8080, //this is the default       
+  server: {
+    host: 'localhost', //this is the default
+    port: 8080, //this is the default       
 
-    },
+  },
 })
 
 export default config


### PR DESCRIPTION
`yarn run build` builds the lib using vite now

If really needed, `common.js` could also be built: https://vitejs.dev/config/#build-lib
