### PR TITLE
no-gutters changed to class="g-0" as per BSv5

### DIFF
--- a/docs/components/Card.md
+++ b/docs/components/Card.md
@@ -427,7 +427,7 @@ card.
 Using a combination of grid components, utility classes and individual card sub-components, cards
 can be made horizontal in a mobile-friendly and responsive way.
 
-In the example below, we remove the row grid gutters with the `no-gutters` prop on `<b-row>` and use
+In the example below, we remove the row grid gutters with the `class="g-0"` prop on `<b-row>` and use
 `md` props on `<b-col>` to make the card horizontal at the `md` breakpoint. Class `rounded-0`
 removes the rounding of the `<b-card-img>` corners while class `overflow-hidden` on `<b-card>` will
 appropriately clip the image's corners based on the border-radius of the card. Further adjustments
@@ -436,7 +436,7 @@ may be needed depending on your card content.
 <ClientOnly>
   <b-card>
     <b-card no-body class="overflow-hidden" style="max-width: 540px;">
-      <b-row no-gutters>
+      <b-row class="g-0">
         <b-col md="6">
           <b-card-img src="https://picsum.photos/400/400/?image=20" alt="Image" class="rounded-0"></b-card-img>
         </b-col>
@@ -456,7 +456,7 @@ may be needed depending on your card content.
 ```html
 <b-card>
   <b-card no-body class="overflow-hidden" style="max-width: 540px;">
-    <b-row no-gutters>
+    <b-row class="g-0">
       <b-col md="6">
         <b-card-img
           src="https://picsum.photos/400/400/?image=20"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/max-attributes-per-line vue/singleline-html-element-content-newline -->
 <template>
-<b-container  id="container" ref="container" :toast="{root: true}" class="mt-4" fluid="sm">
+  <b-container id="container" ref="container" :toast="{root: true}" class="mt-4" fluid="sm">
     <!-- Form -->
     <div class="my-2">
       <h2>Form</h2>
@@ -746,7 +746,7 @@
         </b-col>
         <b-col cols="6">
           <b-card no-body class="overflow-hidden" style="max-width: 540px">
-            <b-row no-gutters>
+            <b-row class="g-0">
               <b-col md="6">
                 <b-card-img
                   src="https://picsum.photos/400/400/?image=20"
@@ -1446,7 +1446,7 @@
       <div v-if="handledVisible">This should only show if handleVisible was triggered</div>
     </div>
 
-    <b-toast v-model="showToast"  title="Hello"  body="cow"></b-toast>
+    <b-toast v-model="showToast" title="Hello" body="cow"></b-toast>
     <b-button class="mt-3" @click="createToast()">Show Toast</b-button>
     <b-button class="mt-3" @click="consoleLog">Hide Toast</b-button>
     <div id="demo"></div>


### PR DESCRIPTION
no-gutters was changed to g-0 in the bootstrap v4 -> v5 change.
https://getbootstrap.com/docs/5.1/layout/gutters/

This PR addresses this change.

Note: Prettier also found some extra spaces.