### PR TITLE
fix(BNavItemDropdown): uncomment the component from the index

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -62,7 +62,7 @@ import BListGroupItem from './BListGroup/BListGroupItem.vue'
 import BModal from './BModal.vue'
 import BNav from './BNav.vue'
 import BNavItem from './BNavItem.vue'
-// import BNavItemDropdown from './BNavItemDropdown.vue'
+import BNavItemDropdown from './BNavItemDropdown.vue'
 import BOffcanvas from './BOffcanvas.vue'
 import BOverlay from './BOverlay/BOverlay.vue'
 import BPagination from './BPagination/BPagination.vue'
@@ -154,7 +154,7 @@ export default {
   BModal,
   BNav,
   BNavItem,
-  // BNavItemDropdown,
+  BNavItemDropdown,
   BOffcanvas,
   BOverlay,
   BPagination,


### PR DESCRIPTION
Hello,

It's not possible to use this component because it's commented on the file since this commit about eslint refactoring.

https://github.com/cdmoro/bootstrap-vue-3/commit/8c2f7362de148f6b5d9a4a5d4e900b684bd8c2a6#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fR38 

@cdmoro Why did you put it im comment?

Is there anything more to be done? Documentation?

Thank you again for this library.

Mathieu 