### PR TITLE
Feature [BPopover component]: Can use a ref instead of a string id for the target

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1223,6 +1223,14 @@
         >
           Click to toggle popover
         </button>
+        <b-button ref="popoverRef">Click to toggle popover by ref</b-button>
+        <b-popover :target="popoverRef" placement="bottom">
+          <template #title> Popover <em>Title</em> - {{ popoverInput }} </template>
+          <b-button @click="consoleLog"> 456 </b-button>
+          I am popover <b>component</b> content!
+          <b-form-input v-model="popoverInput" type="text" />
+          Name: <strong>{{ popoverInput }}</strong>
+        </b-popover>
       </div>
     </div>
 
@@ -1387,7 +1395,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, onMounted, reactive, ref} from 'vue'
+import {ComponentPublicInstance, defineComponent, onMounted, reactive, ref} from 'vue'
 import {useBreadcrumb} from './composables/useBreadcrumb'
 import BDropdown from './components/BDropdown/BDropdown.vue'
 import TableField from './types/TableField'
@@ -1424,6 +1432,7 @@ export default defineComponent({
 
     const name = ref('')
     const popoverInput = ref('foo')
+    const popoverRef = ref<ComponentPublicInstance<HTMLButtonElement>>()
 
     const consoleLog = () => console.log('button clicked!')
 
@@ -1576,6 +1585,7 @@ export default defineComponent({
       paginationPerPage,
       paginationRows,
       paginationDangerClasses,
+      popoverRef,
       setCheckedSelectedCars,
       radioDefault,
       radioButton,

--- a/src/components/BPopover.vue
+++ b/src/components/BPopover.vue
@@ -22,7 +22,17 @@
 
 <script lang="ts">
 import {Popover} from 'bootstrap'
-import {computed, defineComponent, onMounted, PropType, ref, watch} from 'vue'
+import {
+  ComponentPublicInstance,
+  computed,
+  defineComponent,
+  nextTick,
+  onMounted,
+  PropType,
+  ref,
+  unref,
+  watch,
+} from 'vue'
 import useEventListener from '../composables/useEventListener'
 import {ColorVariant} from '../types'
 
@@ -34,7 +44,10 @@ export default defineComponent({
     id: {type: String},
     noninteractive: {type: Boolean, default: false},
     placement: {type: String as PropType<Popover.Options['placement']>, default: 'right'},
-    target: {type: String, required: true},
+    target: {
+      type: [String, Object] as PropType<string | ComponentPublicInstance<HTMLElement> | undefined>,
+      default: undefined,
+    },
     title: {type: String},
     triggers: {type: String as PropType<Popover.Options['trigger']>, default: 'click'},
     show: {type: Boolean, default: false},
@@ -45,7 +58,7 @@ export default defineComponent({
   emits: ['show', 'shown', 'hide', 'hidden', 'inserted'],
   setup(props, {emit, slots}) {
     const element = ref<HTMLElement>()
-    const target = ref<HTMLElement>()
+    const target = ref<HTMLElement | undefined>()
     const instance = ref<Popover>()
     const titleRef = ref<HTMLElement>()
     const contentRef = ref<HTMLElement>()
@@ -54,24 +67,31 @@ export default defineComponent({
     }))
 
     onMounted(() => {
-      instance.value = new Popover(`#${props.target}`, {
-        container: props.container,
-        trigger: props.triggers,
-        placement: props.placement,
-        title: props.title || slots.title ? titleRef.value : '',
-        content: contentRef.value,
-        html: props.html,
-        sanitize: props.sanitize,
-      })
+      nextTick(() => {
+        const unrefTarget = unref(props.target)
+        if (typeof unrefTarget === 'string') {
+          const element = document.getElementById(unrefTarget)
+          target.value = element ? element : undefined
+        } else if (typeof unrefTarget !== 'undefined') target.value = unrefTarget.$el as HTMLElement
+        else target.value = undefined
 
-      if (document.getElementById(props.target)) {
-        target.value = document.getElementById(props.target) as HTMLElement
-      }
+        if (target.value)
+          instance.value = new Popover(target.value, {
+            container: props.container,
+            trigger: props.triggers,
+            placement: props.placement,
+            title: props.title || slots.title ? titleRef.value : '',
+            content: contentRef.value,
+            html: props.html,
+            sanitize: props.sanitize,
+          })
+        else console.warn('[B-Popover] Target is a mandatory props.')
+      })
 
       element.value?.parentNode?.removeChild(element.value)
 
       if (props.show) {
-        instance.value.show()
+        instance.value?.show()
       }
     })
 


### PR DESCRIPTION
I implemented the correction needed by the component to work properly with a ref element.
close  #225