### PR TITLE
fix: v-model support for form radio

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -774,14 +774,75 @@
     <p />
     <div>
       <h1>Radio form</h1>
-      <b-form-radio>Default</b-form-radio>
-      <b-form-radio button> Button format </b-form-radio>
-      <b-form-radio required> Required </b-form-radio>
-      <b-form-radio disabled> Disabled </b-form-radio>
-      <b-form-radio indeterminate> Indeterminate </b-form-radio>
-      <b-form-radio plain>Plain</b-form-radio>
+      <div class="row">
+        <b-form-radio v-model="radioDefault" class="col-4">Default</b-form-radio>
+        <div class="col-6">Checked: {{ radioDefault }}</div>
+      </div>
+      <div class="row">
+        <b-form-radio v-model="radioButton" button class="col-4">Button format</b-form-radio>
+        <div class="col-6">Checked: {{ radioButton }}</div>
+      </div>
+      <div class="row">
+        <b-form-radio v-model="radioRequired" required class="col-4">Required</b-form-radio>
+        <div class="col-6">Checked: {{ radioRequired }}</div>
+      </div>
+      <div class="row">
+        <b-form-radio disabled>Disabled</b-form-radio>
+      </div>
+      <div class="row">
+        <b-form-radio v-model="radioIndeterminate" indeterminate class="col-4"
+          >Indeterminate</b-form-radio
+        >
+        <div class="col-6">Checked: {{ radioIndeterminate }}</div>
+      </div>
+      <div class="row">
+        <b-form-radio
+          v-model="radioString"
+          value="correct"
+          unchecked-value="incorrect"
+          class="col-4"
+          >Bound to string</b-form-radio
+        >
+        <div class="col-6">Value: {{ radioString }}</div>
+      </div>
+      <div class="row">
+        <b-form-radio v-model="radioPlain" plain class="col-4">Plain</b-form-radio>
+        <div class="col-6">Checked: {{ radioPlain }}</div>
+      </div>
+      <h6>Individual radios grouped</h6>
+      <div class="form-group">
+        <b-form-radio v-model="radioSelected" name="some-radios" value="A">Option A</b-form-radio>
+        <b-form-radio v-model="radioSelected" name="some-radios" value="B">Option B</b-form-radio>
+      </div>
+      <div class="mt-3">
+        Selected: <strong>{{ radioSelected }}</strong>
+      </div>
+      <p />
+      <h6>Radio bound to array</h6>
+      <div class="row">
+        <div class="col-4"><strong>Select some cars</strong></div>
+        <div class="col-4"><strong>Selected cars</strong></div>
+      </div>
+      <div class="row">
+        <div class="col-4">
+          <b-form-radio
+            v-for="(car, index) in radioAvailableCars"
+            :key="index"
+            v-model="radioSelectedCars"
+            :value="car"
+          >
+            {{ car }}
+          </b-form-radio>
+        </div>
+        <div class="col-8">
+          <ul>
+            <li v-for="(car, index) in radioSelectedCars" :key="index">{{ car }}</li>
+          </ul>
+        </div>
+      </div>
     </div>
 
+    <p />
     <div>
       <div v-b-visible.once="handleVisible">Handle Visible Test</div>
       <div v-if="handledVisible">This should only show if handleVisible was triggered</div>
