### PR TITLE
Objects as values in options for BFormSelect

### DIFF
--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -12,7 +12,7 @@
     :aria-required="required ? 'true' : null"
     :aria-invalid="computedAriaInvalid"
     v-bind="$attrs"
-    :value="modelValue"
+    :value="JSON.stringify(modelValue)"
     @change="onChange($event)"
   >
     <slot name="first" />
@@ -27,7 +27,7 @@
       <b-form-select-option
         v-else
         :key="`option2_${index}`"
-        :value="option.value"
+        :value="JSON.stringify(option.value)"
         :disabled="option.disabled"
         v-html="option.html || option.text"
       />
@@ -135,8 +135,8 @@ export default defineComponent({
         .filter((o: any) => o.selected)
         .map((o: any) => ('_value' in o ? o._value : o.value))
       nextTick(() => {
-        emit('change', target.multiple ? selectedVal : selectedVal[0])
-        emit('update:modelValue', target.multiple ? selectedVal : selectedVal[0])
+        emit('change', JSON.parse(target.multiple ? selectedVal : selectedVal[0]))
+        emit('update:modelValue', JSON.parse(target.multiple ? selectedVal : selectedVal[0]))
       })
     }
 


### PR DESCRIPTION
## Current bug

Bootstrap-vue allows for objects to be passed for options values in BFormSelect. So, for example, according to this example from their doc:
```
        options: [
              { value: { C: '3PO' }, text: 'Option with object value' },
              { value: { R: '2D2' }, text: 'Another option with object value' }
        ]
```
The current implementation is buggy when trying to add objects as value. If two values with objects are provided, no matter what v-model will be, it will select the first of those two as long as it is an object too. This is because since we can't pass objects into actual HTML, values will not be the actual object but [object Object]. 

## How to reproduce

Have more than one option with object as value. You will see that when selecting one or another, the select is buggy

## Fix

I stringify to JSON any values that are passed to HTML template. OnChange, I emit the parsed value from JSON to go back to its original state. I'm not sure if it's ideal, but it's what I do as a fix for our current project. Any suggestion on how to better solve this is welcome.