### PR TITLE
Fix select/checkbox/radio with object

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -692,6 +692,7 @@
           <b-form-radio value="second">Or toggle this other custom radio</b-form-radio>
           <b-form-radio value="third" disabled>This one is Disabled</b-form-radio>
           <b-form-radio :value="{fourth: 4}">This is the 4th radio</b-form-radio>
+          <b-form-radio :value="{fifth: 5}">This is the 5th radio</b-form-radio>
         </b-form-radio-group>
 
         <div class="mt-3">
@@ -715,6 +716,10 @@
         </div>
       </div>
       <h4 class="m-2">Button styles radios</h4>
+      <div class="mt-3">
+        Selected:
+        <strong>{{ radios.ex3.selected }}</strong>
+      </div>
       <div class="m-4">
         <b-form-radio-group
           id="btn-radios-1"
@@ -1955,21 +1960,24 @@ export default defineComponent({
         ],
       },
       ex2: {
-        selected: {d: 1},
+        selected: {e: 1},
         options: [
           {item: 'A', name: 'Option A'},
           {item: 'B', name: 'Option B'},
           {item: 'D', name: 'Option C', notEnabled: true},
           {item: {d: 1}, name: 'Option D'},
+          {item: {e: 1}, name: 'Option E'},
         ],
       },
       ex3: {
-        selected: 'radio1',
+        selected: {e: 1},
         options: [
           {text: 'Radio 1', value: 'radio1'},
           {text: 'Radio 3', value: 'radio2'},
           {text: 'Radio 3 (disabled)', value: 'radio3', disabled: true},
           {text: 'Radio 4', value: 'radio4'},
+          {value: {d: 1}, text: 'Option D'},
+          {value: {e: 1}, text: 'Option E'},
         ],
       },
     })

--- a/src/App.vue
+++ b/src/App.vue
@@ -583,7 +583,8 @@
           <b-form-checkbox value="orange">Orange</b-form-checkbox>
           <b-form-checkbox value="apple">Apple</b-form-checkbox>
           <b-form-checkbox value="pineapple">Pineapple</b-form-checkbox>
-          <b-form-checkbox value="grape">Grape</b-form-checkbox>
+          <b-form-checkbox :value="{foo: 1}">Object</b-form-checkbox>
+          <b-form-checkbox value="grape">Grapess</b-form-checkbox>
         </b-form-checkbox-group>
         <br />
         <div>
