### PR TITLE
BFormSelect's script setup and improvements

### DIFF
--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -63,9 +63,9 @@ interface BFormSelectProps {
   selectSize?: number
   size?: Size
   state?: boolean | null
-  textField: string
-  valueField: 'value'
-  modelValue: string | Array<string> | Record<string, unknown> | number
+  textField?: string
+  valueField?: 'value'
+  modelValue?: string | Array<string> | Record<string, unknown> | number
 }
 
 const props = withDefaults(defineProps<BFormSelectProps>(), {

--- a/src/components/BFormSelect/BFormSelectOption.vue
+++ b/src/components/BFormSelect/BFormSelectOption.vue
@@ -4,15 +4,15 @@
   </option>
 </template>
 
-<script lang="ts">
-import {defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BFormSelectOptionProps} from '@/types/components'
 
-export default defineComponent({
-  name: 'BFormSelectOption',
-  props: {
-    // eslint-disable-next-line vue/require-prop-types
-    value: {required: true},
-    disabled: {type: Boolean, default: false},
-  },
+interface BFormSelectOptionProps {
+  value: unknown
+  disabled?: boolean
+}
+
+withDefaults(defineProps<BFormSelectOptionProps>(), {
+  disabled: false,
 })
 </script>

--- a/src/components/BFormSelect/BFormSelectOptionGroup.vue
+++ b/src/components/BFormSelect/BFormSelectOptionGroup.vue
@@ -15,30 +15,30 @@
   </optgroup>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BFormSelectOptionGroupProps} from '@/types/components'
+import {computed} from 'vue'
 import BFormSelectOption from './BFormSelectOption.vue'
-import {normalizeOptions} from '../../composables/useFormSelect'
+import {normalizeOptions} from '@/composables/useFormSelect'
 
-export default defineComponent({
-  name: 'BFormSelectOptionGroup',
-  components: {BFormSelectOption},
-  props: {
-    label: {type: String, required: true},
-    disabledField: {type: String, default: 'disabled'},
-    htmlField: {type: String, default: 'html'},
-    options: {type: [Array, Object], default: () => []},
-    textField: {type: String, default: 'text'},
-    valueField: {type: String, default: 'value'},
-  },
-  setup(props) {
-    const formOptions = computed(() =>
-      normalizeOptions(props.options as any, 'BFormSelectOptionGroup', props)
-    )
+interface BFormSelectOptionGroupProps {
+  label?: string
+  disabledField?: string
+  htmlField?: string
+  options?: Array<string> | Record<string, unknown>
+  textField?: string
+  valueField?: string
+}
 
-    return {
-      formOptions,
-    }
-  },
+const props = withDefaults(defineProps<BFormSelectOptionGroupProps>(), {
+  disabledField: 'disabled',
+  htmlField: 'html',
+  options: () => [],
+  textField: 'text',
+  valueField: 'value',
 })
+
+const formOptions = computed<any>(() =>
+  normalizeOptions(props.options as any, 'BFormSelectOptionGroup', props)
+)
 </script>

--- a/src/types/components/BFormSelect/BFormSelect.d.ts
+++ b/src/types/components/BFormSelect/BFormSelect.d.ts
@@ -18,9 +18,9 @@ export interface Props {
   selectSize?: number
   size?: Size
   state?: boolean
-  textField: string
-  valueField: 'value'
-  modelValue: string | Array<string> | Record<string, unknown> | number
+  textField?: string
+  valueField?: 'value'
+  modelValue?: string | Array<string> | Record<string, unknown> | number
 }
 // Emits
 export interface Emits {

--- a/src/types/components/BFormSelect/BFormSelect.d.ts
+++ b/src/types/components/BFormSelect/BFormSelect.d.ts
@@ -1,7 +1,7 @@
 import type {Size} from '@/types'
 // Props
 export interface Props {
-  ariaInvalid?: boolean | 'false' | 'true' | 'grammar' | 'spelling'
+  ariaInvalid?: 'grammar' | 'spelling' | boolean | undefined
   autofocus?: boolean
   disabled?: boolean
   disabledField?: string
@@ -17,7 +17,10 @@ export interface Props {
   required?: boolean
   selectSize?: number
   size?: Size
-  state?: boolean | null
+  state?: boolean
+  textField: string
+  valueField: 'value'
+  modelValue: string | Array<string> | Record<string, unknown> | number
 }
 // Emits
 export interface Emits {


### PR DESCRIPTION
Kind of getting into the weeds of where some of the libraries errors have been existing. 

On a second note, some of the properties on interfaces I have explicitly stated as not undefined, possibly in this PR and previous ones. I did this when specific props were not labeled with a "default" or "required: false" attributes. However, I have noticed that in some instances, I may have been introducing issues with some of them. The benefit is that since it's all TS, the template will error out when the properties are missing. However, some properties may have been unknowingly supposed to have been required: false and not stated to be so. I was thinking about going through once the library has been converted to setup syntax in order to iron out what was supposed to be actually not required. However, if you find some properties that need to be fixed, you can @ me to fix it.

Lastly, I think at some point in the future (I was thinking after the library has been converted, and after the above kinks are ironed out) that we remake TS "no-explicit-any" to use "warn" instead of "off" and attempt to fix any issues that using _any_ may have caused (or do it now). Lmk