### PR TITLE
fix BFormRadio bound to an array + handle BFormChexboxGroup required property + fix BFormRadio warning when bound to an object

### DIFF
--- a/src/components/BFormCheckbox/form-checkbox.spec.js
+++ b/src/components/BFormCheckbox/form-checkbox.spec.js
@@ -950,7 +950,7 @@ describe('form-checkbox', () => {
         'button': true,
         'modelValue': false,
         'value': 'a',
-        'onUpdate:modelValue': async (modelValue) => await wrapper.setProps({modelValue}),
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',

--- a/src/components/BFormCheckbox/form-checkbox.spec.js
+++ b/src/components/BFormCheckbox/form-checkbox.spec.js
@@ -947,9 +947,10 @@ describe('form-checkbox', () => {
   it('stand-alone button has label class active when clicked (checked)', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
-        button: true,
-        modelValue: false,
-        value: 'a',
+        'button': true,
+        'modelValue': false,
+        'value': 'a',
+        'onUpdate:modelValue': async (modelValue) => await wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',
@@ -968,15 +969,11 @@ describe('form-checkbox', () => {
     expect($label.classes()).toContain('btn-secondary')
 
     await $input.trigger('click')
-    /*
-      works in the browser
-      TODO: find a way to make this test work
+    expect($label.classes().length).toEqual(3)
+    expect($label.classes()).toContain('active')
+    expect($label.classes()).toContain('btn')
+    expect($label.classes()).toContain('btn-secondary')
 
-      expect($label.classes().length).toEqual(3)
-      expect($label.classes()).toContain('active')
-      expect($label.classes()).toContain('btn')
-      expect($label.classes()).toContain('btn-secondary')
-    */
     wrapper.unmount()
   })
 

--- a/src/components/BFormCheckboxGroup.vue
+++ b/src/components/BFormCheckboxGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-bind="attrs" :id="id" v-focus="autofocus" role="group" :class="classes">
+  <div v-bind="attrs" :id="computedId" v-focus="autofocus" role="group" :class="classes">
     <template v-for="(item, key) in checkboxList" :key="key">
       <b-form-checkbox
         v-model="item.model"
@@ -18,6 +18,7 @@
 <script lang="ts">
 import {computed, defineComponent, PropType} from 'vue'
 import {ColorVariant, Size} from '../types'
+import useId from '../composables/useId'
 import {
   getGroupAttr,
   getGroupClasses,
@@ -53,12 +54,13 @@ export default defineComponent({
   emits: ['update:modelValue'],
   setup(props, {emit, slots}) {
     const slotsName = 'BFormCheckbox'
+    const computedId = useId(props.id, 'checkbox')
+    const computedName = useId(props.name, 'checkbox')
     const checkboxList = computed(() => {
       const {
         modelValue,
         buttonVariant,
         form,
-        name,
         buttons,
         state,
         plain,
@@ -66,26 +68,29 @@ export default defineComponent({
         stacked,
         switches,
         disabled,
+        required,
         options,
       } = props
 
       return (slots.first ? slotsToElements(slots.first(), slotsName, disabled) : [])
         .concat(options.map((e) => optionToElement(e, props)))
         .concat(slots.default ? slotsToElements(slots.default(), slotsName, disabled) : [])
-        .map((e) =>
+        .map((e, idx) =>
           Object.assign(e, {
             model: modelValue.find((mv) => e.props?.value === mv) ? e.props?.value : false,
             props: {
               ...e.props,
               'button-variant': buttonVariant,
               form,
-              name,
+              'name': computedName.value,
+              'id': `${computedId.value}_option_${idx}`,
               'button': buttons,
               state,
               plain,
               size,
               'inline': !stacked,
               'switch': switches,
+              required,
             },
           })
         )
@@ -107,6 +112,7 @@ export default defineComponent({
       classes,
       checkboxList,
       childUpdated,
+      computedId,
     }
   },
 })

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -40,7 +40,7 @@ export default defineComponent({
     ariaLabel: {type: String},
     ariaLabelledBy: {type: String},
     autofocus: {type: Boolean, default: false},
-    modelValue: {type: [Boolean, String, Array], default: null},
+    modelValue: {type: [Boolean, String, Array, Object], default: null},
     plain: {type: Boolean, default: false},
     button: {type: Boolean, default: false},
     switch: {type: Boolean, default: false},
@@ -61,7 +61,7 @@ export default defineComponent({
     const input: Ref<HTMLElement> = ref(null as unknown as HTMLElement)
     const isFocused = ref(false)
 
-    const localChecked = computed({
+    const localChecked: any = computed({
       get: () => props.modelValue,
       set: (newValue: any) => {
         emit('input', newValue)
@@ -84,8 +84,9 @@ export default defineComponent({
 
     const isChecked = computed(() => {
       const {value, modelValue} = props
+
       if (Array.isArray(modelValue)) {
-        return modelValue.find((e) => e === value)
+        return (modelValue || []).find((e) => e === value)
       }
       return JSON.stringify(modelValue) === JSON.stringify(value)
     })
@@ -98,7 +99,7 @@ export default defineComponent({
       const {modelValue, value} = props
 
       if (Array.isArray(modelValue)) {
-        if (modelValue[0] !== value) {
+        if ((modelValue || [])[0] !== value) {
           localChecked.value = [value]
         }
       } else if (checked && modelValue !== value) {

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -97,14 +97,12 @@ export default defineComponent({
     const handleClick = async (checked: boolean) => {
       const {modelValue, value} = props
 
-      if (!Array.isArray(modelValue)) {
-        if (checked && modelValue !== value) {
-          localChecked.value = value
+      if (Array.isArray(modelValue)) {
+        if (modelValue[0] !== value) {
+          localChecked.value = [value]
         }
-      } else if (Array.isArray(modelValue)) {
-        localChecked.value = modelValue.find((e) => e === value)
-          ? modelValue.filter((e) => e !== value)
-          : modelValue.concat(value)
+      } else if (checked && modelValue !== value) {
+        localChecked.value = value
       }
     }
 

--- a/src/components/BFormRadio/form-radio.spec.js
+++ b/src/components/BFormRadio/form-radio.spec.js
@@ -1060,20 +1060,19 @@ describe('form-radio', () => {
 
     await $input.trigger('click')
     expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(2)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
-    expect(wrapper.vm.localChecked[1]).toEqual('bar')
+    expect(wrapper.vm.localChecked.length).toBe(1)
+    expect(wrapper.vm.localChecked[0]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
-    expect(wrapper.emitted('change')[0][0]).toEqual(['foo', 'bar'])
+    expect(wrapper.emitted('change')[0][0]).toEqual(['bar'])
 
-    await $input.trigger('click') // Todo checkbox doesn't trigger oninput event for unchecking and thus chenge is not emitted
+    await $input.trigger('click')
     expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
     expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(wrapper.vm.localChecked[0]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
-    expect(wrapper.emitted('change')[0][0]).toEqual(['foo'])
+    expect(wrapper.emitted('change')[0][0]).toEqual(['bar'])
 
     await wrapper.setProps({modelValue: []})
     expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
@@ -1091,10 +1090,10 @@ describe('form-radio', () => {
 
     await $input.trigger('click')
     expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(0)
+    expect(wrapper.vm.localChecked.length).toBe(1)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
-    expect(wrapper.emitted('change')[1][0]).toEqual([])
+    expect(wrapper.emitted('change')[1][0]).toEqual(['bar'])
 
     wrapper.unmount()
   })


### PR DESCRIPTION
The former implementation gave the ability for BFormRadio bound to an array to select multiple value, which did not comply with the "standard" bootstrap-vue behaviour.

This PR fix this issue (https://github.com/cdmoro/bootstrap-vue-3/issues/73)