### PR TITLE
Add a simple src/ utility alias with @

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,
     "baseUrl": ".",
     "types": ["vitest/globals", "@vuepress/client/types", "vite/client"],
-    "paths": {},
+    "paths": {"@/*": ["./src/*"]},
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,13 @@ import vue from '@vitejs/plugin-vue'
 import {resolve} from 'path'
 import visualizer from 'rollup-plugin-visualizer'
 import dts from 'vite-plugin-dts'
+import {fileURLToPath, URL} from 'url'
 
 const config = defineConfig({
   resolve: {
-    alias: {},
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
   },
 
   build: {


### PR DESCRIPTION
I have been using src/ syntax to import files consistently when building interfaces. As it turns out, TS is able to get all of the information just fine. This worked fine in some interfaces I was building. Tried to use it when building with Vite, and it could not resolve the path. I figured it would be nice to just sidestep all of that and make a handy alias to the src dir. 