### PR TITLE
feat(github-action): deploy docs to github-pages

### DIFF
--- a/.github/workflows/docs-github-pages-deploy.yml
+++ b/.github/workflows/docs-github-pages-deploy.yml
@@ -1,0 +1,35 @@
+name: Build and Deploy Docs to GitHub Pages
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-github-pages-deploy.yml'
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Install and build library 🔧
+        run: |
+          npm install
+          npm run build
+
+      - name: Install documentation 🔧
+        working-directory: ./docs
+        run: |
+          npm install
+
+      - name: Build documentation 🔧
+        run: |
+          npm run docs:build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ./docs/.vuepress/dist # The folder the action should deploy.


### PR DESCRIPTION
Hello,

Here is a PR to build and deploys the docs to github-pages and to keep the documentation up to date

* https://cdmoro.github.io/bootstrap-vue-3/
* https://github.com/cdmoro/bootstrap-vue-3/tree/gh-pages

I use this github actions https://github.com/JamesIves/github-pages-deploy-action 

Regards

Mathieu