### PR TITLE
Add script component for BCardText in order to help an IDE to detect by naming tags

### DIFF
--- a/src/components/BAvatar/BAvatarGroup.vue
+++ b/src/components/BAvatar/BAvatarGroup.vue
@@ -44,10 +44,8 @@ export default defineComponent({
   setup(props) {
     const computedSize = computed(() => computeSize(props.size))
 
-    const computeOverlap = (value: any): number => {
-      const calcValue = isString(value) && isNumeric(value) ? toFloat(value, 0) : value || 0
-      return calcValue
-    }
+    const computeOverlap = (value: any): number =>
+      isString(value) && isNumeric(value) ? toFloat(value, 0) : value || 0
     const overlapScale = computed(() => mathMin(mathMax(computeOverlap(props.overlap), 0), 1) / 2)
 
     const paddingStyle = computed((): StyleValue => {

--- a/src/components/BCard/BCardText.vue
+++ b/src/components/BCard/BCardText.vue
@@ -3,3 +3,11 @@
     <slot />
   </p>
 </template>
+
+<script lang="ts">
+import {defineComponent} from 'vue'
+
+export default defineComponent({
+  name: 'BCardText',
+})
+</script>


### PR DESCRIPTION
- Simplify computeOverlap function to remove redundant local variable.
- Generate script part in BCardText. In other projects, if I use the tag <b-card-text>xx</b-card-text> is not detected.

![image](https://user-images.githubusercontent.com/95854297/166878269-9c5812f4-daf8-447c-bc87-adfa2d69373a.png)

I'm using IntelliJ 2022.1, I guess the problem should be with the script part (maybe).

Other components are detected well:

![image](https://user-images.githubusercontent.com/95854297/166878388-02c8aeb6-e503-4f2f-a163-23ea4c84664c.png)
![image](https://user-images.githubusercontent.com/95854297/166878417-50869fba-a7f4-4510-b0ae-05b51224f6a0.png)

