### PR TITLE
More field options for BTable

### DIFF
--- a/src/components/BTable/BTable.vue
+++ b/src/components/BTable/BTable.vue
@@ -43,23 +43,21 @@ export default defineComponent({
     const itemHelper = useItemHelper()
     const computedFields = computed(() => itemHelper.normaliseFields(props.fields, props.items))
 
-    const headerTable = computed(() => {
-      if (computedFields.value.length > 0) {
-        return computedFields.value.map((f) => f.label)
-      }
-      return []
-    })
-
-    // return {
-    //     classes,
-    //     headerTable
-    // }
     return () => {
       const tHead = h(
         'thead',
         h(
           'tr',
-          headerTable.value.map((th) => h('th', {scope: 'col'}, th))
+          computedFields.value.map((field) =>
+            h(
+              'th',
+              {
+                scope: 'col',
+                class: [field.class, field.thClass],
+              },
+              field.label
+            )
+          )
         )
       )
 
@@ -81,7 +79,14 @@ export default defineComponent({
                     items: props.items,
                   })
                 }
-                return h('td', tdContent)
+
+                return h(
+                  'td',
+                  {
+                    class: [field.class, field.tdClass],
+                  },
+                  tdContent
+                )
               })
             )
           )
@@ -104,7 +109,16 @@ export default defineComponent({
           'tfoot',
           h(
             'tr',
-            headerTable.value.map((th) => h('th', {scope: 'col'}, th))
+            computedFields.value.map((field) =>
+              h(
+                'th',
+                {
+                  scope: 'col',
+                  class: [field.class, field.thClass],
+                },
+                field.label
+              )
+            )
           )
         )
 

--- a/src/types/TableField.d.ts
+++ b/src/types/TableField.d.ts
@@ -10,7 +10,8 @@ export interface TableFieldObject {
   sortDirection?: string
   sortByFormatted?: boolean
   filterByFormatted?: boolean
-  tdClass?: string
+  tdClass?: string | string[]
+  thClass?: string | string[]
   thStyle?: Record<string, unknown>
   variant?: string
   tdAttr?: Record<string, unknown>


### PR DESCRIPTION
Implemented class, tdClass (for now without callback support) and thClass properties and corrected type definition of TableFieldObject accordingly.
If this approach is correct I can implement more similar field options (variant, tdAttr etc.), but wanted you to check these changes first. Looks like I did not break reactivity in the process, in my project cell classes now update correctly when field options are changed.