### PR TITLE
feat: generates *.d.ts files from .ts or .vue source

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ts-jest": "^27.0.4",
     "typescript": "4.x.x",
     "vite": "2.x.x",
+    "vite-plugin-dts": "^1.0.5",
     "vue": "^3.2.31",
     "vue-loader": "17.x.x",
     "vue-router": "^4.0.12",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import {defineConfig} from 'vite'
 import vue from '@vitejs/plugin-vue'
 import {resolve} from 'path'
 import visualizer from 'rollup-plugin-visualizer'
+import dts from 'vite-plugin-dts'
 
 const config = defineConfig({
   resolve: {
@@ -60,6 +61,7 @@ const config = defineConfig({
       include: [/\.vue$/, /\.md$/],
     }),
     visualizer(), // generates admin/stats.html on npm run build
+    dts(),
   ],
 
   server: {


### PR DESCRIPTION
Hello, 

I saw an issue https://github.com/cdmoro/bootstrap-vue-3/issues/326 about d.ts file missing.

There is a nice plugin https://github.com/qmhc/vite-plugin-dts that generates declaration files (*.d.ts) from .ts or .vue source files when using vite in [library mode](https://vitejs.dev/guide/build.html#library-mode)

It's very simple, as vite developer experience.

May be we can use it.

![Screenshot 2022-04-07 at 16 07 09](https://user-images.githubusercontent.com/80677/162218390-6502968e-c935-41fc-acfa-1e61574bfa0a.png)

Mathieu