### PR TITLE
feat: support for library authors for nuxt3

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -40,7 +40,7 @@ In order to use this library you have to install these packages:
 
 ## Install
 
-### Bundlers
+### Installation - Vue.js
 
 To install this library you can use Yarn or NPM:
 
@@ -78,6 +78,51 @@ import 'bootstrap-vue-3/dist/bootstrap-vue-3.css'
 const app = createApp(App)
 app.use(BootstrapVue3)
 app.mount('#app')
+```
+
+### Installation - Nuxt.js 3
+
+As with the Vue.js installation.
+
+In your Nuxt3 application, install `bootstrap-vue-3`
+
+<CodeGroup>
+  <CodeGroupItem title="YARN" active>
+
+```bash
+yarn add bootstrap bootstrap-vue-3
+```
+
+  </CodeGroupItem>
+
+  <CodeGroupItem title="NPM">
+
+```bash
+npm install bootstrap bootstrap-vue-3
+```
+
+  </CodeGroupItem>
+</CodeGroup>
+
+Open your `nuxt.config.ts` or `nuxt.config.js` file and configure your application to use `bootstrap-vue-3`. The components will be imported automatically as needed.
+
+```javascript
+import {defineNuxtConfig} from 'nuxt3'
+
+export default defineNuxtConfig({
+  modules: ['bootstrap-vue-3/nuxt'],
+  css: ['bootstrap/dist/css/bootstrap.css'],
+})
+```
+
+Enjoy it in your app without import.
+
+```vue
+<template>
+  <div>
+    <BButton variant="primary">Test</BButton>
+  </div>
+</template>
 ```
 
 ## Comparison with BoostrapVue

--- a/nuxt.js
+++ b/nuxt.js
@@ -1,0 +1,14 @@
+import {defineNuxtModule} from '@nuxt/kit'
+import {fileURLToPath} from 'node:url'
+
+export default defineNuxtModule({
+  hooks: {
+    'components:dirs'(dirs) {
+      // Add ./components dir to the list
+      dirs.push({
+        path: fileURLToPath(new URL('./src/components', import.meta.url)),
+        extensions: ['vue'],
+      })
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
       "import": "./dist/bootstrap-vue-3.es.js",
       "require": "./dist/bootstrap-vue-3.umd.js"
     },
-    "./dist/bootstrap-vue-3.css": "./dist/bootstrap-vue-3.css"
+    "./dist/bootstrap-vue-3.css": "./dist/bootstrap-vue-3.css",
+    "./nuxt": "./nuxt.js"
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "nuxt.js"
   ],
   "types": "./dist/BootstrapVue.d.ts",
   "workspaces": [


### PR DESCRIPTION
Implements [support for library authors for nuxt3](https://v3.nuxtjs.org/guide/directory-structure/components/#library-authors)

# Create a Nuxt3 project

```
npx nuxi init nuxt-app
cd nuxt-app
npm install
npm run dev -- -o
```

# Install bootstrap-vue3 and boostrap

```
npm install bootstrap bootstrap-vue-3
```
# Configure your project

Open your `nuxt.config.ts` or `nuxt.config.js` file and configure your application to use `bootstrap-vue-3`. The components will be imported automatically as needed.

```javascript
import {defineNuxtConfig} from 'nuxt3'
export default defineNuxtConfig({
  modules: ['bootstrap-vue-3/nuxt'],
  css: ['bootstrap/dist/css/bootstrap.css'],
})
```

# Enjoy it in your app without import.

```vue
<template>
  <div>
    <BButton variant="primary">Primary</BButton>
    <BBadge variant="danger">Danger</BBadge>
  </div>
</template>
```
