### PR TITLE
Component Reference Plugin

### DIFF
--- a/docs/.vuepress/PluginComponentReference/client/clientAppEnhance.ts
+++ b/docs/.vuepress/PluginComponentReference/client/clientAppEnhance.ts
@@ -1,0 +1,7 @@
+import {h} from 'vue'
+import {defineClientAppEnhance} from '@vuepress/client'
+import ReferenceSection from './components/reference-section'
+export default defineClientAppEnhance(({app}) => {
+  // wrap the `<ComponentReference />` component with plugin options
+  app.component('ComponentReference', (props) => h(ReferenceSection, {}))
+})

--- a/docs/.vuepress/PluginComponentReference/client/components/anchored-heading.ts
+++ b/docs/.vuepress/PluginComponentReference/client/components/anchored-heading.ts
@@ -13,30 +13,27 @@ export default defineComponent({
       default: 2,
     },
   },
-  setup(props) {
-    return {}
-  },
-  render() {
+  setup(props, {slots}) {
     const blink = resolveComponent('b-link')
     const $anchor = h(
       blink,
       {
         class: 'header-anchor',
-        to: {hash: `#${this.id}`},
+        to: {hash: `#${props.id}`},
         // 'aria-labelledby': this.id || null,
         // 'aria-label': this.id ? null : 'Anchor',
       },
-      '#'
+      () => '#'
     )
 
-    const $content = h('span', {class: ['bd-content-title']}, [this.$slots.default(), $anchor])
-    return h(
-      `h${this.level}`,
-      {
-        id: this.id,
-        tabindex: '-1',
-      },
-      $content
-    )
+    return () =>
+      h(
+        `h${props.level}`,
+        {
+          id: props.id,
+          tabindex: '-1',
+        },
+        h('span', {class: ['bd-content-title']}, [slots.default(), $anchor])
+      )
   },
 })

--- a/docs/.vuepress/PluginComponentReference/client/components/anchored-heading.ts
+++ b/docs/.vuepress/PluginComponentReference/client/components/anchored-heading.ts
@@ -1,0 +1,42 @@
+import {computed, defineComponent, resolveComponent, h} from 'vue'
+// import BLink from '@/components/BLink'
+export default defineComponent({
+  name: 'BVAnchoredHeading',
+  functional: true,
+  props: {
+    id: {
+      type: String,
+      default: '',
+    },
+    level: {
+      type: [Number, String],
+      default: 2,
+    },
+  },
+  setup(props) {
+    return {}
+  },
+  render() {
+    const blink = resolveComponent('b-link')
+    const $anchor = h(
+      blink,
+      {
+        class: 'header-anchor',
+        to: {hash: `#${this.id}`},
+        // 'aria-labelledby': this.id || null,
+        // 'aria-label': this.id ? null : 'Anchor',
+      },
+      '#'
+    )
+
+    const $content = h('span', {class: ['bd-content-title']}, [this.$slots.default(), $anchor])
+    return h(
+      `h${this.level}`,
+      {
+        id: this.id,
+        tabindex: '-1',
+      },
+      $content
+    )
+  },
+})

