### PR TITLE
Remove link on tab, prevent default action

### DIFF
--- a/src/components/BTabs/BTabs.vue
+++ b/src/components/BTabs/BTabs.vue
@@ -17,24 +17,23 @@
           class="nav-item"
           :class="tab.props['title-item-class']"
         >
-          <a
+          <button
             :id="buttonId"
             class="nav-link"
             :class="navItemClasses"
             data-bs-toggle="tab"
             :data-bs-target="target"
-            href="#"
             role="tab"
             :aria-controls="contentId"
             :aria-selected="active"
             v-bind="tab.props['title-link-attributes']"
-            @click.stop="(e) => handleClick(e, idx)"
+            @click.stop.prevent="(e) => handleClick(e, idx)"
           >
             <component :is="tab.children.title" v-if="tab.children && tab.children.title" />
             <template v-else>
               {{ tab.props.title }}
             </template>
-          </a>
+          </button>
         </li>
         <slot name="tabs-end" />
       </ul>


### PR DESCRIPTION
Clicking on tab scrolls the page to the top.

also I think button is better default for tab. can use slot if you need it to a link.