### PR TITLE
remove import on bootstrap.js, only direct components

### DIFF
--- a/src/components/BAlert.vue
+++ b/src/components/BAlert.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import {computed, defineComponent, onBeforeUnmount, PropType, ref, watch} from 'vue'
-import {Alert} from 'bootstrap'
+import Alert from 'bootstrap/js/dist/alert'
 import {ColorVariant} from '../types'
 import {toInteger} from '../utils/number'
 

--- a/src/components/BCarousel/BCarousel.vue
+++ b/src/components/BCarousel/BCarousel.vue
@@ -42,7 +42,7 @@
 
 <script lang="ts">
 import {defineComponent, InjectionKey, onMounted, provide, ref, VNode} from 'vue'
-import {Carousel} from 'bootstrap'
+import Carousel from 'bootstrap/js/dist/carousel'
 import useEventListener from '../../composables/useEventListener'
 import useId from '../../composables/useId'
 

--- a/src/components/BCollapse.vue
+++ b/src/components/BCollapse.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import {computed, defineComponent, onMounted, ref, watch} from 'vue'
-import {Collapse} from 'bootstrap'
+import Collapse from 'bootstrap/js/dist/collapse'
 import useEventListener from '../composables/useEventListener'
 import getID from '../utils/getID'
 

--- a/src/components/BDropdown/BDropdown.vue
+++ b/src/components/BDropdown/BDropdown.vue
@@ -40,7 +40,7 @@
 
 <script lang="ts">
 import * as Popper from '@popperjs/core'
-import {Dropdown} from 'bootstrap'
+import Dropdown from 'bootstrap/js/dist/dropdown'
 import {ComponentPublicInstance, computed, defineComponent, onMounted, PropType, ref} from 'vue'
 import BButton from '../../components/BButton/BButton.vue'
 import {ButtonVariant, Size} from '../../types'

--- a/src/components/BModal.vue
+++ b/src/components/BModal.vue
@@ -58,7 +58,7 @@
 
 <script lang="ts">
 import {computed, defineComponent, onMounted, PropType, ref, watch} from 'vue'
-import {Modal} from 'bootstrap'
+import Modal from 'bootstrap/js/dist/modal'
 import BButton from '../components/BButton/BButton.vue'
 import useEventListener from '../composables/useEventListener'
 import ColorVariant from '../types/ColorVariant'

--- a/src/components/BOffcanvas.vue
+++ b/src/components/BOffcanvas.vue
@@ -29,7 +29,7 @@
 
 <script lang="ts">
 import {computed, defineComponent, onMounted, ref, watch} from 'vue'
-import {Offcanvas} from 'bootstrap'
+import Offcanvas from 'bootstrap/js/dist/offcanvas'
 import useEventListener from '../composables/useEventListener'
 
 export default defineComponent({

--- a/src/components/BPopover.vue
+++ b/src/components/BPopover.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts">
-import {Popover} from 'bootstrap'
+import Popover from 'bootstrap/js/dist/popover'
 import {
   ComponentPublicInstance,
   computed,

--- a/src/directives/BPopover.ts
+++ b/src/directives/BPopover.ts
@@ -1,5 +1,5 @@
 import {Directive} from 'vue'
-import {Popover} from 'bootstrap'
+import Popover from 'bootstrap/js/dist/popover'
 
 const BPopover: Directive<HTMLElement> = {
   mounted(el, binding) {

--- a/src/directives/BTooltip.ts
+++ b/src/directives/BTooltip.ts
@@ -1,5 +1,5 @@
 import {Directive, DirectiveBinding} from 'vue'
-import {Tooltip} from 'bootstrap'
+import Tooltip from 'bootstrap/js/dist/tooltip'
 
 function resolveTrigger(modifiers: DirectiveBinding['modifiers']): Tooltip.Options['trigger'] {
   if (modifiers.manual) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,6 @@ const router = createRouter({
   routes,
 })
 
-import 'bootstrap'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './styles/styles.scss'
 const app = createApp(App)


### PR DESCRIPTION
So, on import bootstrap.js install evenlisteners on every class, data-api, document etc. for every component. So if I import only Modal and use my own Dropdown (but bootstrap style/classes) it still install the events on it.

This just changes the imports to individual components so it doesn't pollute the dom for every component.

also required step if we want to start converting the components to vue components. see #243 and #310 