### PR TITLE
BTable: add row data to scope of cell slots.

### DIFF
--- a/src/components/BTable/BTable.vue
+++ b/src/components/BTable/BTable.vue
@@ -76,6 +76,7 @@ export default defineComponent({
                 if (slots[slotName]) {
                   tdContent = slots[slotName]?.({
                     value: tr[field.key],
+                    item: tr,
                     items: props.items,
                   })
                 }


### PR DESCRIPTION
With this change, all current row data is passed to the cell slot as an "item" property. This allows you to combine multiple fields into a single cell, similar to BootstrapVue.