### PR TITLE
BModal : Update for preventDefault feature

### DIFF
--- a/src/components/BModal.vue
+++ b/src/components/BModal.vue
@@ -78,18 +78,22 @@ export default defineComponent({
       'modal-dialog-scrollable': props.scrollable,
     }))
 
-    useEventListener(element, 'shown.bs.modal', () => emit('shown'))
-    useEventListener(element, 'hidden.bs.modal', () => emit('hidden'))
-    useEventListener(element, 'hidePrevented.bs.modal', () => emit('hide-prevented'))
+    useEventListener(element, 'shown.bs.modal', (e) => emit('shown', e))
+    useEventListener(element, 'hidden.bs.modal', (e) => emit('hidden', e))
+    useEventListener(element, 'hidePrevented.bs.modal', (e) => emit('hide-prevented', e))
 
-    useEventListener(element, 'show.bs.modal', () => {
-      emit('show')
-      emit('update:modelValue', true)
+    useEventListener(element, 'show.bs.modal', (e) => {
+      emit('show', e)
+      if (!e.defaultPrevented) {
+        emit('update:modelValue', true)
+      }
     })
 
-    useEventListener(element, 'hide.bs.modal', () => {
-      emit('hide')
-      emit('update:modelValue', false)
+    useEventListener(element, 'hide.bs.modal', (e) => {
+      emit('hide', e)
+      if (!e.defaultPrevented) {
+        emit('update:modelValue', false)
+      }
     })
 
     onMounted(() => {


### PR DESCRIPTION
Example of use:

```
<template>
  <b-modal v-model="showed" title="Example Modal" @hide="hide">
    <!-- Modal content here -->
  </b-modal>
</template>

<script>
export default {
  data() {
    return {
      showed: true,
      isUnsaved: true,
    };
  },
  methods: {
    hide(e) {
      if (this.isUnsaved) {
        e.preventDefault();

        // Or SweetAlert2
        if (confirm("Close Modal?")) {
          this.isUnsaved = false;
          this.showed = false;
        }
      }
    },
  },
};
</script>
```
