### PR TITLE
Update vue test utils package

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@vitejs/plugin-vue": "2.x.x",
     "@vue/compiler-sfc": "3.x.x",
     "@vue/eslint-config-typescript": "10.x.x",
-    "@vue/test-utils": "^2.0.0-rc.14",
+    "@vue/test-utils": "^2.0.0-rc.18",
     "eslint": "8.x.x",
     "eslint-config-prettier": "8.x.x",
     "eslint-plugin-prettier": "^4.0.0",

--- a/src/types/components/BFormCheckbox/BFormCheckbox.d.ts
+++ b/src/types/components/BFormCheckbox/BFormCheckbox.d.ts
@@ -1,5 +1,4 @@
-import type {InputSize} from '@/types'
-
+import type {ButtonVariant, InputSize} from '@/types'
 // Props
 export interface Props {
   ariaLabel: string
@@ -13,7 +12,7 @@ export interface Props {
   button?: boolean
   switch?: boolean
   disabled?: boolean
-  buttonVariant?: string
+  buttonVariant?: ButtonVariant
   inline?: boolean
   required?: boolean
   size?: InputSize

--- a/src/types/components/BFormCheckbox/BFormCheckboxGroup.d.ts
+++ b/src/types/components/BFormCheckbox/BFormCheckboxGroup.d.ts
@@ -1,5 +1,4 @@
-import type {ColorVariant, Size} from '@/types'
-
+import type {ButtonVariant, Size} from '@/types'
 // Props
 export interface Props {
   id?: string
@@ -7,7 +6,7 @@ export interface Props {
   modelValue?: Array
   ariaInvalid?: boolean | string
   autofocus?: boolean
-  buttonVariant?: ColorVariant
+  buttonVariant?: ButtonVariant
   buttons?: boolean
   disabled?: boolean
   disabledField?: string

--- a/src/types/components/BFormRadio/BFormRadio.d.ts
+++ b/src/types/components/BFormRadio/BFormRadio.d.ts
@@ -1,3 +1,4 @@
+import type {ButtonVariant} from '@/types'
 // Props
 export interface Props {
   ariaLabel: string
@@ -12,7 +13,7 @@ export interface Props {
   button?: boolean
   switch?: boolean
   disabled?: boolean
-  buttonVariant?: string
+  buttonVariant?: ButtonVariant
   inline?: boolean
   required?: boolean
   state?: boolean | null

--- a/src/types/components/BFormRadio/BFormRadioGroup.d.ts
+++ b/src/types/components/BFormRadio/BFormRadioGroup.d.ts
@@ -1,5 +1,4 @@
-import type {ColorVariant, Size} from '@/types'
-
+import type {ButtonVariant, Size} from '@/types'
 // Props
 export interface Props {
   size: Size
@@ -9,7 +8,7 @@ export interface Props {
   modelValue?: string | boolean | Array | Record<string, unknown> | number
   ariaInvalid?: boolean | string
   autofocus?: boolean
-  buttonVariant?: ColorVariant
+  buttonVariant?: ButtonVariant
   buttons?: boolean
   disabled?: boolean
   disabledField?: string

--- a/src/types/components/BFormTags/BFormTag.d.ts
+++ b/src/types/components/BFormTags/BFormTag.d.ts
@@ -1,4 +1,5 @@
-import type {RawSlots, VNodeArrayChildren} from 'vue'
+import type {VNodeNormalizedChildren} from 'vue'
+import type {ColorVariant} from '@/types'
 // Props
 export interface Props {
   id: string
@@ -8,10 +9,10 @@ export interface Props {
   pill?: boolean
   removeLabel?: string
   tag?: string
-  variant?: string
+  variant?: ColorVariant
 }
 // Emits
 export interface Emits {
-  (e: 'remove', value?: string | VNodeArrayChildren | RawSlots): void
+  (e: 'remove', value?: VNodeNormalizedChildren): void
 }
 // Other


### PR DESCRIPTION
The main reason for the PR was to update package and state some intentions. It also contains some minor fixes in some unused types files. 

I'm going to need to change some tests in the next script setup conversions. BFormCheckbox has contained an error where input v-model cannot be assigned to null. Instead, I opt to use undefined since it's valid and behaves the same. Just the types checks expecting it toBe(null) will always issue out. 

I'm also going to opt to moving the `Array<string>`'s that I have been using to `Array<unknown>` (and retroactively fix the previous ones) as I have encountered some issues with them, and they're usually unknown to _me_. The unknowns will provide a better search ability to make them more explicit in the future as they were basically not strongly typed before anyways. 