### PR TITLE
add support for "mixed" tabs in BTabs default slots

### DIFF
--- a/src/BootstrapVue.d.ts
+++ b/src/BootstrapVue.d.ts
@@ -1,1 +1,1 @@
-declare module 'bootstrap-vue-3'
+declare module 'efficy-bootstrap-vue-3'

--- a/src/BootstrapVue.d.ts
+++ b/src/BootstrapVue.d.ts
@@ -1,1 +1,1 @@
-declare module 'efficy-bootstrap-vue-3'
+declare module 'bootstrap-vue-3'

--- a/src/components/BTabs.vue
+++ b/src/components/BTabs.vue
@@ -47,13 +47,17 @@ import Alignment from '../types/Alignment'
 const getTabs = (slots: any): any[] => {
   if (!slots || !slots.default) return []
 
-  const defaultSlots = slots.default()
-
-  return (
-    defaultSlots.length === 1 && typeof defaultSlots[0].type === 'symbol'
-      ? defaultSlots[0].children
-      : defaultSlots
-  ).filter((child: any) => child.type.name === 'BTab')
+  return slots
+    .default()
+    .reduce((arr: number[], slot: any) => {
+      if (typeof slot.type === 'symbol') {
+        arr = arr.concat(slot.children)
+      } else {
+        arr.push(slot)
+      }
+      return arr
+    }, [])
+    .filter((child: any) => child.type.name === 'BTab')
 }
 
 export default defineComponent({


### PR DESCRIPTION
support for "mixed" tabs, ex:

 ```
 <b-tabs>
    <b-tab title="First" active><p>First</p></b-tab>
    <b-tab title="Second"><p>Second</p></b-tab>
    <b-tab v-for="(tabName, tabIndex) in ['Third', 'Fourth']" :title="tabName" :key="tabIndex">{{ tabName }}</b-tab>
    <b-tab title="Fifth"><p>Fifth</p></b-tab>
  </b-tabs>
```