### PR TITLE
fix: remove variant classes from OK/Cancel buttons

### DIFF
--- a/src/components/BModal.vue
+++ b/src/components/BModal.vue
@@ -28,7 +28,7 @@
               <b-button
                 v-if="!okOnly"
                 type="button"
-                class="btn btn-secondary"
+                class="btn"
                 data-bs-dismiss="modal"
                 :disabled="disableCancel"
                 :size="buttonSize"
@@ -39,7 +39,7 @@
               </b-button>
               <b-button
                 type="button"
-                class="btn btn-primary"
+                class="btn"
                 data-bs-dismiss="modal"
                 :disabled="disableOk"
                 :size="buttonSize"


### PR DESCRIPTION
First PR on this, so apologies if I miss something.

`b-modal` has `ok-variant` and `cancel-variant` to set the button variants.  These aren't working because we have explicit `btn-primary`/`btn-secondary` classes in there.  That means you get both classes inserted, and the primary wins.  We don't need these classes (I think) because `variant` will already ensure the correct one is inserted.