### PR TITLE
always execute the "build" task on post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "yarn run test:lint && yarn run test:unit",
     "test:lint": "yarn run lint",
     "test:unit": "jest",
-    "prepare": "husky install"
+    "prepare": "husky install && vite build"
   },
   "types": "src/BootstrapVue.d.ts",
   "dependencies": {


### PR DESCRIPTION
Execute the "build" task (which generate the `/dist` folder) when the project is installed directly from github (ex: `npm i https://github.com/cdmoro/bootstrap-vue-3`)

Currently it is only executed when the project is installed from the npm registry (ex: `npm i bootstrap-vue-3`)