### PR TITLE
Do not use ES6 destructuring on props

### DIFF
--- a/docs/components/FormInput.md
+++ b/docs/components/FormInput.md
@@ -385,7 +385,7 @@ invalid), `true` (for valid), or `null` (no validation state).
 </script>
 ```
 
-> ~~**Tip:** Use the [`<b-form-group>`](/docs/components/form-group) component to automatically generate markup similar to above.~~
+> **Tip:** Use the [`<b-form-group>`](/docs/components/form-group) component to automatically generate markup similar to above.
 
 ### Conveying contextual state to assistive technologies and colorblind users
 

--- a/docs/components/FormTextArea.md
+++ b/docs/components/FormTextArea.md
@@ -358,7 +358,7 @@ form field styling and preserve the correct text size, margin, padding and heigh
 <ClientOnly>
   <b-card>
   <div>
-    <b-form-textarea id="textarea-plaintext" plaintext v-model="textReadOnly"></b-form-textarea>
+    <b-form-textarea id="textarea-plaintext" plaintext :modelValue="textReadOnly"></b-form-textarea>
   </div>
 
   </b-card>
@@ -368,7 +368,11 @@ form field styling and preserve the correct text size, margin, padding and heigh
 <template>
   <b-card>
     <div>
-      <b-form-textarea id="textarea-plaintext" plaintext :value="textReadOnly"></b-form-textarea>
+      <b-form-textarea
+        id="textarea-plaintext"
+        plaintext
+        :modelValue="textReadOnly"
+      ></b-form-textarea>
     </div>
   </b-card>
 </template>

--- a/src/components/BCard/BCardImg.vue
+++ b/src/components/BCard/BCardImg.vue
@@ -20,31 +20,29 @@ export default defineComponent({
     width: {type: [Number, String], required: false},
   },
   setup(props) {
-    const attrs = computed(() => {
-      const {src, width, height} = props
-
-      return {
-        src,
-        alt: props.alt,
-        width: (typeof width === 'number' ? width : parseInt(width as string, 10)) || undefined,
-        height: (typeof height === 'number' ? height : parseInt(height as string, 10)) || undefined,
-      }
-    })
+    const attrs = computed(() => ({
+      src: props.src,
+      alt: props.alt,
+      width:
+        (typeof props.width === 'number' ? props.width : parseInt(props.width as string, 10)) ||
+        undefined,
+      height:
+        (typeof props.height === 'number' ? props.height : parseInt(props.height as string, 10)) ||
+        undefined,
+    }))
 
     const classes = computed(() => {
-      const {top, right, end, bottom, left, start} = props
-
-      const align = left ? 'float-left' : right ? 'float-right' : ''
+      const align = props.left ? 'float-left' : props.right ? 'float-right' : ''
 
       let baseClass = 'card-img'
 
       if (top) {
         baseClass += '-top'
-      } else if (right || end) {
+      } else if (props.right || props.end) {
         baseClass += '-right'
-      } else if (bottom) {
+      } else if (props.bottom) {
         baseClass += '-bottom'
-      } else if (left || start) {
+      } else if (props.left || props.start) {
         baseClass += '-left'
       }
 

--- a/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -75,22 +75,20 @@ export default defineComponent({
       },
     })
 
-    const checkboxList = computed(() => {
-      const {modelValue, switches, disabled, options} = props
-
-      return (slots.first ? slotsToElements(slots.first(), slotsName, disabled) : [])
-        .concat(options.map((e) => optionToElement(e, props)))
-        .concat(slots.default ? slotsToElements(slots.default(), slotsName, disabled) : [])
+    const checkboxList = computed(() =>
+      (slots.first ? slotsToElements(slots.first(), slotsName, props.disabled) : [])
+        .concat(props.options.map((e) => optionToElement(e, props)))
+        .concat(slots.default ? slotsToElements(slots.default(), slotsName, props.disabled) : [])
         .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
         .map((e) => ({
           ...e,
-          model: modelValue.find((mv) => e.props?.value === mv) ? e.props?.value : false,
+          model: props.modelValue.find((mv) => e.props?.value === mv) ? e.props?.value : false,
           props: {
-            switch: switches,
+            switch: props.switches,
             ...e.props,
           },
         }))
-    })
+    )
 
     const childUpdated = (newValue: any, checkedValue: any) => {
       const resp = props.modelValue.filter(

--- a/src/components/BFormInput/BFormInput.vue
+++ b/src/components/BFormInput/BFormInput.vue
@@ -61,17 +61,16 @@ export default defineComponent({
   emits: ['update:modelValue', 'change', 'blur', 'input'],
   setup(props, {emit}) {
     const classes = computed(() => {
-      const {plaintext, size, state, type} = props
-      const isRange = type === 'range'
-      const isColor = type === 'color'
+      const isRange = props.type === 'range'
+      const isColor = props.type === 'color'
       return {
         'form-range': isRange,
-        'form-control': isColor || (!plaintext && !isRange),
+        'form-control': isColor || (!props.plaintext && !isRange),
         'form-control-color': isColor,
-        'form-control-plaintext': plaintext && !isRange && !isColor,
-        [`form-control-${size}`]: size,
-        'is-valid': state === true,
-        'is-invalid': state === false,
+        'form-control-plaintext': props.plaintext && !isRange && !isColor,
+        [`form-control-${props.size}`]: props.size,
+        'is-valid': props.state === true,
+        'is-invalid': props.state === false,
       }
     })
 

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -83,12 +83,10 @@ export default defineComponent({
     }
 
     const isChecked = computed(() => {
-      const {value, modelValue} = props
-
-      if (Array.isArray(modelValue)) {
-        return (modelValue || []).find((e) => e === value)
+      if (Array.isArray(props.modelValue)) {
+        return (props.modelValue || []).find((e) => e === props.value)
       }
-      return JSON.stringify(modelValue) === JSON.stringify(value)
+      return JSON.stringify(props.modelValue) === JSON.stringify(props.value)
     })
 
     const classes = getClasses(props)
@@ -96,14 +94,12 @@ export default defineComponent({
     const labelClasses = getLabelClasses(props)
 
     const handleClick = async (checked: boolean) => {
-      const {modelValue, value} = props
-
-      if (Array.isArray(modelValue)) {
-        if ((modelValue || [])[0] !== value) {
-          localChecked.value = [value]
+      if (Array.isArray(props.modelValue)) {
+        if ((props.modelValue || [])[0] !== props.value) {
+          localChecked.value = [props.value]
         }
-      } else if (checked && modelValue !== value) {
-        localChecked.value = value
+      } else if (checked && props.modelValue !== props.value) {
+        localChecked.value = props.value
       }
     }
 

--- a/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/src/components/BFormRadio/BFormRadioGroup.vue
@@ -69,19 +69,19 @@ export default defineComponent({
       },
     })
 
-    const checkboxList = computed(() => {
-      const {modelValue, disabled, options} = props
-
-      return (slots.first ? slotsToElements(slots.first(), slotsName, disabled) : [])
-        .concat(options.map((e) => optionToElement(e, props)))
-        .concat(slots.default ? slotsToElements(slots.default(), slotsName, disabled) : [])
+    const checkboxList = computed(() =>
+      (slots.first ? slotsToElements(slots.first(), slotsName, props.disabled) : [])
+        .concat(props.options.map((e) => optionToElement(e, props)))
+        .concat(slots.default ? slotsToElements(slots.default(), slotsName, props.disabled) : [])
         .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
         .map((e) => ({
           ...e,
           model:
-            JSON.stringify(modelValue) === JSON.stringify(e.props?.value) ? e.props?.value : null,
+            JSON.stringify(props.modelValue) === JSON.stringify(e.props?.value)
+              ? e.props?.value
+              : null,
         }))
-    })
+    )
 
     const childUpdated = (newValue: any) => {
       emit('change', newValue)

--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -102,17 +102,14 @@ export default defineComponent({
     // /lifecycle events
 
     // computed
-    const classes = computed(() => {
-      const {plain, size, state} = props
-      return {
-        'form-control': plain,
-        [`form-control-${size}`]: size && plain,
-        'form-select': !plain,
-        [`form-select-${size}`]: size && !plain,
-        'is-valid': state === true,
-        'is-invalid': state === false,
-      }
-    })
+    const classes = computed(() => ({
+      'form-control': props.plain,
+      [`form-control-${props.size}`]: props.size && props.plain,
+      'form-select': !props.plain,
+      [`form-select-${props.size}`]: props.size && !props.plain,
+      'is-valid': props.state === true,
+      'is-invalid': props.state === false,
+    }))
 
     const computedSelectSize = computed(() => {
       if (props.selectSize || props.plain) {
@@ -122,12 +119,10 @@ export default defineComponent({
     })
 
     const computedAriaInvalid = computed(() => {
-      const {ariaInvalid, state} = props
-
-      if (ariaInvalid) {
-        return ariaInvalid.toString()
+      if (props.ariaInvalid) {
+        return props.ariaInvalid.toString()
       }
-      return state === false ? 'true' : null
+      return props.state === false ? 'true' : null
     })
 
     const formOptions = computed(() => normalizeOptions(props.options, 'BFormSelect', props))

--- a/src/components/BFormTextarea/BFormTextarea.vue
+++ b/src/components/BFormTextarea/BFormTextarea.vue
@@ -36,16 +36,13 @@ export default defineComponent({
   },
   emits: ['update:modelValue', 'change', 'blur', 'input'],
   setup(props, {emit}) {
-    const classes = computed(() => {
-      const {plaintext, size, state} = props
-      return {
-        'form-control': !plaintext,
-        'form-control-plaintext': plaintext,
-        [`form-control-${size}`]: size,
-        'is-valid': state === true,
-        'is-invalid': state === false,
-      }
-    })
+    const classes = computed(() => ({
+      'form-control': !props.plaintext,
+      'form-control-plaintext': props.plaintext,
+      [`form-control-${props.size}`]: props.size,
+      'is-valid': props.state === true,
+      'is-invalid': props.state === false,
+    }))
 
     const computedStyles = computed(() => (props.noResize ? {resize: 'none'} : undefined))
 

--- a/src/components/BImg.vue
+++ b/src/components/BImg.vue
@@ -42,7 +42,8 @@ export default defineComponent({
   },
   setup(props) {
     const attrs = computed(() => {
-      let {src} = props
+      // eslint-disable-next-line prefer-destructuring
+      let src = props.src
       let width =
         (typeof props.width === 'number' ? props.width : parseInt(props.width as string, 10)) ||
         null
@@ -94,7 +95,8 @@ export default defineComponent({
 
     const classes = computed(() => {
       let align = ''
-      let {block} = props
+      // eslint-disable-next-line prefer-destructuring
+      let block = props.block
       if (props.left) {
         align = 'float-start'
       } else if (props.right) {

--- a/src/components/BLink/BLink.vue
+++ b/src/components/BLink/BLink.vue
@@ -63,16 +63,15 @@ export default defineComponent({
     const link: Ref<HTMLElement> = ref(null as unknown as HTMLElement)
 
     const tag = computed(() => {
-      const {to, disabled, routerComponentName} = props
-      const routerName = routerComponentName
+      const routerName = props.routerComponentName
         .split('-')
         .map((e) => e.charAt(0).toUpperCase() + e.slice(1))
         .join('')
       const hasRouter = instance?.appContext.app.component(routerName) !== undefined
-      if (!hasRouter || disabled || !to) {
+      if (!hasRouter || props.disabled || !props.to) {
         return 'a'
       }
-      return routerComponentName
+      return props.routerComponentName
     })
 
     const computedHref = computed(() => {

--- a/src/components/BListGroup/BListGroupItem.vue
+++ b/src/components/BListGroup/BListGroupItem.vue
@@ -58,13 +58,12 @@ export default defineComponent({
     )
 
     const classes = computed(() => {
-      const {button, variant, active, disabled} = props
-      const action = props.action || link.value || button || ACTION_TAGS.includes(props.tag)
+      const action = props.action || link.value || props.button || ACTION_TAGS.includes(props.tag)
       return {
-        [`list-group-item-${variant}`]: variant,
+        [`list-group-item-${props.variant}`]: props.variant,
         'list-group-item-action': action,
-        active,
-        disabled,
+        'active': props.active,
+        'disabled': props.disabled,
       }
     })
 

--- a/src/composables/useAlignment.ts
+++ b/src/composables/useAlignment.ts
@@ -4,13 +4,12 @@ import {computed, ComputedRef} from 'vue'
 import Alignment from '../types/Alignment'
 
 function alignment(props: any): ComputedRef<string> {
-  const {align}: {align: Alignment} = props
   return computed(() => {
-    if (align === 'center') {
+    if (props.align === 'center') {
       return 'justify-content-center'
-    } else if (align === 'end') {
+    } else if (props.align === 'end') {
       return 'justify-content-end'
-    } else if (align === 'start') {
+    } else if (props.align === 'start') {
       return 'justify-content-start'
     }
     return 'justify-content-start'

--- a/src/composables/useFormCheck.ts
+++ b/src/composables/useFormCheck.ts
@@ -2,13 +2,12 @@ import {computed, ComputedRef} from 'vue'
 
 const _getComputedAriaInvalid = (props: any): ComputedRef =>
   computed(() => {
-    const {ariaInvalid, state} = props
-    if (ariaInvalid === true || ariaInvalid === 'true' || ariaInvalid === '') {
+    if (props.ariaInvalid === true || props.ariaInvalid === 'true' || props.ariaInvalid === '') {
       return 'true'
     }
 
-    const computedState = typeof state === 'boolean' ? props.state : null
-    return computedState === false ? 'true' : ariaInvalid
+    const computedState = typeof props.state === 'boolean' ? props.state : null
+    return computedState === false ? 'true' : props.ariaInvalid
   })
 
 const getClasses = (props: any): ComputedRef =>
@@ -67,14 +66,12 @@ const slotsToElements = (slots: Array<any>, nodeType: string, disabled: boolean)
       }
     })
 
-const optionToElement = (option: any, props: any) => {
-  const {valueField, disabled, disabledField, textField, htmlField} = props
-
+const optionToElement = (option: any, props: any): any => {
   if (typeof option === 'string') {
     return {
       props: {
         value: option,
-        disabled: disabled,
+        disabled: props.disabled,
       },
       text: option,
     }
@@ -82,12 +79,12 @@ const optionToElement = (option: any, props: any) => {
 
   return {
     props: {
-      value: option[valueField],
-      disabled: disabled || option[disabledField],
+      value: option[props.valueField],
+      disabled: props.disabled || option[props.disabledField],
       ...option.props,
     },
-    text: option[textField],
-    html: option[htmlField],
+    text: option[props.textField],
+    html: option[props.htmlField],
   }
 }
 
@@ -97,26 +94,22 @@ const bindGroupProps = (
   props: any,
   computedName: ComputedRef,
   computedId: ComputedRef
-) => {
-  const {buttonVariant, buttons, stacked, form, state, plain, size, required} = props
-
-  return {
-    ...el,
-    props: {
-      'button-variant': buttonVariant,
-      form,
-      'name': computedName.value,
-      'id': `${computedId.value}_option_${idx}`,
-      'button': buttons,
-      state,
-      plain,
-      size,
-      'inline': !stacked,
-      required,
-      ...el.props,
-    },
-  }
-}
+): any => ({
+  ...el,
+  props: {
+    'button-variant': props.buttonVariant,
+    'form': props.form,
+    'name': computedName.value,
+    'id': `${computedId.value}_option_${idx}`,
+    'button': props.buttons,
+    'state': props.state,
+    'plain': props.plain,
+    'size': props.size,
+    'inline': !props.stacked,
+    'required': props.required,
+    ...el.props,
+  },
+})
 
 export {
   getClasses,

--- a/src/composables/useFormInput.ts
+++ b/src/composables/useFormInput.ts
@@ -51,20 +51,17 @@ function useFormInput(props: Readonly<InputProps>, emit: InputEmitType) {
   const computedId = useId(props.id, 'input')
 
   const _formatValue = (value: unknown, evt: any, force = false) => {
-    const {formatter, lazyFormatter} = props
     value = String(value)
-    if (typeof formatter === 'function' && (!lazyFormatter || force)) {
+    if (typeof props.formatter === 'function' && (!props.lazyFormatter || force)) {
       neverFormatted = false
-      return formatter(value, evt)
+      return props.formatter(value, evt)
     }
     return value
   }
 
   const _getModelValue = (value: any) => {
-    const {trim, number} = props
-
-    if (trim) return value.trim()
-    if (number) return parseFloat(value)
+    if (props.trim) return value.trim()
+    if (props.number) return parseFloat(value)
 
     return value
   }
@@ -85,16 +82,13 @@ function useFormInput(props: Readonly<InputProps>, emit: InputEmitType) {
   onActivated(handleAutofocus)
 
   const computedAriaInvalid = computed(() => {
-    const {ariaInvalid, state} = props
-
-    if (ariaInvalid) {
-      return ariaInvalid.toString()
+    if (props.ariaInvalid) {
+      return props.ariaInvalid.toString()
     }
-    return state === false ? 'true' : undefined
+    return props.state === false ? 'true' : undefined
   })
 
   const onInput = (evt: Event) => {
-    const {lazy, modelValue} = props
     const {value} = evt.target as HTMLInputElement
     const formattedValue = _formatValue(value, evt)
     if (formattedValue === false || evt.defaultPrevented) {
@@ -102,19 +96,18 @@ function useFormInput(props: Readonly<InputProps>, emit: InputEmitType) {
       return
     }
 
-    if (lazy) return
+    if (props.lazy) return
     emit('input', formattedValue)
 
     const nextModel = _getModelValue(formattedValue)
 
-    if (modelValue !== nextModel) {
+    if (props.modelValue !== nextModel) {
       inputValue = value
       emit('update:modelValue', nextModel)
     }
   }
 
   const onChange = (evt: Event) => {
-    const {lazy, modelValue} = props
     const {value} = evt.target as HTMLInputElement
     const formattedValue = _formatValue(value, evt)
     if (formattedValue === false || evt.defaultPrevented) {
@@ -122,20 +115,19 @@ function useFormInput(props: Readonly<InputProps>, emit: InputEmitType) {
       return
     }
 
-    if (!lazy) return
+    if (!props.lazy) return
     inputValue = value
     emit('update:modelValue', formattedValue)
 
     const nextModel = _getModelValue(formattedValue)
-    if (modelValue !== nextModel) {
+    if (props.modelValue !== nextModel) {
       emit('change', formattedValue)
     }
   }
 
   const onBlur = (evt: FocusEvent) => {
-    const {lazy, lazyFormatter} = props
     emit('blur', evt)
-    if (!lazy && !lazyFormatter) return
+    if (!props.lazy && !props.lazyFormatter) return
 
     const {value} = evt.target as HTMLInputElement
     const formattedValue = _formatValue(value, evt, true)

--- a/src/composables/useFormSelect.ts
+++ b/src/composables/useFormSelect.ts
@@ -14,17 +14,15 @@ const _normalizeOption = (
   props: any
 ) => {
   if (Object.prototype.toString.call(option) === '[object Object]') {
-    const {valueField, textField, optionsField, labelField, htmlField, disabledField} = props
+    const value = _getNested(option, props.valueField)
+    const text = _getNested(option, props.textField)
+    const html = _getNested(option, props.htmlField)
+    const disabled = _getNested(option, props.disabledField)
 
-    const value = _getNested(option, valueField)
-    const text = _getNested(option, textField)
-    const html = _getNested(option, htmlField)
-    const disabled = _getNested(option, disabledField)
-
-    const options = option[optionsField] || null
+    const options = option[props.optionsField] || null
     if (options !== null) {
       return {
-        label: String(_getNested(option, labelField) || text),
+        label: String(_getNested(option, props.labelField) || text),
         options: normalizeOptions(options, componentName, props),
       }
     }


### PR DESCRIPTION
Do not use ES6 destructuring on props because then reactivity is lost.
Fixes #189 

