### PR TITLE
fix: retain tooltip visibility on title update

### DIFF
--- a/src/directives/BTooltip.ts
+++ b/src/directives/BTooltip.ts
@@ -72,9 +72,10 @@ const BTooltip: Directive<HTMLElement> = {
 
     if (title !== '') {
       const instance = Tooltip.getInstance(el)
-      instance?.hide()
+      instance?.toggle()
       el.setAttribute('data-bs-original-title', title || '')
       el.setAttribute('title', '')
+      instance?.toggle()
     }
   },
   unmounted(el) {


### PR DESCRIPTION
Correct bootstrap implementation is not yet available.
In the meantime this PR is a quick fix for #250 

While it fixes the issue of disappearing tooltip, it is not a perfect fix as the tooltip will fade out and in as opposed to remaining in view throughout