### PR TITLE
By default BDropdown should display inline instead of stacked

### DIFF
--- a/src/components/BDropdown.vue
+++ b/src/components/BDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="parent" :class="classes">
+  <div ref="parent" :class="classes" class="btn-group">
     <b-button
       :id="computedId"
       :variant="variant"
@@ -93,8 +93,6 @@ export default defineComponent({
     useEventListener(parent, 'hidden.bs.dropdown', () => emit('hidden'))
 
     const classes = computed(() => ({
-      'btn-group': props.split,
-      'dropdown': !props.split,
       'd-grid': props.block,
     }))
 


### PR DESCRIPTION
Always set class btn-group on wrapper div
Removed the dropdown class because it only set position relative and class btn-group already sets position relative