@@ -1923,11 +1924,12 @@ export default defineComponent({
     }
     const checkboxes = reactive({
       status: 'accepted',
-      selected: ['pineapple'],
+      selected: ['pineapple', {foo: 1}],
       options: [
         {text: 'Orange', value: 'orange'},
         {text: 'Apple', value: 'apple'},
         {text: 'Pineapple', value: 'pineapple'},
+        {text: 'Object', value: {foo: 1}},
         {html: '<b>Grape</b> (html content)', value: 'grape'},
       ],
     })
@@ -1943,16 +1945,17 @@ export default defineComponent({
     const radioSelected = ref()
     const radios = reactive({
       ex1: {
-        selected: 'first',
+        selected: {fifth: 5},
         options: [
           {text: 'Toggle this custom radio', value: 'first'},
           {text: 'Or toggle this other custom radio', value: 'second'},
           {text: 'This one is Disabled', value: 'third', disabled: true},
           {text: 'This is the 4th radio', value: {fourth: 4}},
+          {text: 'This is the 5th radio', value: {fifth: 5}},
         ],
       },
       ex2: {
-        selected: 'A',
+        selected: {d: 1},
         options: [
           {item: 'A', name: 'Option A'},
           {item: 'B', name: 'Option B'},
@@ -1983,7 +1986,7 @@ export default defineComponent({
 
     const formInputRangeValue = ref(3)
 
-    const formSelectSelected = ref()
+    const formSelectSelected = ref({foo: 'item 6', baz: false})
     const formSelectMultipleSelected = ref<string[]>([])
     formSelectMultipleSelected.value = ['first', 'second']
     const formSelectOptions = [
@@ -1992,7 +1995,8 @@ export default defineComponent({
       {text: 'Item 2', value: 'second'},
       {html: '<b>Item</b> 3', value: 'third', disabled: true},
       {text: 'Item 4'},
-      {text: 'Item 5', value: {foo: 'bar', baz: true}},
+      {text: 'Item 5', value: {foo: 'item 5', baz: true}},
+      {text: 'Item 6', value: {foo: 'item 6', baz: false}},
       {
         label: 'Grouped options',
         options: [

--- a/src/App.vue
+++ b/src/App.vue
@@ -485,17 +485,17 @@
         <h4 class="m-2">array with uncheckedValue</h4>
         <div class="m-4">
           <b-form-checkbox
-            id="checkbox-1"
+            id="checkbox-2"
             v-model="checkboxes.statusArray"
-            name="checkbox-1"
+            name="checkbox-2"
             value="accepted"
             unchecked-value="not_accepted"
             >I accept the terms and use</b-form-checkbox
           >
           <b-form-checkbox
-            id="checkbox-2"
+            id="checkbox-3"
             v-model="checkboxes.statusArray"
-            name="checkbox-2"
+            name="checkbox-3"
             value="accepted2"
             unchecked-value="not_accepted2"
             >I accept the terms and use</b-form-checkbox

--- a/src/App.vue
+++ b/src/App.vue
@@ -482,6 +482,29 @@
             <strong>{{ checkboxes.status }}</strong>
           </div>
         </div>
+        <h4 class="m-2">array with uncheckedValue</h4>
+        <div class="m-4">
+          <b-form-checkbox
+            id="checkbox-1"
+            v-model="checkboxes.statusArray"
+            name="checkbox-1"
+            value="accepted"
+            unchecked-value="not_accepted"
+            >I accept the terms and use</b-form-checkbox
+          >
+          <b-form-checkbox
+            id="checkbox-2"
+            v-model="checkboxes.statusArray"
+            name="checkbox-2"
+            value="accepted2"
+            unchecked-value="not_accepted2"
+            >I accept the terms and use</b-form-checkbox
+          >
+          <div>
+            State:
+            <strong>{{ checkboxes.statusArray }}</strong>
+          </div>
+        </div>
         <h4 class="m-2">Individual</h4>
         <div class="row mx-4">
           <b-form-checkbox v-model="checkedDefault" class="col-4">Default</b-form-checkbox>
@@ -1929,6 +1952,7 @@ export default defineComponent({
     }
     const checkboxes = reactive({
       status: 'accepted',
+      statusArray: ['accepted'],
       selected: ['pineapple', {foo: 1}],
       options: [
         {text: 'Orange', value: 'orange'},

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -16,6 +16,8 @@
       :aria-required="name && required ? 'true' : null"
       :value="value"
       :indeterminate="indeterminate"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
     />
     <label
       v-if="$slots.default || !plain"

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -69,7 +69,7 @@ export default defineComponent({
       get: () => {
         if (props.uncheckedValue) {
           if (!Array.isArray(props.modelValue)) {
-            return props.modelValue ? props.value : props.uncheckedValue
+            return props.modelValue === props.value
           }
           return props.modelValue.indexOf(props.value) > -1
         }
@@ -77,13 +77,11 @@ export default defineComponent({
       },
       set: (newValue: any) => {
         let emitValue = newValue
-        console.log(newValue)
-        if (props.uncheckedValue) {
-          if (!Array.isArray(props.modelValue)) {
-            emitValue = newValue ? props.value : props.uncheckedValue
-          } else {
+        if (!Array.isArray(props.modelValue)) {
+          emitValue = newValue ? props.value : props.uncheckedValue
+        } else {
+          if (props.uncheckedValue) {
             emitValue = props.modelValue
-            console.log('array', emitValue, newValue)
             if (newValue) {
               if (emitValue.indexOf(props.uncheckedValue) > -1)
                 emitValue.splice(emitValue.indexOf(props.uncheckedValue), 1)
@@ -95,7 +93,6 @@ export default defineComponent({
             }
           }
         }
-        console.log(emitValue)
         emit('input', emitValue)
         emit('update:modelValue', emitValue)
         emit('change', emitValue)

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -4,6 +4,7 @@
       :id="computedId"
       v-bind="$attrs"
       ref="input"
+      v-model="localValue"
       :class="inputClasses"
       type="checkbox"
       :disabled="disabled"
@@ -15,10 +16,6 @@
       :aria-required="name && required ? 'true' : null"
       :value="value"
       :indeterminate="indeterminate"
-      :checked="isChecked"
-      @click.stop="handleClick($event.target.checked)"
-      @focus="focus()"
-      @blur="blur()"
     />
     <label
       v-if="$slots.default || !plain"
@@ -32,7 +29,7 @@
 
 <script lang="ts">
 import {getClasses, getInputClasses, getLabelClasses} from '../../composables/useFormCheck'
-import {computed, defineComponent, onMounted, PropType, Ref, ref, watch} from 'vue'
+import {computed, defineComponent, onMounted, PropType, Ref, ref} from 'vue'
 import {InputSize} from '../../types'
 import useId from '../../composables/useId'
 
@@ -66,7 +63,7 @@ export default defineComponent({
     const input: Ref<HTMLElement> = ref(null as unknown as HTMLElement)
     const isFocused = ref(false)
 
-    const localChecked = computed({
+    const localValue = computed({
       get: () => props.modelValue,
       set: (newValue: any) => {
         emit('input', newValue)
@@ -86,45 +83,6 @@ export default defineComponent({
     const inputClasses = getInputClasses(props)
     const labelClasses = getLabelClasses(props)
 
-    watch(
-      () => props.modelValue,
-      (newValue) => {
-        emit('input', newValue)
-      }
-    )
-
-    const focus = () => {
-      isFocused.value = true
-      if (!props.disabled) input.value.focus()
-    }
-
-    const blur = () => {
-      isFocused.value = false
-      if (!props.disabled) {
-        input.value.blur()
-      }
-    }
-
-    const handleClick = (checked: boolean) => {
-      if (!Array.isArray(props.modelValue)) {
-        localChecked.value = checked ? props.value : props.uncheckedValue
-      } else {
-        const tempArray = props.modelValue
-        if (checked) {
-          const index = tempArray.indexOf(props.value)
-          if (index < 0) {
-            tempArray.push(props.value)
-          }
-        } else {
-          const index = tempArray.indexOf(props.value)
-          if (index > -1) {
-            tempArray.splice(index, 1)
-          }
-        }
-        localChecked.value = tempArray
-      }
-    }
-
     // TODO: make jest tests compatible with the v-focus directive
     if (props.autofocus) {
       onMounted(() => {
@@ -138,12 +96,9 @@ export default defineComponent({
       classes,
       inputClasses,
       labelClasses,
-      localChecked,
+      localValue,
       isChecked,
       isFocused,
-      handleClick,
-      focus,
-      blur,
     }
   },
 })

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -64,11 +64,39 @@ export default defineComponent({
     const isFocused = ref(false)
 
     const localValue = computed({
-      get: () => props.modelValue,
+      get: () => {
+        if (props.uncheckedValue) {
+          if (!Array.isArray(props.modelValue)) {
+            return props.modelValue ? props.value : props.uncheckedValue
+          }
+          return props.modelValue.indexOf(props.value) > -1
+        }
+        return props.modelValue
+      },
       set: (newValue: any) => {
-        emit('input', newValue)
-        emit('update:modelValue', newValue)
-        emit('change', newValue)
+        let emitValue = newValue
+        console.log(newValue)
+        if (props.uncheckedValue) {
+          if (!Array.isArray(props.modelValue)) {
+            emitValue = newValue ? props.value : props.uncheckedValue
+          } else {
+            emitValue = props.modelValue
+            console.log('array', emitValue, newValue)
+            if (newValue) {
+              if (emitValue.indexOf(props.uncheckedValue) > -1)
+                emitValue.splice(emitValue.indexOf(props.uncheckedValue), 1)
+              emitValue.push(props.value)
+            } else {
+              if (emitValue.indexOf(props.value) > -1)
+                emitValue.splice(emitValue.indexOf(props.value), 1)
+              emitValue.push(props.uncheckedValue)
+            }
+          }
+        }
+        console.log(emitValue)
+        emit('input', emitValue)
+        emit('update:modelValue', emitValue)
+        emit('change', emitValue)
       },
     })
 

--- a/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -8,11 +8,7 @@
     tabindex="-1"
   >
     <template v-for="(item, key) in checkboxList" :key="key">
-      <b-form-checkbox
-        v-model="item.model"
-        v-bind="item.props"
-        @change="childUpdated($event, item.props?.value)"
-      >
+      <b-form-checkbox v-model="localValue" v-bind="item.props">
         <!-- eslint-disable vue/no-v-html -->
         <span v-if="item.html" v-html="item.html" />
         <!--eslint-enable-->
@@ -65,7 +61,7 @@ export default defineComponent({
     const computedId = useId(props.id, 'checkbox')
     const computedName = useId(props.name, 'checkbox')
 
-    const localChecked = computed({
+    const localValue = computed({
       get: () => props.modelValue,
       set: (newValue: any) => {
         if (JSON.stringify(newValue) === JSON.stringify(props.modelValue)) return
@@ -82,7 +78,6 @@ export default defineComponent({
         .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
         .map((e) => ({
           ...e,
-          model: props.modelValue.find((mv) => e.props?.value === mv) ? e.props?.value : false,
           props: {
             switch: props.switches,
             ...e.props,
@@ -90,24 +85,8 @@ export default defineComponent({
         }))
     )
 
-    const childUpdated = (newValue: any, checkedValue: any) => {
-      const resp = props.modelValue.filter(
-        (e) => JSON.stringify(e) !== JSON.stringify(checkedValue)
-      )
-      if (JSON.stringify(newValue) === JSON.stringify(checkedValue)) resp.push(newValue)
-      emit('update:modelValue', resp)
-      emit('change', resp)
-    }
-
     const attrs = getGroupAttr(props)
     const classes = getGroupClasses(props)
-
-    watch(
-      () => props.modelValue,
-      (newValue) => {
-        emit('input', newValue)
-      }
-    )
 
     // TODO: make jest tests compatible with the v-focus directive
 
@@ -115,9 +94,8 @@ export default defineComponent({
       attrs,
       classes,
       checkboxList,
-      childUpdated,
       computedId,
-      localChecked,
+      localValue,
     }
   },
 })

--- a/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script lang="ts">
-import {computed, defineComponent, PropType, watch} from 'vue'
+import {computed, defineComponent, PropType} from 'vue'
 import {ColorVariant, Size} from '../../types'
 import useId from '../../composables/useId'
 import {

--- a/src/components/BFormCheckbox/form-checkbox-group.spec.js
+++ b/src/components/BFormCheckbox/form-checkbox-group.spec.js
@@ -347,8 +347,10 @@ describe('form-checkbox-group', () => {
       attachTo: createContainer(),
       global,
       props: {
-        'options': ['one', 'two', 'three'],
-        'modelValue': [],
+        options: ['one', 'two', 'three'],
+        modelValue: [],
+      },
+      attrs: {
         'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
     })
@@ -392,55 +394,6 @@ describe('form-checkbox-group', () => {
     wrapper.unmount()
   })
 
-  it('does not emit "input" event when value loosely changes', async () => {
-    const value = ['one', 'two', 'three']
-    const wrapper = mount(BFormCheckboxGroup, {
-      attachTo: createContainer(),
-      global,
-      props: {
-        'options': value.slice(),
-        'modelValue': value.slice(),
-        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
-      },
-    })
-
-    expect(wrapper.classes()).toBeDefined()
-
-    const $inputs = wrapper.findAll('input[type=checkbox]')
-    expect($inputs.length).toBe(3)
-    expect(wrapper.vm.modelValue).toEqual(value)
-    expect($inputs[0].element.checked).toBe(true)
-    expect($inputs[1].element.checked).toBe(true)
-    expect($inputs[2].element.checked).toBe(true)
-
-    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
-
-    // Set internal value to new array reference
-    wrapper.vm.localChecked = value.slice()
-    await waitNT(wrapper.vm)
-
-    expect(wrapper.vm.modelValue).toEqual(value)
-    expect($inputs[0].element.checked).toBe(true)
-    expect($inputs[1].element.checked).toBe(true)
-    expect($inputs[2].element.checked).toBe(true)
-
-    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
-
-    // Set internal value to new array (reversed order)
-    wrapper.vm.localChecked = value.slice().reverse()
-    await waitNT(wrapper.vm)
-
-    expect(wrapper.vm.modelValue).toEqual(value.slice().reverse())
-    expect($inputs[0].element.checked).toBe(true)
-    expect($inputs[1].element.checked).toBe(true)
-    expect($inputs[2].element.checked).toBe(true)
-    expect(wrapper.emitted('update:modelValue')).toBeDefined()
-    expect(wrapper.emitted('update:modelValue').length).toBe(1)
-    expect(wrapper.emitted('update:modelValue')[0][0]).toEqual(value.slice().reverse())
-
-    wrapper.unmount()
-  })
-
   it('checkboxes reflect group checked v-model', async () => {
     const wrapper = mount(BFormCheckboxGroup, {
       attachTo: createContainer(),
@@ -455,13 +408,13 @@ describe('form-checkbox-group', () => {
 
     const $inputs = wrapper.findAll('input[type=checkbox]')
     expect($inputs.length).toBe(3)
-    expect(wrapper.vm.localChecked).toEqual(['two'])
+    expect(wrapper.vm.modelValue).toEqual(['two'])
     expect($inputs[0].element.checked).toBe(false)
     expect($inputs[1].element.checked).toBe(true)
     expect($inputs[2].element.checked).toBe(false)
 
     await wrapper.setProps({modelValue: ['three', 'one']})
-    expect(wrapper.vm.localChecked).toEqual(['three', 'one'])
+    expect(wrapper.vm.modelValue).toEqual(['three', 'one'])
     expect($inputs[0].element.checked).toBe(true)
     expect($inputs[1].element.checked).toBe(false)
     expect($inputs[2].element.checked).toBe(true)
@@ -481,7 +434,7 @@ describe('form-checkbox-group', () => {
     })
 
     expect(wrapper.classes()).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual([])
+    expect(wrapper.vm.modelValue).toEqual([])
 
     const $inputs = wrapper.findAll('input[type=checkbox]')
     expect($inputs.length).toBe(3)
@@ -503,7 +456,7 @@ describe('form-checkbox-group', () => {
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual([])
+    expect(wrapper.vm.modelValue).toEqual([])
 
     const $inputs = wrapper.findAll('input[type=checkbox]')
     expect($inputs.length).toBe(3)
@@ -525,7 +478,7 @@ describe('form-checkbox-group', () => {
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual([])
+    expect(wrapper.vm.modelValue).toEqual([])
 
     const $inputs = wrapper.findAll('input[type=checkbox]')
     expect($inputs.length).toBe(3)
@@ -548,7 +501,7 @@ describe('form-checkbox-group', () => {
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual([])
+    expect(wrapper.vm.modelValue).toEqual([])
 
     const $inputs = wrapper.findAll('input[type=checkbox]')
     expect($inputs.length).toBe(3)

--- a/src/components/BFormCheckbox/form-checkbox.spec.js
+++ b/src/components/BFormCheckbox/form-checkbox.spec.js
@@ -947,9 +947,11 @@ describe('form-checkbox', () => {
   it('stand-alone button has label class active when clicked (checked)', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
-        'button': true,
-        'modelValue': false,
-        'value': 'a',
+        button: true,
+        modelValue: false,
+        value: 'a',
+      },
+      attrs: {
         'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
@@ -968,7 +970,7 @@ describe('form-checkbox', () => {
     expect($label.classes()).toContain('btn')
     expect($label.classes()).toContain('btn-secondary')
 
-    await $input.trigger('click')
+    await $input.setValue(true)
     expect($label.classes().length).toEqual(3)
     expect($label.classes()).toContain('active')
     expect($label.classes()).toContain('btn')
@@ -1120,7 +1122,7 @@ describe('form-checkbox', () => {
 
   // --- Functionality testing ---
 
-  it('default has internal localChecked=false when prop modelValue=false', async () => {
+  it('default has internal modelValue=false when prop modelValue=false', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
         modelValue: false,
@@ -1131,8 +1133,8 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual(false)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toEqual(false)
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
@@ -1141,7 +1143,7 @@ describe('form-checkbox', () => {
     wrapper.unmount()
   })
 
-  it('default has internal localChecked=true when prop modelValue=true', async () => {
+  it('default has internal modelValue=true when prop modelValue=true', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
         modelValue: true,
@@ -1152,8 +1154,8 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual(true)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toEqual(true)
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
@@ -1162,7 +1164,7 @@ describe('form-checkbox', () => {
     wrapper.unmount()
   })
 
-  it('default has internal localChecked null', async () => {
+  it('default has internal modelValue null', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
         uncheckedValue: 'foo',
@@ -1174,13 +1176,13 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
 
     wrapper.unmount()
   })
 
-  it('default has internal localChecked set to checked prop', async () => {
+  it('default has internal modelValue set to checked prop', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
         uncheckedValue: 'foo',
@@ -1193,13 +1195,13 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual('foo')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toEqual('foo')
 
     wrapper.unmount()
   })
 
-  it('default has internal localChecked set to value when checked=value', async () => {
+  it('default has internal modelValue set to value when checked=value', async () => {
     const wrapper = mount(BFormCheckbox, {
       props: {
         uncheckedValue: 'foo',
@@ -1212,34 +1214,8 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual('bar')
-
-    wrapper.unmount()
-  })
-
-  it('default has internal localChecked set to value when checked changed to value', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      props: {
-        uncheckedValue: 'foo',
-        value: 'bar',
-      },
-      slots: {
-        default: 'foobar',
-      },
-    })
-
-    expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
-
-    await wrapper.setProps({modelValue: 'bar'})
-    expect(wrapper.vm.localChecked).toEqual('bar')
-    expect(wrapper.emitted('input')).toBeDefined()
-
-    const $last = wrapper.emitted('input').length - 1
-    expect(wrapper.emitted('input')[$last]).toBeDefined()
-    expect(wrapper.emitted('input')[$last][0]).toEqual('bar')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toEqual('bar')
 
     wrapper.unmount()
   })
@@ -1251,25 +1227,28 @@ describe('form-checkbox', () => {
         uncheckedValue: 'foo',
         value: 'bar',
       },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
+      },
       slots: {
         default: 'foobar',
       },
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
 
-    await $input.trigger('click')
+    await $input.setValue(true)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual('bar')
 
-    await $input.trigger('click')
+    await $input.setValue(false)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual('foo')
@@ -1284,14 +1263,17 @@ describe('form-checkbox', () => {
         uncheckedValue: 'foo',
         value: 'bar',
       },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
+      },
       slots: {
         default: 'foobar',
       },
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')
@@ -1318,14 +1300,17 @@ describe('form-checkbox', () => {
         value: 'bar',
         disabled: true,
       },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
+      },
       slots: {
         default: 'foobar',
       },
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $input = wrapper.find('input')
@@ -1345,14 +1330,17 @@ describe('form-checkbox', () => {
         value: 'bar',
         disabled: true,
       },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
+      },
       slots: {
         default: 'foobar',
       },
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')
@@ -1371,26 +1359,29 @@ describe('form-checkbox', () => {
         value: 'bar',
         modelValue: ['foo'],
       },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
+      },
       slots: {
         default: 'foobar',
       },
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(false)
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(2)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
-    expect(wrapper.vm.localChecked[1]).toEqual('bar')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(2)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
+    expect(wrapper.vm.modelValue[1]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual(['foo', 'bar'])
@@ -1399,9 +1390,9 @@ describe('form-checkbox', () => {
     expect($input.element.checked).toBe(true)
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual(['foo'])
@@ -1410,8 +1401,8 @@ describe('form-checkbox', () => {
     expect($input.element.checked).toBe(false)
 
     await wrapper.setProps({modelValue: []})
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(0)
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(0)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
 
@@ -1419,9 +1410,9 @@ describe('form-checkbox', () => {
     expect($input.element.checked).toBe(false)
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('bar')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(3)
     expect(wrapper.emitted('change')[2][0]).toEqual(['bar'])
@@ -1430,8 +1421,8 @@ describe('form-checkbox', () => {
     expect($input.element.checked).toBe(true)
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(0)
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(0)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(4)
     expect(wrapper.emitted('change')[3][0]).toEqual([])
@@ -1455,10 +1446,10 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
@@ -1469,11 +1460,11 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(true)
 
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(2)
-    expect(wrapper.vm.localChecked[0]).toEqual('bar')
-    expect(wrapper.vm.localChecked[1]).toEqual('foo')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(2)
+    expect(wrapper.vm.modelValue[0]).toEqual('bar')
+    expect(wrapper.vm.modelValue[1]).toEqual('foo')
 
     wrapper.unmount()
   })
@@ -1485,39 +1476,8 @@ describe('form-checkbox', () => {
         value: {bar: 1, baz: 2},
         modelValue: ['foo'],
       },
-      slots: {
-        default: 'foobar',
-      },
-    })
-
-    expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
-
-    const $input = wrapper.find('input')
-    expect($input).toBeDefined()
-
-    await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(2)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
-    expect(wrapper.vm.localChecked[1]).toEqual({bar: 1, baz: 2})
-
-    await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
-
-    wrapper.unmount()
-  })
-
-  it('focus() and blur() methods work', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      attachTo: createContainer(),
-      props: {
-        modelValue: false,
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',
@@ -1525,28 +1485,27 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
-    expect(document).toBeDefined()
 
-    expect(wrapper.vm.focus).toBeDefined()
-    expect(typeof wrapper.vm.focus).toBe('function')
-    expect(wrapper.vm.blur).toBeDefined()
-    expect(typeof wrapper.vm.blur).toBe('function')
-    expect($input.element).not.toBe(document.activeElement)
+    await $input.trigger('click')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(2)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
+    expect(wrapper.vm.modelValue[1]).toEqual({bar: 1, baz: 2})
 
-    wrapper.vm.focus()
-    await waitNT(wrapper.vm)
-    expect($input.element).toBe(document.activeElement)
-
-    wrapper.vm.blur()
-    await waitNT(wrapper.vm)
-    expect($input.element).not.toBe(document.activeElement)
+    await $input.trigger('click')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
     wrapper.unmount()
   })
-
   // These tests are wrapped in a new describe to limit the scope
   // of the `getBoundingClientRect()` mock
   describe('prop `autofocus`', () => {

--- a/src/components/BFormInput/form-input.spec.js
+++ b/src/components/BFormInput/form-input.spec.js
@@ -456,11 +456,13 @@ describe('form-input', () => {
   it('does not apply formatter on input when lazy', async () => {
     const wrapper = mount(BFormInput, {
       props: {
-        'formatter'(value) {
+        formatter(value) {
           return value.toLowerCase()
         },
-        'lazyFormatter': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        lazyFormatter: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       attachTo: createContainer(),
     })
@@ -484,12 +486,14 @@ describe('form-input', () => {
   it('applies formatter on blur when lazy', async () => {
     const wrapper = mount(BFormInput, {
       props: {
-        'modelValue': '',
-        'formatter'(value) {
+        modelValue: '',
+        formatter(value) {
           return value.toLowerCase()
         },
-        'lazyFormatter': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        lazyFormatter: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       attachTo: createContainer(),
     })
@@ -589,11 +593,13 @@ describe('form-input', () => {
   it('does not update value when non-lazy formatter returns false', async () => {
     const wrapper = mount(BFormInput, {
       props: {
-        'modelValue': 'abc',
-        'formatter'() {
+        modelValue: 'abc',
+        formatter() {
           return false
         },
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       attachTo: createContainer(),
     })
@@ -718,9 +724,11 @@ describe('form-input', () => {
   it('"number" modifier prop works', async () => {
     const wrapper = mount(BFormInput, {
       props: {
-        'type': 'text',
-        'number': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        type: 'text',
+        number: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
     })
 
@@ -762,9 +770,11 @@ describe('form-input', () => {
   it('"lazy" modifier prop works', async () => {
     const wrapper = mount(BFormInput, {
       props: {
-        'type': 'text',
-        'lazy': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        type: 'text',
+        lazy: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
     })
 
@@ -912,25 +922,6 @@ describe('form-input', () => {
     wrapper.unmount()
   })
   */
-
-  it('focus() and blur() methods work', async () => {
-    const wrapper = mount(BFormInput, {
-      attachTo: createContainer(),
-    })
-
-    const $input = wrapper.find('input')
-
-    expect(typeof wrapper.vm.focus).toBe('function')
-    expect(typeof wrapper.vm.blur).toBe('function')
-
-    expect(document.activeElement).not.toBe($input.element)
-    wrapper.vm.focus()
-    expect(document.activeElement).toBe($input.element)
-    wrapper.vm.blur()
-    expect(document.activeElement).not.toBe($input.element)
-
-    wrapper.unmount()
-  })
 
   // These tests are wrapped in a new describe to limit the scope of the getBCR Mock
   describe('prop `autofocus`', () => {

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -4,6 +4,7 @@
       :id="computedId"
       v-bind="$attrs"
       ref="input"
+      v-model="localValue"
       :class="inputClasses"
       type="radio"
       :disabled="disabled"
@@ -13,11 +14,7 @@
       :aria-label="ariaLabel"
       :aria-labelledby="ariaLabelledBy"
       :value="value"
-      :checked="isChecked"
       :aria-required="name && required ? 'true' : null"
-      @click.stop="handleClick($event.target.checked)"
-      @focus="focus"
-      @blur="blur"
     />
     <label
       v-if="$slots.default || !plain"
@@ -61,7 +58,7 @@ export default defineComponent({
     const input: Ref<HTMLElement> = ref(null as unknown as HTMLElement)
     const isFocused = ref(false)
 
-    const localChecked: any = computed({
+    const localValue: any = computed({
       get: () => props.modelValue,
       set: (newValue: any) => {
         emit('input', newValue)
@@ -69,18 +66,6 @@ export default defineComponent({
         emit('update:modelValue', newValue)
       },
     })
-
-    const focus = () => {
-      isFocused.value = true
-      if (!props.disabled) input.value.focus()
-    }
-
-    const blur = () => {
-      isFocused.value = false
-      if (!props.disabled) {
-        input.value.blur()
-      }
-    }
 
     const isChecked = computed(() => {
       if (Array.isArray(props.modelValue)) {
@@ -93,23 +78,6 @@ export default defineComponent({
     const inputClasses = getInputClasses(props)
     const labelClasses = getLabelClasses(props)
 
-    const handleClick = async (checked: boolean) => {
-      if (Array.isArray(props.modelValue)) {
-        if ((props.modelValue || [])[0] !== props.value) {
-          localChecked.value = [props.value]
-        }
-      } else if (checked && props.modelValue !== props.value) {
-        localChecked.value = props.value
-      }
-    }
-
-    watch(
-      () => props.modelValue,
-      (newValue) => {
-        emit('input', newValue)
-      }
-    )
-
     // TODO: make jest tests compatible with the v-focus directive
     if (props.autofocus) {
       onMounted(() => {
@@ -118,7 +86,7 @@ export default defineComponent({
     }
 
     return {
-      localChecked,
+      localValue,
       computedId,
       classes,
       inputClasses,
@@ -126,9 +94,6 @@ export default defineComponent({
       isChecked,
       isFocused,
       input,
-      handleClick,
-      focus,
-      blur,
     }
   },
 })

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -63,7 +63,8 @@ export default defineComponent({
     const localValue: any = computed({
       get: () => (Array.isArray(props.modelValue) ? props.modelValue[0] : props.modelValue),
       set: (newValue: any) => {
-        const emitValue = Array.isArray(props.modelValue) ? [newValue] : newValue
+        const value = newValue ? props.value : false
+        const emitValue = Array.isArray(props.modelValue) ? [value] : value
         emit('input', emitValue)
         emit('change', emitValue)
         emit('update:modelValue', emitValue)

--- a/src/components/BFormRadio/BFormRadio.vue
+++ b/src/components/BFormRadio/BFormRadio.vue
@@ -15,6 +15,8 @@
       :aria-labelledby="ariaLabelledBy"
       :value="value"
       :aria-required="name && required ? 'true' : null"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
     />
     <label
       v-if="$slots.default || !plain"
@@ -28,7 +30,7 @@
 
 <script lang="ts">
 import {getClasses, getInputClasses, getLabelClasses} from '../../composables/useFormCheck'
-import {computed, defineComponent, onMounted, PropType, Ref, ref, watch} from 'vue'
+import {computed, defineComponent, onMounted, PropType, Ref, ref} from 'vue'
 import useId from '../../composables/useId'
 
 export default defineComponent({
@@ -59,11 +61,12 @@ export default defineComponent({
     const isFocused = ref(false)
 
     const localValue: any = computed({
-      get: () => props.modelValue,
+      get: () => (Array.isArray(props.modelValue) ? props.modelValue[0] : props.modelValue),
       set: (newValue: any) => {
-        emit('input', newValue)
-        emit('change', newValue)
-        emit('update:modelValue', newValue)
+        const emitValue = Array.isArray(props.modelValue) ? [newValue] : newValue
+        emit('input', emitValue)
+        emit('change', emitValue)
+        emit('update:modelValue', emitValue)
       },
     })
 

--- a/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/src/components/BFormRadio/BFormRadioGroup.vue
@@ -8,7 +8,7 @@
     tabindex="-1"
   >
     <template v-for="(item, key) in checkboxList" :key="key">
-      <b-form-radio v-model="item.model" v-bind="item.props" @change="childUpdated">
+      <b-form-radio v-model="localValue" v-bind="item.props">
         <!-- eslint-disable vue/no-v-html -->
         <span v-if="item.html" v-html="item.html" />
         <!--eslint-enable-->
@@ -60,7 +60,7 @@ export default defineComponent({
     const computedId = useId(props.id, 'radio')
     const computedName = useId(props.name, 'checkbox')
 
-    const localChecked = computed({
+    const localValue = computed({
       get: () => props.modelValue,
       set: (newValue: any) => {
         emit('input', newValue)
@@ -76,17 +76,8 @@ export default defineComponent({
         .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
         .map((e) => ({
           ...e,
-          model:
-            JSON.stringify(props.modelValue) === JSON.stringify(e.props?.value)
-              ? e.props?.value
-              : null,
         }))
     )
-
-    const childUpdated = (newValue: any) => {
-      emit('change', newValue)
-      emit('update:modelValue', newValue)
-    }
 
     const attrs = getGroupAttr(props)
     const classes = getGroupClasses(props)
@@ -97,9 +88,8 @@ export default defineComponent({
       attrs,
       classes,
       checkboxList,
-      childUpdated,
       computedId,
-      localChecked,
+      localValue,
     }
   },
 })

--- a/src/components/BFormRadio/form-radio-group.spec.js
+++ b/src/components/BFormRadio/form-radio-group.spec.js
@@ -311,7 +311,7 @@ describe('form-radio-group', () => {
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual('')
+    expect(wrapper.vm.modelValue).toEqual('')
     expect(wrapper.findAll('input[type=radio]').length).toBe(3)
 
     wrapper.unmount()
@@ -327,7 +327,7 @@ describe('form-radio-group', () => {
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual('')
+    expect(wrapper.vm.modelValue).toEqual('')
     expect(wrapper.classes()).toBeDefined()
 
     const $radios = wrapper.findAll('input[type=radio]')
@@ -354,7 +354,7 @@ describe('form-radio-group', () => {
     // computed in a `$nextTick()` on mount
     await waitNT(wrapper.vm)
 
-    expect(wrapper.vm.localChecked).toEqual('')
+    expect(wrapper.vm.modelValue).toEqual('')
     expect(wrapper.classes()).toBeDefined()
 
     const $radios = wrapper.findAll('input[type=radio]')
@@ -372,20 +372,22 @@ describe('form-radio-group', () => {
       attachTo: createContainer(),
       global,
       props: {
-        'options': ['one', 'two', 'three'],
-        'modelValue': '',
+        options: ['one', 'two', 'three'],
+        modelValue: '',
+      },
+      attrs: {
         'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual('')
+    expect(wrapper.vm.modelValue).toEqual('')
     expect(wrapper.classes()).toBeDefined()
 
     const $radios = wrapper.findAll('input[type=radio]')
     expect($radios.length).toBe(3)
 
     await $radios[0].trigger('click')
-    expect(wrapper.vm.localChecked).toEqual('one')
+    expect(wrapper.vm.modelValue).toEqual('one')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual('one')
@@ -394,14 +396,14 @@ describe('form-radio-group', () => {
     expect(wrapper.emitted('update:modelValue')[0][0]).toEqual('one')
 
     await $radios[2].trigger('click')
-    expect(wrapper.vm.localChecked).toEqual('three')
+    expect(wrapper.vm.modelValue).toEqual('three')
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual('three')
     expect(wrapper.emitted('update:modelValue').length).toBe(2)
     expect(wrapper.emitted('update:modelValue')[1][0]).toEqual('three')
 
     await $radios[0].trigger('click')
-    expect(wrapper.vm.localChecked).toEqual('one')
+    expect(wrapper.vm.modelValue).toEqual('one')
     expect(wrapper.emitted('change').length).toBe(3)
     expect(wrapper.emitted('change')[2][0]).toEqual('one')
     expect(wrapper.emitted('update:modelValue').length).toBe(3)
@@ -415,13 +417,15 @@ describe('form-radio-group', () => {
       attachTo: createContainer(),
       global,
       props: {
-        'options': ['one', 'two', 'three'],
-        'modelValue': 'two',
+        options: ['one', 'two', 'three'],
+        modelValue: 'two',
+      },
+      attrs: {
         'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
     })
 
-    expect(wrapper.vm.localChecked).toEqual('two')
+    expect(wrapper.vm.modelValue).toEqual('two')
     expect(wrapper.classes()).toBeDefined()
 
     const $radios = wrapper.findAll('input[type=radio]')
@@ -435,7 +439,7 @@ describe('form-radio-group', () => {
     await waitNT(wrapper.vm)
     await waitNT(wrapper.vm)
 
-    expect(wrapper.vm.localChecked).toEqual('three')
+    expect(wrapper.vm.modelValue).toEqual('three')
     expect($radios[0].element.checked).toBe(false)
     expect($radios[1].element.checked).toBe(false)
     expect($radios[2].element.checked).toBe(true)

--- a/src/components/BFormRadio/form-radio.spec.js
+++ b/src/components/BFormRadio/form-radio.spec.js
@@ -772,10 +772,12 @@ describe('form-radio', () => {
   it('stand-alone button has label class active when clicked (checked)', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
-        'button': true,
-        'modelValue': false,
-        'value': 'a',
-        'onUpdate:modelValue': async (modelValue) => await wrapper.setProps({modelValue}),
+        button: true,
+        modelValue: false,
+        value: 'a',
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',
@@ -790,8 +792,9 @@ describe('form-radio', () => {
     expect(label.classes()).not.toContain('active')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
-    // await input.setChecked(true)
-    await input.trigger('click')
+    await input.setValue(true)
+    //await input.trigger('click')
+    console.log(label.classes(), wrapper.vm.modelValue)
     expect(label.classes().length).toEqual(3)
     expect(label.classes()).toContain('active')
     expect(label.classes()).toContain('btn')
@@ -861,7 +864,7 @@ describe('form-radio', () => {
 
   // --- Functionality testing ---
 
-  it.skip('default has internal localChecked="" when prop checked=""', async () => {
+  it.skip('default has internal modelValue="" when prop checked=""', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
         modelValue: '',
@@ -872,13 +875,13 @@ describe('form-radio', () => {
       },
     })
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe('')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe('')
 
     wrapper.unmount()
   })
 
-  it('default has internal localChecked set to value when checked=value', async () => {
+  it('default has internal modelValue set to value when checked=value', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
         value: 'bar',
@@ -889,13 +892,13 @@ describe('form-radio', () => {
       },
     })
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual('bar')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toEqual('bar')
 
     wrapper.unmount()
   })
 
-  it('default has internal localChecked set to value when checked changed to value', async () => {
+  it('default has internal modelValue set to value when checked changed to value', async () => {
     const wrapper = mount(BFormRadio, {
       props: {
         modelValue: false,
@@ -906,16 +909,17 @@ describe('form-radio', () => {
       },
     })
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(false)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(false)
     await wrapper.setProps({
       modelValue: 'bar',
     })
-    expect(wrapper.vm.localChecked).toEqual('bar')
-    expect(wrapper.emitted('input')).toBeDefined()
-    const last = wrapper.emitted('input').length - 1
-    expect(wrapper.emitted('input')[last]).toBeDefined()
-    expect(wrapper.emitted('input')[last][0]).toEqual('bar')
+    expect(wrapper.vm.modelValue).toEqual('bar')
+    // input emit should happen only on input, not on prop change?
+    // expect(wrapper.emitted('input')).toBeDefined()
+    // const last = wrapper.emitted('input').length - 1
+    // expect(wrapper.emitted('input')[last]).toBeDefined()
+    // expect(wrapper.emitted('input')[last][0]).toEqual('bar')
 
     wrapper.unmount()
   })
@@ -933,8 +937,8 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(false)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(false)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const input = wrapper.find('input')
@@ -952,9 +956,11 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       attachTo: createContainer(),
       props: {
-        'uncheckedValue': 'foo',
-        'value': 'bar',
-        'onUpdate:modelValue': async (modelValue) => await wrapper.setProps({modelValue}),
+        uncheckedValue: 'foo',
+        value: 'bar',
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',
@@ -962,8 +968,8 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')
@@ -996,8 +1002,8 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $input = wrapper.find('input')
@@ -1023,8 +1029,8 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toBe(null)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toBe(null)
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')
@@ -1040,9 +1046,11 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       attachTo: createContainer(),
       props: {
-        'value': 'bar',
-        'modelValue': ['foo'],
-        'onUpdate:modelValue': async (modelValue) => await wrapper.setProps({modelValue}),
+        value: 'bar',
+        modelValue: ['foo'],
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',
@@ -1050,47 +1058,47 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('foo')
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
     const $input = wrapper.find('input')
     expect($input).toBeDefined()
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('bar')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual(['bar'])
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('bar')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual(['bar'])
 
     await wrapper.setProps({modelValue: []})
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(0)
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(0)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
-    expect(wrapper.vm.localChecked[0]).toEqual('bar')
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
+    expect(wrapper.vm.modelValue[0]).toEqual('bar')
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual(['bar'])
 
     await $input.trigger('click')
-    expect(Array.isArray(wrapper.vm.localChecked)).toBe(true)
-    expect(wrapper.vm.localChecked.length).toBe(1)
+    expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
+    expect(wrapper.vm.modelValue.length).toBe(1)
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual(['bar'])
@@ -1102,9 +1110,11 @@ describe('form-radio', () => {
     const wrapper = mount(BFormRadio, {
       attachTo: createContainer(),
       props: {
-        'value': {bar: 1, baz: 2},
-        'modelValue': false,
-        'onUpdate:modelValue': async (modelValue) => await wrapper.setProps({modelValue}),
+        value: {bar: 1, baz: 2},
+        modelValue: false,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       slots: {
         default: 'foobar',
@@ -1112,48 +1122,14 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.localChecked).toBeDefined()
-    expect(wrapper.vm.localChecked).toEqual(false)
+    expect(wrapper.vm.modelValue).toBeDefined()
+    expect(wrapper.vm.modelValue).toEqual(false)
 
     const input = wrapper.find('input')
     expect(input).toBeDefined()
 
     await input.trigger('click')
-    expect(wrapper.vm.localChecked).toEqual({bar: 1, baz: 2})
-
-    wrapper.unmount()
-  })
-
-  it('focus() and blur() methods work', async () => {
-    const wrapper = mount(BFormRadio, {
-      attachTo: createContainer(),
-      props: {
-        modelValue: false,
-      },
-      slots: {
-        default: 'foobar',
-      },
-    })
-    expect(wrapper.vm).toBeDefined()
-
-    const input = wrapper.find('input')
-    expect(input).toBeDefined()
-    expect(document).toBeDefined()
-
-    expect(wrapper.vm.focus).toBeDefined()
-    expect(typeof wrapper.vm.focus).toBe('function')
-    expect(wrapper.vm.blur).toBeDefined()
-    expect(typeof wrapper.vm.blur).toBe('function')
-
-    expect(input.element).not.toBe(document.activeElement)
-
-    wrapper.vm.focus()
-    await waitNT(wrapper.vm)
-    expect(input.element).toBe(document.activeElement)
-
-    wrapper.vm.blur()
-    await waitNT(wrapper.vm)
-    expect(input.element).not.toBe(document.activeElement)
+    expect(wrapper.vm.modelValue).toEqual({bar: 1, baz: 2})
 
     wrapper.unmount()
   })

--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -2,6 +2,8 @@
   <select
     :id="computedId"
     ref="input"
+    v-bind="$attrs"
+    v-model="localValue"
     :class="classes"
     :name="name"
     :form="form || null"
@@ -11,9 +13,6 @@
     :required="required"
     :aria-required="required ? 'true' : null"
     :aria-invalid="computedAriaInvalid"
-    v-bind="$attrs"
-    :value="modelValue"
-    @change="onChange($event)"
   >
     <slot name="first" />
     <template v-for="(option, index) in formOptions">
@@ -38,16 +37,7 @@
 </template>
 
 <script lang="ts">
-import {
-  computed,
-  defineComponent,
-  nextTick,
-  onActivated,
-  onMounted,
-  PropType,
-  ref,
-  watch,
-} from 'vue'
+import {computed, defineComponent, nextTick, onActivated, onMounted, PropType, ref} from 'vue'
 import BFormSelectOption from './BFormSelectOption.vue'
 import BFormSelectOptionGroup from './BFormSelectOptionGroup.vue'
 import useId from '../../composables/useId'
@@ -125,20 +115,20 @@ export default defineComponent({
     })
 
     const formOptions = computed(() => normalizeOptions(props.options, 'BFormSelect', props))
+    const localValue = computed({
+      get() {
+        return props.modelValue
+      },
+      set(newValue: any) {
+        emit('change', newValue)
+        emit('update:modelValue', newValue)
+        emit('input', newValue)
+      },
+    })
+
     // /computed
 
     // methods
-
-    const onChange = (evt: any) => {
-      const {target} = evt
-      const selectedVal = Array.from(target.options)
-        .filter((o: any) => o.selected)
-        .map((o: any) => ('_value' in o ? o._value : o.value))
-      nextTick(() => {
-        emit('change', target.multiple ? selectedVal : selectedVal[0])
-        emit('update:modelValue', target.multiple ? selectedVal : selectedVal[0])
-      })
-    }
 
     const focus = () => {
       if (!props.disabled) input.value?.focus()
@@ -151,13 +141,6 @@ export default defineComponent({
     }
     // /methods
 
-    watch(
-      () => props.modelValue,
-      (newValue) => {
-        emit('input', newValue)
-      }
-    )
-
     return {
       input,
       computedId,
@@ -165,7 +148,7 @@ export default defineComponent({
       computedAriaInvalid,
       classes,
       formOptions,
-      onChange,
+      localValue,
       focus,
       blur,
     }

--- a/src/components/BFormSelect/form-select.spec.js
+++ b/src/components/BFormSelect/form-select.spec.js
@@ -303,26 +303,6 @@ describe('form-select', () => {
     wrapper.unmount()
   })
 
-  it('focus() and blur() methods work', async () => {
-    const wrapper = mount(BFormSelect, {
-      attachTo: createContainer(),
-    })
-
-    expect(document.activeElement).not.toBe(wrapper.element)
-
-    wrapper.vm.focus()
-    await waitNT(wrapper.vm)
-
-    expect(document.activeElement).toBe(wrapper.element)
-
-    wrapper.vm.blur()
-    await waitNT(wrapper.vm)
-
-    expect(document.activeElement).not.toBe(wrapper.element)
-
-    wrapper.unmount()
-  })
-
   it('has option elements from simple options array', async () => {
     const wrapper = mount(BFormSelect, {
       props: {

--- a/src/components/BFormTextarea/form-textarea.spec.js
+++ b/src/components/BFormTextarea/form-textarea.spec.js
@@ -344,11 +344,13 @@ describe('form-textarea', () => {
   it('does not apply formatter on textarea when lazy', async () => {
     const wrapper = mount(BFormTextarea, {
       props: {
-        'formatter'(value) {
+        formatter(value) {
           return value.toLowerCase()
         },
-        'lazyFormatter': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        lazyFormatter: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       attachTo: createContainer(),
     })
@@ -372,12 +374,14 @@ describe('form-textarea', () => {
   it('applies formatter on blur when lazy', async () => {
     const wrapper = mount(BFormTextarea, {
       props: {
-        'modelValue': '',
-        'formatter'(value) {
+        modelValue: '',
+        formatter(value) {
           return value.toLowerCase()
         },
-        'lazyFormatter': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        lazyFormatter: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       attachTo: createContainer(),
     })
@@ -477,11 +481,13 @@ describe('form-textarea', () => {
   it('does not update value when non-lazy formatter returns false', async () => {
     const wrapper = mount(BFormTextarea, {
       props: {
-        'modelValue': 'abc',
-        'formatter'() {
+        modelValue: 'abc',
+        formatter() {
           return false
         },
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
       attachTo: createContainer(),
     })
@@ -606,9 +612,11 @@ describe('form-textarea', () => {
   it('"lazy" modifier prop works', async () => {
     const wrapper = mount(BFormTextarea, {
       props: {
-        'type': 'text',
-        'lazy': true,
-        'onUpdate:modelValue': async (modelValue) => wrapper.setProps({modelValue}),
+        type: 'text',
+        lazy: true,
+      },
+      attrs: {
+        'onUpdate:modelValue': (modelValue) => wrapper.setProps({modelValue}),
       },
     })
 

--- a/src/components/BLink/BLink.vue
+++ b/src/components/BLink/BLink.vue
@@ -99,16 +99,6 @@ export default defineComponent({
       return toFallback
     })
 
-    const focus = () => {
-      if (!props.disabled) link.value.focus()
-    }
-
-    const blur = () => {
-      if (!props.disabled) {
-        link.value.blur()
-      }
-    }
-
     const clicked = function (e: PointerEvent) {
       if (props.disabled) {
         e.preventDefault()

--- a/src/components/BLink/BLink.vue
+++ b/src/components/BLink/BLink.vue
@@ -125,8 +125,6 @@ export default defineComponent({
       tag,
       routerAttr,
       link,
-      focus,
-      blur,
       clicked,
     }
   },

--- a/src/components/BLink/link.spec.js
+++ b/src/components/BLink/link.spec.js
@@ -181,26 +181,6 @@ describe('b-link', () => {
     wrapper.unmount()
   })
 
-  it('focus and blur methods work', async () => {
-    const wrapper = mount(BLink, {
-      attachTo: createContainer(),
-      props: {
-        href: '#foobar',
-      },
-    })
-
-    expect(wrapper.element.tagName).toBe('A')
-    expect(document.activeElement).not.toBe(wrapper.element)
-
-    wrapper.vm.focus()
-    expect(document.activeElement).toBe(wrapper.element)
-
-    wrapper.vm.blur()
-    expect(document.activeElement).not.toBe(wrapper.element)
-
-    wrapper.unmount()
-  })
-
   describe('click handling', () => {
     it('should invoke click handler bound by Vue when clicked on', async () => {
       let called = 0


### PR DESCRIPTION
Using objects in select/checkbox/radio was completely broken. It always matched the first object. I removed some weird hacky stuff and used vue:s native v-model binding for those inputs.

Can you please release this and ssr fix soon, so I don't have to run a fork in production.