### PR TITLE
Added basic tooltip-directive delay feature

### DIFF
--- a/src/directives/BTooltip.ts
+++ b/src/directives/BTooltip.ts
@@ -43,6 +43,14 @@ function resolvePlacement(modifiers: DirectiveBinding['modifiers']): Tooltip.Opt
   return 'top'
 }
 
+function resolveDelay(values: DirectiveBinding['value']): Tooltip.Options['delay'] {
+  if (values?.delay) {
+    return values.delay
+  }
+
+  return 50
+}
+
 const BTooltip: Directive<HTMLElement> = {
   beforeMount(el, binding) {
     el.setAttribute('data-bs-toogle', 'tooltip')
@@ -50,10 +58,12 @@ const BTooltip: Directive<HTMLElement> = {
     const isHtml = /<("[^"]*"|'[^']*'|[^'">])*>/.test(el.title)
     const trigger = resolveTrigger(binding.modifiers)
     const placement = resolvePlacement(binding.modifiers)
+    const delay = resolveDelay(binding.value)
 
     new Tooltip(el, {
       trigger,
       placement,
+      delay,
       html: isHtml,
     })
   },


### PR DESCRIPTION
Hi, first of all thanks for making this project. I just made a basic implementation to add the `delay` option to the tooltip directive so by using something like : `v-b-tooltip="{ delay: 100 }"` or `v-b-tooltip="{ delay:  { "show": 500, "hide": 100 }  }` the delay options works.
This implementations is really basic, it **doesn't** implement mods like `d###` or `ds###` to use them like `v-b-tooltip.d100` for example.
I need this option implemented for one of my projects so if i have to change something please let me know.
