### PR TITLE
add bootstrap js to external

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,15 +20,34 @@ const config = defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['bootstrap', 'vue'],
+      external: [
+        'bootstrap',
+        'bootstrap/js/dist/alert',
+        'bootstrap/js/dist/collapse',
+        'bootstrap/js/dist/modal',
+        'bootstrap/js/dist/offcanvas',
+        'bootstrap/js/dist/popover',
+        'bootstrap/js/dist/carousel',
+        'bootstrap/js/dist/dropdown',
+        'bootstrap/js/dist/tooltip',
+        'vue',
+      ],
       output: {
         exports: 'named',
         assetFileNames: `bootstrap-vue-3.[ext]`, //without this, it generates build/styles.css
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {
-          vue: 'Vue',
-          bootstrap: 'Bootstrap',
+          'vue': 'Vue',
+          'bootstrap': 'Bootstrap',
+          'bootstrap/js/dist/collapse': 'Collapse',
+          'bootstrap/js/dist/alert': 'Alert',
+          'bootstrap/js/dist/carousel': 'Carousel',
+          'bootstrap/js/dist/dropdown': 'Dropdown',
+          'bootstrap/js/dist/modal': 'Modal',
+          'bootstrap/js/dist/offcanvas': 'Offcanvas',
+          'bootstrap/js/dist/popover': 'Popover',
+          'bootstrap/js/dist/tooltip': 'Tooltip',
         },
       },
     },


### PR DESCRIPTION
Didn't notice that now the bootstrap js is included in the components:
![Screenshot 2022-03-18 at 10 52 21](https://user-images.githubusercontent.com/130606/158970179-dc8ad746-d472-4f1d-b9f5-ffea2c22176f.png)
this fixes that:
![Screenshot 2022-03-18 at 10 52 29](https://user-images.githubusercontent.com/130606/158970329-782a7ecb-01db-4abc-8ff4-bcfb5244148a.png)

