### PR TITLE
Reduce dependence on global components

### DIFF
--- a/src/components/BDropdown/BDropdown.vue
+++ b/src/components/BDropdown/BDropdown.vue
@@ -42,6 +42,7 @@
 import * as Popper from '@popperjs/core'
 import {Dropdown} from 'bootstrap'
 import {ComponentPublicInstance, computed, defineComponent, onMounted, PropType, ref} from 'vue'
+import BButton from '../../components/BButton/BButton.vue'
 import {ButtonVariant, Size} from '../../types'
 import mergeDeep from '../../utils/mergeDeep'
 import useId from '../../composables/useId'
@@ -50,6 +51,7 @@ import {HTMLElement} from '../../types/safe-types'
 
 export default defineComponent({
   name: 'BDropdown',
+  components: {BButton},
   props: {
     autoClose: {type: [Boolean, String], default: true},
     block: {type: Boolean, default: false},

--- a/src/components/BModal.vue
+++ b/src/components/BModal.vue
@@ -59,12 +59,14 @@
 <script lang="ts">
 import {computed, defineComponent, onMounted, PropType, ref, watch} from 'vue'
 import {Modal} from 'bootstrap'
+import BButton from '../components/BButton/BButton.vue'
 import useEventListener from '../composables/useEventListener'
 import ColorVariant from '../types/ColorVariant'
 import InputSize from '../types/InputSize'
 
 export default defineComponent({
   name: 'BModal',
+  components: {BButton},
   inheritAttrs: false,
   props: {
     bodyBgVariant: {type: String as PropType<ColorVariant>, required: false},


### PR DESCRIPTION
The following error occurs when you try to import and use individual components.

```
[Vue warn]: Failed to resolve component: b-button
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement.
```

Related Issue: #188 #194