### PR TITLE
Documentation for BFormCheckbox

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -28,6 +28,7 @@ export default defineUserConfig<DefaultThemeOptions>({
               '/components/README.md',
               '/components/Accordion.md',
               '/components/Badge.md',
+              '/components/FormCheckbox.md',
               '/components/Progress.md',
               '/components/Spinners.md',
             ]

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,5 +1,5 @@
 :root {
-    --content-width: 960px;
+    --content-width: 1200px;
 }
 
 body {

--- a/docs/components/FormCheckbox.md
+++ b/docs/components/FormCheckbox.md
@@ -1,0 +1,145 @@
+# Form Checkbox
+For cross browser consistency, `<b-form-checkbox>` uses Bootstrap's custom checkbox input to replace the browser default checkbox input. It is built on top of semantic and accessible markup, so it is a solid replacement for the default checkbox input.
+
+## Button style checkboxes
+
+You can optionally render checkboxes to appear as buttons, either individually, or in a group.
+
+Button style checkboxes will have the class .active automatically applied to the label when they are in the checked state.
+### Individual checkbox button style
+A single checkbox can be rendered with a button appearance by setting the prop button to true
+
+Change the button variant by setting the button-variant prop to one of the standard Bootstrap button variants (see `<b-button>` for supported variants). The default variant is secondary.
+
+<ClientOnly>
+    <b-card>
+        <div class="d-flex flex-row">
+            <b-form-checkbox class="m-2" button>Button Checkbox</b-form-checkbox>
+            <b-form-checkbox class="m-2" button button-variant="danger">Button Checkbox</b-form-checkbox>
+        </div>
+    </b-card>
+</ClientOnly>
+
+``` html
+    <b-form-checkbox button>Button Checkbox</b-form-checkbox>
+    <b-form-checkbox button button-variant="danger">Button Checkbox</b-form-checkbox>
+```
+## Switch style checkboxes
+Switch styling is supported on `<b-form-checkbox>` components.
+
+Note: If the checkbox is in [button mode](#button-style-checkboxes), switch mode will have no effect.
+
+### Individual checkbox switch style
+A single checkbox can be rendered with a switch appearance by setting the prop switch to true
+
+<ClientOnly>
+    <b-card>
+        <b-form-checkbox switch>Switch Checkbox {{ checked }}</b-form-checkbox>
+    </b-card>
+</ClientOnly>
+
+``` html
+    <b-form-checkbox switch>Switch Checkbox</b-form-checkbox>
+```
+## Non custom check inputs (plain)
+You can have `<b-form-checkbox>` render a browser native checkbox input by setting the plain prop to `false`.
+
+<ClientOnly>
+    <b-card>
+        <b-form-checkbox :plain="false">Plain Checkbox</b-form-checkbox>
+    </b-card>
+</ClientOnly>
+
+``` html
+    <b-form-checkbox :plain="false">Plain Checkbox</b-form-checkbox>
+```
+
+## Contextual states
+Bootstrap includes validation styles for valid and invalid states on most form controls.
+
+Generally speaking, you'll want to use a particular state for specific types of feedback:
+
+- `false` (denotes invalid state) is great for when there's a blocking or required field. A user must fill in this field properly to submit the form.
+- `true` (denotes valid state) is ideal for situations when you have per-field validation throughout a form and want to encourage a user through the rest of the fields.
+- `null` Displays no validation state (neither valid nor invalid)
+To apply one of the contextual state icons on `<b-form-checkbox>`, set the state prop to false (for invalid), true (for valid), or null (no validation state).
+
+Note: Contextual states are not supported when in button mode.
+
+<ClientOnly>
+    <b-card>
+        <b-form-checkbox :state="false">Checkbox state false</b-form-checkbox>
+        <b-form-checkbox :state="true">Checkbox state true</b-form-checkbox>
+        <b-form-checkbox>Checkbox state null</b-form-checkbox>
+    </b-card>
+</ClientOnly>
+
+``` html
+    <b-form-checkbox :state="false">Checkbox state false</b-form-checkbox>
+    <b-form-checkbox :state="true">Checkbox state true</b-form-checkbox>
+    <b-form-checkbox>Checkbox state null</b-form-checkbox>
+```
+## Autofocus
+When the autofocus prop is set on `<b-form-checkbox>`, the input will be auto-focused when it is inserted (i.e. mounted) into the document, or re-activated when inside a Vue `<keep-alive>` component. Note that this prop does not set the autofocus attribute on the input, nor can it tell when the input becomes visible.
+
+## Indeterminate (tri-state) support
+Normally a checkbox input can only have two states: checked or unchecked. They can have any value, but they either submit that value (checked) or don't (unchecked) with a form submission (although BootstrapVue allows a value for the unchecked state on a single checkbox)
+
+Visually, there are actually three states a checkbox can be in: checked, unchecked, or **indeterminate**.
+
+The indeterminate state is **visual only**. The checkbox is still either checked or unchecked as a value. That means the visual indeterminate state masks the real value of the checkbox, so that better make sense in your UI!
+
+`<b-form-checkbox>` supports setting this visual indeterminate state via the indeterminate prop (defaults to false). Clicking the checkbox will clear its indeterminate state. 
+
+<ClientOnly>
+    <b-card>
+        <b-form-checkbox :indeterminate="true">Click me to see what happens</b-form-checkbox>
+    </b-card>
+</ClientOnly>
+
+``` html
+    <b-form-checkbox :indeterminate="true">Click me to see what happens</b-form-checkbox>
+```
+## Component reference
+### `<b-form-checkbox>`
+### Properties
+
+| Property | Type | Default | Description
+| --- | --- | --- | --- |
+| `aria-label` | `String` |  | Sets the value of `aria-label` attribute on the rendered element | 
+| <nobr>`aria-labeledby`</nobr> | `String` |  | The ID of the element that provides a label for this component. Used as the value for the `aria-labelledby` attribute | 
+| `autofocus` | `Boolean` | `false` | When set to `true`, attempts to auto-focus the control when it is mounted, or re-activated when in a keep-alive. Does not set the `autofocus` attribute on the control | 
+| `button` | `Boolean` | `false` | When set, renders the checkbox with the appearance of a button | 
+| <nobr>`button-variant`</nobr> | `String` | `secondary` | Applies one of Bootstrap's theme colors when in 'button' mode | 
+| `checked` | `Boolean,String, Array` | `null` | The current value of the checkbox(es). Must be an array when there are multiple checkboxes | 
+| `disabled` | `Boolean` | `false` | When set to `true`, disables the component's functionality and places it in a disabled state | 
+| `form` | `String` |  | ID of the form that the form control belongs to. Sets the `form` attribute on the control | 
+| `id` | `String` |  | Used to set the `id` attribute on the rendered content, and used as the base to generate any additional element IDs as needed. When not set, an autogenerated id is used. | 
+| `indeterminate` | `Boolean` | `false` | Renders the checkbox in an indeterminate state. | 
+| `inline` | `Boolean` | `false` | When set, renders the checkbox as an inline element rather than as a 100% width block | 
+| `name` | `String` |  | Sets the value of the `name` attribute on the form control | 
+| `plain` | `Boolean` | `true` | When false, renders the form control in plain mode, rather than custom styled mode | 
+| `required` | `Boolean` |  | Adds the `required` attribute to the form control when `name` is also filled in. | 
+| ~~`size`~~ | `String` | `md` | Set the size of the component's appearance. 'sm', 'md' (default), or 'lg' | 
+| `state` | `Boolean` |  | Controls the validation state appearance of the component. `true` for valid, `false` for invalid, or `null` for no validation state | 
+| `switch` | `Boolean` | `false` | When set, renders the checkbox with the appearance of a switch | 
+| `unchecked-value` | `String`,`Boolean` | `false` | Value returned when this checkbox is unchecked.| 
+| `value` | `String`,`Boolean`, `Object` | `false` | Value returned when this checkbox is checked.| 
+
+#### v-model
+
+
+### Slots
+
+| Name | Description
+| --- | --- |
+| `default` | Content to place in the label of the form checkbox
+
+### Events
+| Name | Argument | Description
+| --- | --- | --- |
+| `change` | `checked` - Value of checkbox(es). When bound to multiple checkboxes, value will be an array | Emitted when selected value(s) is changed due to user interaction
+| `input` | `checked` - Value of checkbox(es). When bound to multiple checkboxes, value will be an array | Emitted when selected value(s) is changed
+
+
+

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -11,6 +11,9 @@ BootstrapVue 3 components
             <RouterLink to="./Badge.html">Badge</RouterLink> — Small and adaptive tag for adding context to just about any content.
         </b-list-group-item>
         <b-list-group-item>
+            <RouterLink to="./FormCheckbox.html">Form Checkbox</RouterLink> — Custom checkbox input and checkbox group to replace the browser default checkbox input, built on top of semantic and accessible markup. Optionally supports switch styling.
+        </b-list-group-item>
+        <b-list-group-item>
             <RouterLink to="./Progress.html">Progress</RouterLink> — A custom progress component for displaying simple or complex progress bars, featuring support for horizontally stacked bars, animated backgrounds, and text labels.
         </b-list-group-item>
         <b-list-group-item>

--- a/docs/reference/parityList.md
+++ b/docs/reference/parityList.md
@@ -78,6 +78,30 @@ This is a <Badge type="warning" text="non-standard" /> component.
 
 ## Form Checkbox
 
+### Properties
+
+| Property | Status | Observations
+| --- | --- | --- |
+| `aria-label` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `aria-labeledby` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `autofocus` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `button` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `button-variant` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `checked` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `disabled` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `form` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `id` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `indeterminate` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `inline` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `name` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `plain` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed | reverse behavior compared with bootstrap-vue
+| `required` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `size` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/0)
+| `state` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `switch` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `unchecked-value` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+| `value` | ![](https://us-central1-progress-markdown.cloudfunctions.net/progress/100) Completed
+
 ## Form Datepicker
 
 This is a <Badge type="warning" text="non-standard" /> component.


### PR DESCRIPTION
Preliminary documentation for BFormCheckbox

Remarks :
- v-model does not seem to work, so this is not mentioned yet
- as stated in #46 , the plain property seems to work opposite of bootstrap-vue. Documentation reflects the behavior of bootstrap-vue-3
- size property is available, but not implemented. So documented as strike-through. Can be removed if this project is not going to implement the size property

Request :
- Can anybody show me how to implement script in markdown. I would like to include display of the current checked value like the doc of bootstrap-vue.
