### PR TITLE
Issue #397 popover doesn't contain offset

### DIFF
--- a/src/components/BPopover.vue
+++ b/src/components/BPopover.vue
@@ -64,6 +64,7 @@ export default defineComponent({
     variant: {type: String as PropType<ColorVariant>, default: undefined},
     html: {type: Boolean, default: true},
     sanitize: {type: Boolean, default: false},
+    offset: {type: String as PropType<Popover.Options['offset']>, default: '0px'},
   },
   emits: ['show', 'shown', 'hide', 'hidden', 'inserted'],
   setup(props, {emit, slots}) {
@@ -110,6 +111,7 @@ export default defineComponent({
             html: props.html,
             delay: props.delay,
             sanitize: props.sanitize,
+            offset: props.offset,
           })
         else console.warn('[B-Popover] Target is a mandatory props.')
       })


### PR DESCRIPTION
Popover doesn't contain offset prop from either bootstrap vue or bootstrap. This change would be considered breaking from migrating from boostrap vue to bootstrap vue 3. Offset on bootstrap vue types are number | string. In line with bootstrap 5, offset now is [number, number] | string | function. 