### PR TITLE
Fixed issues revolving around broken packages.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,10 +12,12 @@ module.exports = {
     '@vue/typescript/recommended',
     'prettier',
   ],
+  plugins: ['prettier'],
   parserOptions: {
     ecmaVersion: 2021,
   },
   rules: {
+    'prettier/prettier': ['warn', {endOfLine: 'auto'}],
     'no-alert': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "audit": "improved-yarn-audit --ignore-dev-deps --min-severity moderate",
     "dev": "vite",
-    "build": "vite build",
+    "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "docs:dev": "npm exec --workspace=docs vuepress dev docs",
     "docs:build": "npm exec --workspace=docs vuepress build .",
@@ -38,7 +38,6 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "npm run lint",
     "test:unit": "vitest",
-    "prepare": "husky install && vite build",
     "publish": "npm publish --tag develop",
     "release": "standard-version"
   },
@@ -61,6 +60,7 @@
     "@vue/test-utils": "^2.0.0-rc.14",
     "eslint": "8.x.x",
     "eslint-config-prettier": "8.x.x",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "8.x.x",
     "husky": "^7.0.2",
     "improved-yarn-audit": "3.x.x",
@@ -75,7 +75,8 @@
     "vite-plugin-dts": "1.x.x",
     "vitest": "^0.10.4",
     "vue": "3.x.x",
-    "vue-router": "4.x.x"
+    "vue-router": "4.x.x",
+    "vue-tsc": "^0.37.2"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,13 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "types": ["vitest/globals", "@vuepress/client/types"],
+    "types": ["vitest/globals", "@vuepress/client/types", "vite/client"],
     "paths": {},
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "vueCompilerOptions": {
+    "experimentalSuppressInvalidJsxElementTypeErrors": true
+  }
 }


### PR DESCRIPTION
The prettier plugin hasn't worked for awhile. A fix in the eslintrc file to include prettier as a plugin, and as a rule fixes prettier not working.

tsconfig file was changed to temporarily fix these two issues revolving around volar plugin: https://github.com/johnsoncodehk/volar/issues/1405 && https://github.com/johnsoncodehk/volar/discussions/592 

The prepare script was causing too many issues. It was preventing packages from being installed and hurting the development process. It should be added later when not so many breaking "vite build" options cause npm install to not install the required packages to actually develop. 

vue-tsc was added for the build command. I'm not sure why this was not already included. But to my understanding it's required for a Vite app using TS to build. In relation to https://github.com/cdmoro/bootstrap-vue-3/issues/403 it fixes the TS compilation issue, however, still running build causes _actual_ issues to appear.