### PR TITLE
Add missing gx-x and gy-x classes for BContainer

### DIFF
--- a/src/components/BContainer.vue
+++ b/src/components/BContainer.vue
@@ -11,6 +11,8 @@ import {computed, defineComponent, PropType} from 'vue'
 export default defineComponent({
   name: 'BContainer',
   props: {
+    gutterX: {type: String, default: null},
+    gutterY: {type: String, default: null},
     fluid: {type: [Boolean, String] as PropType<boolean | Breakpoint>, default: false},
   },
   setup(props) {
@@ -18,6 +20,8 @@ export default defineComponent({
       container: !props.fluid,
       [`container-fluid`]: typeof props.fluid === 'boolean' && props.fluid,
       [`container-${props.fluid}`]: typeof props.fluid === 'string',
+      [`gx-${props.gutterX}`]: props.gutterX !== null,
+      [`gy-${props.gutterY}`]: props.gutterY !== null,
     }))
 
     return {


### PR DESCRIPTION
Hi,

When we try to use a BContainer with fluid, the css class "container-fluid" is reading the padding right/left from --v-gutter-x, so It's applying a default padding that sometimes I want to avoid.

So, we can allow this padding with the parameters like we are doing for BRow.vue component.