### PR TITLE
Issue#124 incorrect values when using null value

### DIFF
--- a/src/components/BFormSelect/BFormSelectOption.vue
+++ b/src/components/BFormSelect/BFormSelectOption.vue
@@ -1,5 +1,5 @@
 <template>
-  <option :value="value" :disabled="disabled">
+  <option :value="value ?? ''" :disabled="disabled">
     <slot />
   </option>
 </template>


### PR DESCRIPTION
When values in the :value of the option element contain null or undefined, it doesn't create value="", instead, it ignores the attribute. Thus causing incorrect reading of null values when switching to a value with null, and mounting with null as default value. Simply null-checking the value prop and assigning an empty string safely adds in an empty value attribute for correct targeting. 