@@ -1127,6 +1188,16 @@ export default defineComponent({
     const checkedAvailableCars = ['BMW', 'Mercedes', 'Toyota']
     const checkedSelectedCars = ref([])
 
+    const radioDefault = ref(false)
+    const radioButton = ref(false)
+    const radioRequired = ref(false)
+    const radioIndeterminate = ref(false)
+    const radioString = ref('incorrect')
+    const radioPlain = ref(false)
+    const radioAvailableCars = ['BMW', 'Mercedes', 'Toyota']
+    const radioSelectedCars = ref([])
+    const radioSelected = ref()
+
     onMounted(() => {
       // input.value?.focus();
       breadcrumb.items.push({
@@ -1159,6 +1230,15 @@ export default defineComponent({
       checkedPlain,
       checkedAvailableCars,
       checkedSelectedCars,
+      radioDefault,
+      radioButton,
+      radioRequired,
+      radioIndeterminate,
+      radioString,
+      radioPlain,
+      radioSelected,
+      radioAvailableCars,
+      radioSelectedCars,
     }
   },
   data() {

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -12,6 +12,7 @@
       :form="form"
       :aria-label="ariaLabel"
       :aria-labelledby="ariaLabelledBy"
+      :aria-required="required ? 'true' : null"
       :value="value"
       :indeterminate="indeterminate"
       :checked="isChecked"

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -2,33 +2,25 @@
   <div :class="classes">
     <input
       :id="computedId"
+      v-bind="$attrs"
       ref="input"
       :class="inputClasses"
       type="radio"
-      :name="name"
-      :form="form"
-      :value="value"
-      :checked="isChecked"
       :disabled="disabled"
       :required="isRequired"
-      :aria-required="required ? 'true' : null"
+      :name="name"
+      :form="form"
       :aria-label="ariaLabel"
       :aria-labelledby="ariaLabelledBy"
-      :indeterminate="indeterminate"
-      v-bind="$attrs"
+      :value="value"
+      :checked="isChecked"
+      :aria-required="required ? 'true' : null"
       @click="toggleChecked()"
       @focus="focus()"
       @blur="blur()"
       @input="(event) => onInput(event)"
     />
-    <label
-      v-if="$slots.default || !plain"
-      :class="labelClasses"
-      :for="id"
-      @click="toggleChecked()"
-      @focus="focus()"
-      @blur="blur()"
-    >
+    <label v-if="$slots.default || !plain" :for="computedId" :class="labelClasses">
       <slot />
     </label>
   </div>
@@ -44,7 +36,7 @@ export default defineComponent({
     ariaLabel: {type: String},
     ariaLabelledBy: {type: String},
     autofocus: {type: Boolean, default: false},
-    checked: {type: [Boolean, String, Array], default: null},
+    modelValue: {type: [Boolean, String, Array], default: null},
     plain: {type: Boolean, default: false},
     button: {type: Boolean, default: false},
     switch: {type: Boolean, default: false},
@@ -52,7 +44,6 @@ export default defineComponent({
     buttonVariant: {type: String, default: 'secondary'},
     form: {type: String},
     id: {type: String},
-    indeterminate: {type: Boolean},
     inline: {type: Boolean, default: false},
     name: {type: String},
     required: {type: Boolean, default: false},
@@ -85,7 +76,7 @@ export default defineComponent({
       props.inline,
       props.switch,
       props.state,
-      props.checked,
+      props.modelValue,
       props.value,
       props.buttonVariant,
       props.uncheckedValue,
@@ -95,7 +86,14 @@ export default defineComponent({
       emit
     )
     onUpdated(() => {
-      handleUpdate(isChecked, props.checked, props.value, props.uncheckedValue, localChecked, emit)
+      handleUpdate(
+        isChecked,
+        props.modelValue,
+        props.value,
+        props.uncheckedValue,
+        localChecked,
+        emit
+      )
     })
 
     return {

--- a/src/components/BFormRadio/form-radio.spec.js
+++ b/src/components/BFormRadio/form-radio.spec.js
@@ -8,7 +8,7 @@ describe('form-radio', () => {
   it('default has structure <div><input><label></label></div>', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -28,7 +28,7 @@ describe('form-radio', () => {
   it('default has wrapper class form-check', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -44,7 +44,7 @@ describe('form-radio', () => {
   it('default has input type radio', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -61,7 +61,7 @@ describe('form-radio', () => {
   it('default has input class form-check-input', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -78,7 +78,7 @@ describe('form-radio', () => {
   it('default has label class form-check-label', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: false,
+        modelValue: false,
         value: 'a',
       },
       slots: {
@@ -95,7 +95,7 @@ describe('form-radio', () => {
   it('has default slot content in label', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -111,7 +111,7 @@ describe('form-radio', () => {
   it('default has no disabled attribute on input', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -127,7 +127,7 @@ describe('form-radio', () => {
   it('has disabled attribute on input when prop disabled set', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
         disabled: true,
       },
@@ -144,7 +144,7 @@ describe('form-radio', () => {
   it('default has no required attribute on input', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -160,7 +160,7 @@ describe('form-radio', () => {
   it('does not have required attribute on input when prop required set and name prop not provided', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
         required: true,
       },
@@ -177,7 +177,7 @@ describe('form-radio', () => {
   it('has required attribute on input when prop required and name set', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
         name: 'test',
         required: true,
@@ -195,7 +195,7 @@ describe('form-radio', () => {
   it('default has no name attribute on input', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -211,7 +211,7 @@ describe('form-radio', () => {
   it('has name attribute on input when name prop set', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
         name: 'test',
       },
@@ -229,7 +229,7 @@ describe('form-radio', () => {
   it('default has no form attribute on input', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -245,7 +245,7 @@ describe('form-radio', () => {
   it('has form attribute on input when form prop set', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
         form: 'test',
       },
@@ -277,7 +277,7 @@ describe('form-radio', () => {
   it('default has class form-check-inline when prop inline=true', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
         inline: true,
       },
@@ -295,7 +295,7 @@ describe('form-radio', () => {
   it('default has no input validation classes by default', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -314,7 +314,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         state: null,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -333,7 +333,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         state: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -352,7 +352,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         state: false,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -367,13 +367,112 @@ describe('form-radio', () => {
     wrapper.unmount()
   })
 
+  it('has id attribute on input when id prop set', async () => {
+    const wrapper = mount(BFormRadio, {
+      props: {
+        modelValue: false,
+        id: 'test',
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    const $input = wrapper.find('input')
+    expect($input.attributes('id')).toBeDefined()
+    expect($input.attributes('id')).toEqual('test')
+
+    wrapper.unmount()
+  })
+
+  it('default has id attribute on input', async () => {
+    const wrapper = mount(BFormRadio, {
+      props: {
+        modelValue: false,
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    const $input = wrapper.find('input')
+    expect($input.attributes('id')).toBeDefined()
+
+    wrapper.unmount()
+  })
+
+  it('has for attribute on label when id prop set', async () => {
+    const wrapper = mount(BFormRadio, {
+      props: {
+        modelValue: false,
+        id: 'test',
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    const $label = wrapper.find('label')
+    expect($label.attributes('for')).toBeDefined()
+    expect($label.attributes('for')).toEqual('test')
+
+    wrapper.unmount()
+  })
+
+  it('default has for attribute on label equal to id property of input', async () => {
+    const wrapper = mount(BFormRadio, {
+      props: {
+        modelValue: false,
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    const $input = wrapper.find('input')
+    expect($input.attributes('id')).toBeDefined()
+
+    const $label = wrapper.find('label')
+    expect($label.attributes('for')).toBeDefined()
+    expect($input.attributes('id')).toEqual($label.attributes('for'))
+
+    wrapper.unmount()
+  })
+
+  it('default has unique id attribute on input', async () => {
+    const wrapper = mount(BFormRadio, {
+      props: {
+        modelValue: false,
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    const wrapper2 = mount(BFormRadio, {
+      props: {
+        modelValue: false,
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    const $input = wrapper.find('input')
+    const $input2 = wrapper2.find('input')
+    expect($input.attributes('id')).toBeDefined()
+    expect($input2.attributes('id')).toBeDefined()
+    expect($input.attributes('id')).not.toEqual($input2.attributes('id'))
+
+    wrapper.unmount()
+  })
   // --- Plain styling ---
 
   it('plain has structure <div><input><label></label></div>', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -394,7 +493,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -411,7 +510,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -429,7 +528,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -447,7 +546,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: false,
+        modelValue: false,
         value: 'a',
       },
       slots: {
@@ -465,7 +564,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -482,7 +581,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -502,7 +601,7 @@ describe('form-radio', () => {
       props: {
         state: null,
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -522,7 +621,7 @@ describe('form-radio', () => {
       props: {
         state: true,
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -542,7 +641,7 @@ describe('form-radio', () => {
       props: {
         state: false,
         plain: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -563,7 +662,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         button: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -585,7 +684,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         button: true,
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -603,7 +702,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         button: true,
-        checked: false,
+        modelValue: false,
         value: 'a',
       },
       slots: {
@@ -625,7 +724,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         button: true,
-        checked: 'a',
+        modelValue: 'a',
         value: 'a',
       },
       slots: {
@@ -647,7 +746,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         button: true,
-        checked: false,
+        modelValue: false,
         value: 'a',
       },
       slots: {
@@ -678,7 +777,7 @@ describe('form-radio', () => {
       attachTo: createContainer(),
       props: {
         button: true,
-        checked: false,
+        modelValue: false,
         value: 'a',
       },
       slots: {
@@ -713,7 +812,7 @@ describe('form-radio', () => {
       props: {
         button: true,
         buttonVariant: 'primary',
-        checked: false,
+        modelValue: false,
         value: 'a',
       },
       slots: {
@@ -737,7 +836,7 @@ describe('form-radio', () => {
   it.skip('default has internal localChecked="" when prop checked=""', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: '',
+        modelValue: '',
         value: 'a',
       },
       slots: {
@@ -755,7 +854,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       props: {
         value: 'bar',
-        checked: 'bar',
+        modelValue: 'bar',
       },
       slots: {
         default: 'foobar',
@@ -771,7 +870,7 @@ describe('form-radio', () => {
   it('default has internal localChecked set to value when checked changed to value', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        checked: false,
+        modelValue: false,
         value: 'bar',
       },
       slots: {
@@ -782,7 +881,7 @@ describe('form-radio', () => {
     expect(wrapper.vm.localChecked).toBeDefined()
     expect(wrapper.vm.localChecked).toBe(false)
     await wrapper.setProps({
-      checked: 'bar',
+      modelValue: 'bar',
     })
     expect(wrapper.vm.localChecked).toEqual('bar')
     expect(wrapper.emitted('input')).toBeDefined()
@@ -797,7 +896,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       attachTo: createContainer(),
       props: {
-        checked: false,
+        modelValue: false,
         value: 'bar',
       },
       slots: {
@@ -821,12 +920,161 @@ describe('form-radio', () => {
     wrapper.unmount()
   })
 
+  it('emits a change event when label clicked', async () => {
+    const wrapper = mount(BFormRadio, {
+      attachTo: createContainer(),
+      props: {
+        uncheckedValue: 'foo',
+        value: 'bar',
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.vm.localChecked).toBeDefined()
+    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.emitted('change')).toBeUndefined()
+
+    const $label = wrapper.find('label')
+    expect($label).toBeDefined()
+
+    await $label.trigger('click')
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(1)
+    expect(wrapper.emitted('change')[0][0]).toEqual('bar')
+
+    await $label.trigger('click') // unchecking should not emit change
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(1)
+    expect(wrapper.emitted('change')[0][0]).toEqual('bar')
+
+    wrapper.unmount()
+  })
+
+  it('does not emit a change event when clicked if disabled', async () => {
+    const wrapper = mount(BFormRadio, {
+      attachTo: createContainer(),
+      props: {
+        uncheckedValue: 'foo',
+        value: 'bar',
+        disabled: true,
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.vm.localChecked).toBeDefined()
+    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.emitted('change')).toBeUndefined()
+
+    const $input = wrapper.find('input')
+    expect($input).toBeDefined()
+
+    await $input.trigger('click')
+    expect(wrapper.emitted('change')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('does not emit a change event when label clicked if disabled', async () => {
+    const wrapper = mount(BFormRadio, {
+      attachTo: createContainer(),
+      props: {
+        uncheckedValue: 'foo',
+        value: 'bar',
+        disabled: true,
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.vm.localChecked).toBeDefined()
+    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.emitted('change')).toBeUndefined()
+
+    const $label = wrapper.find('label')
+    expect($label).toBeDefined()
+
+    await $label.trigger('click')
+    expect(wrapper.emitted('change')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('works when v-model bound to an array', async () => {
+    const wrapper = mount(BFormRadio, {
+      attachTo: createContainer(),
+      props: {
+        value: 'bar',
+        modelValue: ['foo'],
+      },
+      slots: {
+        default: 'foobar',
+      },
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.vm.localChecked).toBeDefined()
+    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
+    expect(wrapper.vm.localChecked.length).toBe(1)
+    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+
+    const $input = wrapper.find('input')
+    expect($input).toBeDefined()
+
+    await $input.trigger('click')
+    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
+    expect(wrapper.vm.localChecked.length).toBe(2)
+    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(wrapper.vm.localChecked[1]).toEqual('bar')
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(1)
+    expect(wrapper.emitted('change')[0][0]).toEqual(['foo', 'bar'])
+
+    await $input.trigger('click') // Todo checkbox doesn't trigger oninput event for unchecking and thus chenge is not emitted
+    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
+    expect(wrapper.vm.localChecked.length).toBe(1)
+    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(1)
+    expect(wrapper.emitted('change')[0][0]).toEqual(['foo'])
+
+    await wrapper.setProps({modelValue: []})
+    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
+    expect(wrapper.vm.localChecked.length).toBe(0)
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(1)
+
+    await $input.trigger('click')
+    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
+    expect(wrapper.vm.localChecked.length).toBe(1)
+    expect(wrapper.vm.localChecked[0]).toEqual('bar')
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(2)
+    expect(wrapper.emitted('change')[1][0]).toEqual(['bar'])
+
+    await $input.trigger('click')
+    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
+    expect(wrapper.vm.localChecked.length).toBe(0)
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change').length).toBe(2)
+    expect(wrapper.emitted('change')[1][0]).toEqual([])
+
+    wrapper.unmount()
+  })
+
   it('works when value is an object', async () => {
     const wrapper = mount(BFormRadio, {
       attachTo: createContainer(),
       props: {
         value: {bar: 1, baz: 2},
-        checked: false,
+        modelValue: false,
       },
       slots: {
         default: 'foobar',
@@ -850,7 +1098,7 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       attachTo: createContainer(),
       props: {
-        checked: false,
+        modelValue: false,
       },
       slots: {
         default: 'foobar',
@@ -906,7 +1154,7 @@ describe('form-radio', () => {
       const wrapper = mount(BFormRadio, {
         attachTo: createContainer(),
         props: {
-          checked: false,
+          modelValue: false,
           autofocus: true,
         },
         slots: {
@@ -929,7 +1177,7 @@ describe('form-radio', () => {
       const wrapper = mount(BFormRadio, {
         attachTo: createContainer(),
         props: {
-          checked: false,
+          modelValue: false,
         },
         slots: {
           default: 'foobar',

--- a/src/composables/useFormCheck.ts
+++ b/src/composables/useFormCheck.ts
@@ -85,6 +85,7 @@ export const handleUpdate = (
 
   if (localChecked.value !== checked) {
     emit('input', checked)
+    // console.log('input emitted', checked);
     emit('update:modelValue', checked)
   }
 
@@ -196,6 +197,7 @@ export function useFormCheck(
       localChecked.value = computeLocalChecked(isChecked.value, checked, value, uncheckedValue)
     }
     emit('change', localChecked.value)
+    // console.log('change emitted', localChecked.value);
     emit('update:modelValue', localChecked.value)
   }
 


### PR DESCRIPTION
v-model support for form radio
Does not work well in grouping, but that's expected when multiple component change the same model.

I think a grouping component like b-form-group or b-form-radio-group is needed

