### PR TITLE
Fix: Accordion default behaviour not collapsing when clicking on other accordion header

### DIFF
--- a/src/components/BAccordion.vue
+++ b/src/components/BAccordion.vue
@@ -24,7 +24,7 @@ export default defineComponent({
     }))
 
     if (!props.free) {
-      provide(injectionKey, `#${computedId.value}`)
+      provide(injectionKey, `${computedId.value}`)
     }
 
     return {

--- a/src/components/BAccordionItem.vue
+++ b/src/components/BAccordionItem.vue
@@ -18,7 +18,7 @@
       :id="computedId"
       class="accordion-collapse"
       :visible="visible"
-      :parent="parent"
+      :accordion="parent"
       :aria-labelledby="`heading${computedId}`"
     >
       <div class="accordion-body">


### PR DESCRIPTION
Problem: Accordion default behaviour (without free property) was not collapsing when other accordion buttons are clicked. 
i.e. it is behaving like it has the free property 

Fix: Minor fix to binding properties in BAccordionItem. v-binding to "accordion" instead of "parent", 
removal of extra "#" during injection