--- a/docs/.vuepress/PluginComponentReference/client/components/component-doc.vue
+++ b/docs/.vuepress/PluginComponentReference/client/components/component-doc.vue
@@ -1,0 +1,142 @@
+<template>
+  <b-table
+    :items="propsItems"
+    :fields="propFields"
+    primary-key="prop"
+    table-class="bv-docs-table"
+    responsive="sm"
+    sort-icon-left
+    bordered
+    striped
+  >
+    <template #cell(type)="{value}">
+      <span v-html="value"></span>
+    </template>
+  </b-table>
+</template>
+<script lang="ts">
+import {resolveComponent, defineComponent, computed, ComputedRef, ConcreteComponent} from 'vue'
+
+// type definitions
+const SORT_THRESHOLD: number = 10
+
+export default defineComponent({
+  name: 'BVComponentdoc',
+  props: {
+    component: {type: String},
+    propsMeta: {
+      // For getting prop descriptions
+      type: Array,
+      default: () => [],
+    },
+    slots: {
+      type: Array,
+      default: () => [],
+    },
+    events: {
+      type: Array,
+      default: () => [],
+    },
+    rootEventListeners: {
+      type: Array,
+      default: () => [],
+    },
+    aliases: {
+      type: Array,
+      default: () => [],
+    },
+    version: {
+      type: String,
+      default: null,
+    },
+  },
+  setup(props) {
+    const component: ConcreteComponent = resolveComponent(
+      props.component as string
+    ) as ConcreteComponent
+
+    const componentPropsMetaObj: ComputedRef<any> = computed(() => {
+      return props.propsMeta.reduce((obj, propMeta) => {
+        if (propMeta.prop) {
+          obj[propMeta.prop] = propMeta
+        }
+        return obj
+      }, {})
+    })
+
+    const propsItems: ComputedRef<any> = computed(() => {
+      const props: any = component.props
+      const propsMetaObj = componentPropsMetaObj
+      return Object.keys(props)
+        .sort()
+        .map((prop: string) => {
+          const p = props[prop]
+          const meta = {
+            // ...(commonProps[prop] || {}),
+            ...(propsMetaObj.value[prop] || {}),
+          }
+
+          // Describe type
+          let type = p.type
+          let types = []
+          if (Array.isArray(type)) {
+            types = type.map((type) => type.name)
+          } else {
+            types = type && type.name ? [type.name] : ['Any']
+          }
+
+          type = types
+            .map((type) => `<code class="notranslate" translate="no">${type}</code>`)
+            .join(' or ')
+
+          //default Value
+          let defaultValue = p.default
+          if (defaultValue instanceof Function && !Array.isArray(defaultValue)) {
+            defaultValue = defaultValue()
+          }
+          defaultValue =
+            typeof defaultValue === 'undefined'
+              ? ''
+              : String(JSON.stringify(defaultValue, undefined, 1)).replace(/"/g, "'")
+
+          return {
+            prop: prop, // KEBAB case this
+            type,
+            defaultValue,
+            required: p.required || false,
+            description: meta.description || '',
+            version: meta.version || '',
+            xss: meta.xss || false,
+            // isVModel: this.componentVModel && this.componentVModel.prop === prop,
+            deprecated: p.deprecated || false,
+            deprecation: p.deprecation || false,
+            _showDetails: typeof p.deprecated === 'string' || typeof p.deprecation === 'string',
+          }
+        })
+    })
+
+    const propFields: ComputedRef<any> = computed(() => {
+      const sortable = propsItems.value.length >= SORT_THRESHOLD
+
+      // TODO define Type for propItems
+      const hasDescriptions = propsItems.value.some((p) => {
+        return p.description
+      })
+
+      return [
+        {key: 'prop', label: 'Property', sortable},
+        {key: 'type', label: 'Type', sortable},
+        {key: 'defaultValue', label: 'Default'},
+        ...(hasDescriptions ? [{key: 'description', label: 'Description'}] : []),
+      ]
+    })
+
+    return {
+      propsItems,
+      propFields,
+    }
+  },
+})
+</script>
+
+})

--- a/docs/.vuepress/PluginComponentReference/client/components/reference-section.ts
+++ b/docs/.vuepress/PluginComponentReference/client/components/reference-section.ts
@@ -1,0 +1,33 @@
+import AnchoredHeading from './anchored-heading'
+import Compoenentdoc from './component-doc'
+import {computed, defineComponent, h, ref, toRefs} from 'vue'
+import {usePageData} from '@vuepress/client'
+
+export default defineComponent({
+  name: 'BDVComponents',
+  setup() {
+    const pagedata: any = usePageData()
+
+    return {
+      pagedata,
+    }
+  },
+  render() {
+    return [
+      h(AnchoredHeading, {id: 'component-reference'}, 'Component reference'),
+      this.pagedata.componentReference.meta.components.map(
+        ({component, events, rootEventListeners, slots, aliases, props: propsMeta, version}) => {
+          return h(Compoenentdoc, {
+            component,
+            events,
+            rootEventListeners,
+            slots,
+            aliases,
+            propsMeta,
+            version,
+          })
+        }
+      ),
+    ]
+  },
+})

