### PR TITLE
fix typescript compilation errors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -122,7 +122,7 @@
     <h6 class="m-2">Custom Button Icon</h6>
     <b-dropdown text="Custom Button Icon" no-caret class="m-2" variant="link">
       <template #button-content>
-        <img src="@/assets/logo.png" style="height: 1em" />
+        <img src="./assets/logo.png" style="height: 1em" />
       </template>
       <b-dropdown-item href="#">Action</b-dropdown-item>
     </b-dropdown>
@@ -1296,7 +1296,7 @@
 <script lang="ts">
 import {defineComponent, onMounted, ref} from 'vue'
 import {useBreadcrumb} from './composables/useBreadcrumb'
-import BDropdown from '@/components/BDropdown.vue'
+import BDropdown from './components/BDropdown.vue'
 import TableField from './types/TableField'
 
 export default defineComponent({

--- a/src/components/BFormRadio/index.ts
+++ b/src/components/BFormRadio/index.ts
@@ -1,3 +1,3 @@
-import BFormRadio from '@/components/BFormRadio/BFormRadio.vue'
+import BFormRadio from './BFormRadio.vue'
 
 export default BFormRadio

--- a/src/components/BIcon.vue
+++ b/src/components/BIcon.vue
@@ -47,7 +47,7 @@ export default /* #__PURE__ */ defineComponent({
   },
 
   computed: {
-    cssClasses() {
+    cssClasses(): string[] {
       const classes = []
 
       if (this.variant) classes.push(`bootstrap-icon--variant-${this.variant}`)
@@ -57,7 +57,7 @@ export default /* #__PURE__ */ defineComponent({
       return classes
     },
 
-    svgTransform() {
+    svgTransform(): string {
       if (!this.flipH && !this.flipV && !this.rotate) return ''
 
       let scale

--- a/src/components/BTable/itemHelper.ts
+++ b/src/components/BTable/itemHelper.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import {TableField, TableItem} from '@/types'
-import {TableFieldObject} from '@/types/TableField'
-import {isObject, isString} from '@/utils/inspect'
-import {startCase} from '@/utils/stringUtils'
+import {TableField, TableItem} from '../../types'
+import {TableFieldObject} from '../../types/TableField'
+import {isObject, isString} from '../../utils/inspect'
+import {startCase} from '../../utils/stringUtils'
 
 const useItemHelper = () => {
   const normaliseFields = (origFields: TableField[], items: TableItem[]): TableFieldObject[] => {

--- a/src/components/BTabs.vue
+++ b/src/components/BTabs.vue
@@ -19,7 +19,12 @@
             :aria-controls="contentId"
             :aria-selected="active"
             v-bind="tab.props['title-link-attributes']"
-            @click.stop="(e) => { $emit('click', e); tabIndex = i }"
+            @click.stop="
+              (e) => {
+                $emit('click', e)
+                tabIndex = i
+              }
+            "
           >
             {{ tab.props.title }}
           </a>
@@ -39,7 +44,7 @@ import {computed, defineComponent, PropType, watch} from 'vue'
 import getID from '../utils/getID'
 import Alignment from '../types/Alignment'
 
-const getTabs = (slots): any[] => {
+const getTabs = (slots: any): any[] => {
   if (!slots || !slots.default) return []
 
   const defaultSlots = slots.default()

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,4 +1,4 @@
-import {RX_FIRST_START_SPACE_WORD, RX_LOWER_UPPER, RX_UNDERSCORE} from '@/constants/regex'
+import {RX_FIRST_START_SPACE_WORD, RX_LOWER_UPPER, RX_UNDERSCORE} from '../constants/regex'
 
 export const startCase: (str: string) => string = (str) =>
   str


### PR DESCRIPTION
Those fixes are required to be able to use `bootstrap-vue-3` in a typescript project.

NB: I had to remove the "autoClose" feature of the dropdown for now