--- a/docs/.vuepress/PluginComponentReference/client/components/reference-section.ts
+++ b/docs/.vuepress/PluginComponentReference/client/components/reference-section.ts
@@ -14,7 +14,7 @@ export default defineComponent({
   },
   render() {
     return [
-      h(AnchoredHeading, {id: 'component-reference'}, 'Component reference'),
+      h(AnchoredHeading, {id: 'component-reference'}, () => 'Component reference'),
       this.pagedata.componentReference.meta.components.map(
         ({component, events, rootEventListeners, slots, aliases, props: propsMeta, version}) => {
           return h(Compoenentdoc, {

--- a/docs/.vuepress/PluginComponentReference/client/types.ts
+++ b/docs/.vuepress/PluginComponentReference/client/types.ts
@@ -1,0 +1,15 @@
+// Some previous prop item properties to keep on over.
+// xss: meta.xss || false,
+// isVModel: this.componentVModel && this.componentVModel.prop === prop,
+// _showDetails: typeof p.deprecated === 'string' || typeof p.deprecation === 'string'
+
+interface PaginationPropItem {
+  prop: string
+  defaultValue: string
+  required: boolean
+  description: string
+  version: string
+  deprecated: boolean
+  deprecation: boolean
+  type: any
+}

--- a/docs/.vuepress/PluginComponentReference/index.ts
+++ b/docs/.vuepress/PluginComponentReference/index.ts
@@ -1,0 +1,37 @@
+import {fs} from '@vuepress/utils'
+import type {Page, Plugin, App, PageData} from '@vuepress/core'
+import {path} from '@vuepress/utils'
+
+export interface ComponentReferenceOptions {
+  baseDir: string
+}
+
+function resolvePageComponentReferencePath(baseDir: string, page, app: App): {filePath: string} {
+  const filePath = path.resolve(app.dir.source(), baseDir, path.addExt(page.slug, '.json'))
+  if (!filePath) {
+    return {
+      filePath: null,
+    }
+  }
+
+  return {
+    filePath: filePath,
+  }
+}
+
+export const componentReference: Plugin<ComponentReferenceOptions> = ({
+  baseDir = 'component-references',
+}) => ({
+  name: 'plugin-object',
+  clientAppEnhanceFiles: path.resolve(__dirname, './client/clientAppEnhance.ts'),
+  extendsPageData(page, app: App) {
+    const {filePath} = resolvePageComponentReferencePath(baseDir, page, app)
+    let componentReference = null
+
+    if (fs.existsSync(filePath)) {
+      componentReference = require(filePath)
+    }
+
+    return {componentReference}
+  },
+})

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -1,4 +1,5 @@
 import {defineUserConfig} from 'vuepress'
+import {componentReference} from './PluginComponentReference'
 import type {DefaultThemeOptions} from 'vuepress'
 
 export default defineUserConfig<DefaultThemeOptions>({
@@ -6,6 +7,8 @@ export default defineUserConfig<DefaultThemeOptions>({
   base: '/bootstrap-vue-3/',
   title: 'BootstrapVue 3',
   head: [['link', {rel: 'icon', href: '/bootstrap-vue-3/favicon.ico'}]],
+
+  plugins: [componentReference],
   themeConfig: {
     logo: '/logo.png',
     repo: 'https://github.com/cdmoro/bootstrap-vue-3',
@@ -32,6 +35,7 @@ export default defineUserConfig<DefaultThemeOptions>({
         {
           text: 'Components',
           children: [
+            '/components/README.md',
             '/components/Accordion.md',
             '/components/Alert.md',
             '/components/Avatar.md',
@@ -41,22 +45,16 @@ export default defineUserConfig<DefaultThemeOptions>({
             '/components/ButtonGroup.md',
             '/components/ButtonToolbar.md',
             '/components/Card.md',
-            '/components/Collapse.md',
             '/components/Dropdown.md',
             '/components/FormCheckbox.md',
-            '/components/Form.md',
-            '/components/FormGroup.md',
-            '/components/FormInput.md',
             '/components/FormRadio.md',
+            '/components/FormInput.md',
             '/components/FormSelect.md',
-            '/components/FormTextArea.md',
-            '/components/Icon.md',
             '/components/Image.md',
-            '/components/InputGroup.md',
             '/components/ListGroup.md',
             '/components/Overlay.md',
-            '/components/Pagination.md',
             '/components/Progress.md',
+            '/components/Pagination.md',
             '/components/Spinners.md',
             '/components/Tabs.md',
           ],

--- a/docs/component-references/Pagination.json
+++ b/docs/component-references/Pagination.json
@@ -1,0 +1,293 @@
+{
+  "name": "@bootstrap-vue/pagination",
+  "version": "1.0.0",
+  "meta": {
+    "components": [
+      {
+        "component": "BPagination",
+        "props": [
+          {
+            "prop": "align",
+            "description": "Alignment of the page buttons: 'start' (or 'left'), 'center', 'end' (or 'right'), or 'fill'"
+          },
+          {
+            "prop": "ariaLabel",
+            "description": "Value to place in the 'aria-label' attribute of the pagination control"
+          },
+          {
+            "prop": "ellipsisClass",
+            "version": "2.3.0",
+            "description": "Class(es) to apply to the 'ellipsis' placeholders"
+          },
+          {
+            "prop": "ellipsisText",
+            "description": "Content to place in the ellipsis placeholder"
+          },
+          {
+            "prop": "firstClass",
+            "version": "2.3.0",
+            "description": "Class(es) to apply to the 'Go to first page' button"
+          },
+          {
+            "prop": "firstNumber",
+            "version": "2.3.0",
+            "description": "Display first page number instead of Goto First button"
+          },
+          {
+            "prop": "firstText",
+            "description": "Content to place in the goto first page button"
+          },
+          {
+            "prop": "hideEllipsis",
+            "description": "Do not show ellipsis buttons"
+          },
+          {
+            "prop": "hideGotoEndButtons",
+            "description": "Hides the goto first and goto last page buttons"
+          },
+          {
+            "prop": "labelFirstPage",
+            "description": "Value to place in the 'aria-label' attribute of the goto first page button"
+          },
+          {
+            "prop": "labelLastPage",
+            "description": "Value to place in the 'aria-label' attribute of the goto last page button"
+          },
+          {
+            "prop": "labelNextPage",
+            "description": "Value to place in the 'aria-label' attribute of the goto next page button"
+          },
+          {
+            "prop": "labelPage",
+            "description": "Value to place in the 'aria-label' attribute of the goto page button. Page number will be prepended automatically"
+          },
+          {
+            "prop": "labelPrevPage",
+            "description": "Value to place in the 'aria-label' attribute of the goto previous page button"
+          },
+          {
+            "prop": "lastClass",
+            "version": "2.3.0",
+            "description": "Class(es) to apply to the 'Go to last page' button"
+          },
+          {
+            "prop": "lastNumber",
+            "version": "2.3.0",
+            "description": "Display last page number instead of Goto Last button"
+          },
+          {
+            "prop": "lastText",
+            "description": "Content to place in the goto last page button"
+          },
+          {
+            "prop": "limit",
+            "description": "Maximum number of buttons to show (including ellipsis if shown, but excluding the bookend buttons)"
+          },
+          {
+            "prop": "nextClass",
+            "version": "2.3.0",
+            "description": "Class(es) to apply to the 'Go to next page' button"
+          },
+          {
+            "prop": "nextText",
+            "description": "Content to place in the goto next page button"
+          },
+          {
+            "prop": "pageClass",
+            "version": "2.3.0",
+            "description": "Class(es) to apply to the 'Go to page #' buttons"
+          },
+          {
+            "prop": "perPage",
+            "description": "Number of rows per page"
+          },
+          {
+            "prop": "pills",
+            "version": "2.1.0",
+            "description": "Applies pill styling to the pagination buttons"
+          },
+          {
+            "prop": "prevClass",
+            "version": "2.3.0",
+            "description": "Class(es) to apply to the 'Go to previous page' button"
+          },
+          {
+            "prop": "prevText",
+            "description": "Content to place in the goto previous page button"
+          },
+          {
+            "prop": "size",
+            "description": "Size of the rendered buttons: 'sm', 'md' (default), or 'lg'"
+          },
+          {
+            "prop": "totalRows",
+            "description": "Total number of rows in the dataset"
+          },
+          {
+            "prop": "value",
+            "description": "Current page number, starting from 1"
+          }
+        ],
+        "events": [
+          {
+            "event": "change",
+            "description": "Emitted when page changes via user interaction",
+            "args": [
+              {
+                "arg": "page",
+                "description": "Selected page number (starting with `1`)"
+              }
+            ]
+          },
+          {
+            "event": "input",
+            "description": "Emitted when page changes via user interaction or programmatically",
+            "args": [
+              {
+                "arg": "page",
+                "description": "Selected page number (starting with `1`), or `null` if no page found"
+              }
+            ]
+          },
+          {
+            "event": "page-click",
+            "description": "Emitted when a page button was clicked. Cancelable",
+            "version": "2.17.0",
+            "args": [
+              {
+                "arg": "bvEvent",
+                "type": "BvEvent",
+                "description": "The `BvEvent` object. Call `bvEvent.preventDefault()` to cancel page selection"
+              },
+              {
+                "arg": "page",
+                "description": "Page number to select (starting with `1`)"
+              }
+            ]
+          }
+        ],
+        "slots": [
+          {
+            "name": "ellipsis-text",
+            "description": "The '...' indicator content. Overrides the `ellipsis-text` prop"
+          },
+          {
+            "name": "first-text",
+            "description": "The 'Go to first page' button content",
+            "scope": [
+              {
+                "prop": "disabled",
+                "type": "Boolean",
+                "description": "Will be `true` if this button is disabled (non-clickable)"
+              },
+              {
+                "prop": "index",
+                "type": "Number",
+                "description": "Page number (indexed from `0` to `numberOfPages - 1`)"
+              },
+              {
+                "prop": "page",
+                "type": "Number",
+                "description": "Page number (from `1` to `numberOfPages`)"
+              }
+            ]
+          },
+          {
+            "name": "last-text",
+            "description": "The 'Go to last page' button content",
+            "scope": [
+              {
+                "prop": "disabled",
+                "type": "Boolean",
+                "description": "Will be `true` if this button is disabled (non-clickable)"
+              },
+              {
+                "prop": "index",
+                "type": "Number",
+                "description": "Page number (indexed from `0` to `numberOfPages - 1`)"
+              },
+              {
+                "prop": "page",
+                "type": "Number",
+                "description": "Page number (from `1` to `numberOfPages`)"
+              }
+            ]
+          },
+          {
+            "name": "next-text",
+            "description": "The 'Go to next page' button content",
+            "scope": [
+              {
+                "prop": "disabled",
+                "type": "Boolean",
+                "description": "Will be `true` if this button is disabled (non-clickable)"
+              },
+              {
+                "prop": "index",
+                "type": "Number",
+                "description": "Page number (indexed from `0` to `numberOfPages - 1`)"
+              },
+              {
+                "prop": "page",
+                "type": "Number",
+                "description": "Page number (from `1` to `numberOfPages`)"
+              }
+            ]
+          },
+          {
+            "name": "page",
+            "description": "Page number button content",
+            "scope": [
+              {
+                "prop": "active",
+                "type": "Boolean",
+                "description": "If the page is the active page"
+              },
+              {
+                "prop": "content",
+                "type": "String",
+                "description": "Default button content"
+              },
+              {
+                "prop": "disabled",
+                "type": "Boolean",
+                "description": "Will be `true` if this button is disabled (non-clickable)"
+              },
+              {
+                "prop": "index",
+                "type": "Number",
+                "description": "Page number (indexed from `0` to `numberOfPages - 1`)"
+              },
+              {
+                "prop": "page",
+                "type": "Number",
+                "description": "Page number (from `1` to `numberOfPages`)"
+              }
+            ]
+          },
+          {
+            "name": "prev-text",
+            "description": "The 'Go to previous page' button content",
+            "scope": [
+              {
+                "prop": "disabled",
+                "type": "Boolean",
+                "description": "Will be `true` if this button is disabled (non-clickable)"
+              },
+              {
+                "prop": "index",
+                "type": "Number",
+                "description": "Page number (indexed from `0` to `numberOfPages - 1`)"
+              },
+              {
+                "prop": "page",
+                "type": "Number",
+                "description": "Page number (from `1` to `numberOfPages`)"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/components/Pagination.md
+++ b/docs/components/Pagination.md
@@ -453,66 +453,7 @@ recommended unless the content of the button textually conveys its purpose.
 
 To be done
 
-## Component reference
-
-### `<b-pagination>`
-
-#### Properties
-
-| Property                | Type                            | Default               | Description                                                                                                        |
-| ----------------------- | ------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `align`                 | `String`                        | `start`               | Alignment of the page buttons: 'start', 'center', 'end' or 'fill'                                                  |
-| `aria-controls`         | `String`                        |                       | If this component controls another component or element, set this to the ID of the controlled component or element |
-| `aria-label`            | `String`                        | `Pagination`          | Value to place in the 'aria-label' attribute of the pagination control                                             |
-| `disabled`              | `Boolean`                       | `false`               | When set to `true`, disables the component's functionality and places it in a disabled state                       |
-| `ellipsis-class`        | `Array` or `Object` or `String` |                       | Class(es) to apply to the 'ellipsis' placeholders                                                                  |
-| `ellipsis-text`         | `String`                        | `...`                 | Content to place in the ellipsis placeholder                                                                       |
-| `first-class`           | `Array` or `Object` or `String` |                       | Class(es) to apply to the 'Go to first page' button                                                                |
-| `first-number`          | `Boolean`                       | `false`               | Display first page number instead of Goto First button                                                             |
-| `first-text`            | `String`                        | `«`                   | Content to place in the goto first page button                                                                     |
-| `hide-ellipsis`         | `Boolean`                       | `false`               | Do not show ellipsis buttons                                                                                       |
-| `hide-goto-end-buttons` | `Boolean`                       | `false`               | Hides the goto first and goto last page buttons                                                                    |
-| `label-first-page`      | `String`                        | `Go to first page`    | Value to place in the 'aria-label' attribute of the goto first page button                                         |
-| `label-last-page`       | `String`                        | `Go to last page`     | Value to place in the 'aria-label' attribute of the goto last page button                                          |
-| `label-next-page`       | `String`                        | `Go to next page`     | Value to place in the 'aria-label' attribute of the goto next page button                                          |
-| `label-page`            | `String`                        | `Go to page`          | Value to place in the 'aria-label' attribute of the goto page button. Page number will be prepended automatically  |
-| `label-prev-page`       | `String`                        | `Go to previous page` | Value to place in the 'aria-label' attribute of the goto previous page button                                      |
-| `last-class`            | `Array` or `Object` or `String` |                       | Class(es) to apply to the 'Go to last page' button                                                                 |
-| `last-number`           | `Boolean`                       | `false`               | Display last page number instead of Goto Last button                                                               |
-| `last-text`             | `String`                        | `»`                   | Content to place in the goto last page button                                                                      |
-| `limit`                 | `Number` or `String`            | 5                     | Maximum number of buttons to show (including ellipsis if shown, but excluding the bookend buttons)                 |
-| `next-class`            | `Array` or `Object` or `String` |                       | Class(es) to apply to the 'Go to next page' button                                                                 |
-| `next-text`             | `String`                        | `›`                   | Content to place in the goto next page button                                                                      |
-| `page-class`            | `Array` or `Object` or `String` |                       | Class(es) to apply to the 'Go to page #' buttons                                                                   |
-| `per-page`              | `Number` or `String`            | 20                    | Number of rows per page                                                                                            |
-| `pills`                 | `Boolean`                       | `false`               | Applies pill styling to the pagination buttons                                                                     |
-| `prev-class`            | `Array` or `Object` or `String` |                       | Class(es) to apply to the 'Go to previous page' button                                                             |
-| `size`                  | `String`                        |                       | Size of the rendered buttons: 'sm', 'md' (default), or 'lg'                                                        |
-| `total-rows`            | `Number` or `String`            | 0                     | Total number of rows in the dataset                                                                                |
-
-#### v-model
-
-| Property           | Type     | Default | Description                          |
-| ------------------ | -------- | ------- | ------------------------------------ |
-| default modelValue | `Number` |         | Current page number, starting from 1 |
-
-#### Slots
-
-| Name            | Scoped | Description                                                     |
-| --------------- | ------ | --------------------------------------------------------------- |
-| `ellipsis-text` | No     | The '...' indicator content. Overrides the `ellipsis-text` prop |
-| `first-text`    | Yes    | The 'Go to first page' button content                           |
-| `last-text`     | Yes    | The 'Go to last page' button content                            |
-| `next-text`     | Yes    | The 'Go to next page' button content                            |
-| `page`          | Yes    | Page number button content                                      |
-| `prev-text`     | Yes    | The 'Go to previous page' button content                        |
-
-#### Events
-
-| Name                | Argument                                                                                    | Description                                        |
-| ------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `update:modelValue` | `current page` - Value of he current page                                                   |                                                    |
-| `page-click`        | `bvEvent ` - The `BvEvent` object. Call `bvEvent.preventDefault()` to cancel page selection | Emitted when a page button was clicked. Cancelable |
+<ComponentReference></ComponentReference>
 
 <script lang='ts' setup>
   import {ref, computed} from 'vue'

--- a/src/types/TableField.d.ts
+++ b/src/types/TableField.d.ts
@@ -1,3 +1,5 @@
+import ColorVariant from './ColorVariant'
+
 export interface TableFieldObject {
   key: string
   label?: string
@@ -13,7 +15,7 @@ export interface TableFieldObject {
   tdClass?: string | string[]
   thClass?: string | string[]
   thStyle?: Record<string, unknown>
-  variant?: string
+  variant?: ColorVariant
   tdAttr?: Record<string, unknown>
   thAttr?: Record<string, unknown>
   isRowHeader?: boolean

--- a/src/types/TableItem.d.ts
+++ b/src/types/TableItem.d.ts
@@ -1,6 +1,8 @@
+import ColorVariant from './ColorVariant'
+
 interface TableItem {
   [key: string]: any
-  _rowVariant?: string
+  _rowVariant?: ColorVariant
   _cellVariants?: Record<string, string>
 }
 


### PR DESCRIPTION
Hey guys, 

I've been working on extending the vue press documentation by porting over the original BoostrapVue's docs to a plugin. This pull request serves as just an example of the current structure, feed back is much appreciated.

In the BoostrapVue a package.json was accompanied with each component describing traits. The component definition and package.json generated the component reference tables. 

Now there is a folder in docs where component references match up with there corresponding mark down pages. By using `ComponentReference` within a components doc page, it will render the necessary documentation. 
