### PR TITLE
Various script setup conversions

### DIFF
--- a/src/components/BDropdown/BDropdownGroup.vue
+++ b/src/components/BDropdown/BDropdownGroup.vue
@@ -26,7 +26,6 @@
 <script setup lang="ts">
 // import type {BDropdownGroupProps} from '@/types/components'
 import type {ColorVariant} from '@/types'
-import {computed, defineComponent} from 'vue'
 
 interface BDropdownGroupProps {
   id: string
@@ -57,6 +56,7 @@ const classes = computed(() => ({
 </script>
 
 <script lang="ts">
+import {computed, defineComponent} from 'vue'
 export default defineComponent({
   inheritAttrs: false,
 })

--- a/src/components/BDropdown/BDropdownItem.vue
+++ b/src/components/BDropdown/BDropdownItem.vue
@@ -15,7 +15,6 @@
 <script setup lang="ts">
 // import type {BDropdownItemButtonEmits, BDropdownItemProps} from '@/types/components'
 import type {ColorVariant, LinkTarget} from '@/types'
-import {computed, defineComponent, useAttrs} from 'vue'
 
 interface BDropdownItemProps {
   href: string
@@ -66,6 +65,7 @@ const clicked = (e: MouseEvent): void => emit('click', e)
 </script>
 
 <script lang="ts">
+import {computed, defineComponent, useAttrs} from 'vue'
 export default defineComponent({
   inheritAttrs: false,
 })

--- a/src/components/BDropdown/BDropdownItemButton.vue
+++ b/src/components/BDropdown/BDropdownItemButton.vue
@@ -9,7 +9,6 @@
 <script setup lang="ts">
 // import type {BDropdownItemButtonEmits, BDropdownItemButtonProps} from '@/types/components'
 import type {ButtonType, ColorVariant} from '@/types'
-import {computed, defineComponent} from 'vue'
 
 interface BDropdownItemButtonProps {
   buttonClass: string | Array<unknown> | Record<string, unknown>
@@ -48,6 +47,7 @@ const clicked = (e: MouseEvent): void => emit('click', e)
 </script>
 
 <script lang="ts">
+import {computed, defineComponent} from 'vue'
 export default defineComponent({
   inheritAttrs: false,
 })

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -8,12 +8,12 @@
       :class="inputClasses"
       type="checkbox"
       :disabled="disabled"
-      :required="name && required"
+      :required="!!name && !!required"
       :name="name"
       :form="form"
       :aria-label="ariaLabel"
       :aria-labelledby="ariaLabelledBy"
-      :aria-required="name && required ? 'true' : null"
+      :aria-required="name && required ? 'true' : undefined"
       :value="value"
       :indeterminate="indeterminate"
       @focus="isFocused = true"
@@ -29,104 +29,119 @@
   </div>
 </template>
 
-<script lang="ts">
-import {getClasses, getInputClasses, getLabelClasses} from '../../composables/useFormCheck'
-import {computed, defineComponent, onMounted, PropType, Ref, ref} from 'vue'
-import {InputSize} from '../../types'
-import useId from '../../composables/useId'
+<script setup lang="ts">
+// import type {BFormCheckboxEmits, BFormCheckboxProps} from '@/types/components'
+import {getClasses, getInputClasses, getLabelClasses} from '@/composables/useFormCheck'
+import type {ButtonVariant, InputSize} from '@/types'
+import useId from '@/composables/useId'
 
-export default defineComponent({
-  name: 'BFormCheckbox',
-  inheritAttrs: false,
-  props: {
-    id: {type: String, default: undefined},
-    ariaLabel: {type: String},
-    ariaLabelledBy: {type: String},
-    autofocus: {type: Boolean, default: false},
-    plain: {type: Boolean, default: false},
-    button: {type: Boolean, default: false},
-    switch: {type: Boolean, default: false},
-    disabled: {type: Boolean, default: false},
-    buttonVariant: {type: String, default: 'secondary'},
-    form: {type: String},
-    indeterminate: {type: Boolean},
-    inline: {type: Boolean, default: false},
-    name: {type: String},
-    required: {type: Boolean, default: undefined},
-    size: {type: String as PropType<InputSize>, default: 'md'},
-    state: {type: Boolean, default: null},
-    uncheckedValue: {type: [Boolean, String, Array, Object, Number], default: false},
-    value: {type: [Boolean, String, Array, Object, Number], default: true},
-    modelValue: {type: [Boolean, String, Array, Object, Number], default: null},
-  },
-  emits: ['update:modelValue', 'input', 'change'],
-  setup(props, {emit}) {
-    const computedId = useId(props.id, 'form-check')
-    const input: Ref<HTMLElement> = ref(null as unknown as HTMLElement)
-    const isFocused = ref(false)
+interface BFormCheckboxProps {
+  ariaLabel?: string
+  ariaLabelledBy?: string
+  form?: string
+  indeterminate?: boolean
+  name?: string
+  id?: string
+  autofocus?: boolean
+  plain?: boolean
+  button?: boolean
+  switch?: boolean
+  disabled?: boolean
+  buttonVariant?: ButtonVariant
+  inline?: boolean
+  required?: boolean
+  size?: InputSize
+  state?: boolean
+  uncheckedValue?: Array<unknown> | Set<unknown> | boolean
+  value?: Array<unknown> | Set<unknown> | boolean
+  modelValue?: Array<unknown> | Set<unknown> | boolean
+}
 
-    const localValue = computed({
-      get: () => {
-        if (props.uncheckedValue) {
-          if (!Array.isArray(props.modelValue)) {
-            return props.modelValue === props.value
-          }
-          return props.modelValue.indexOf(props.value) > -1
-        }
-        return props.modelValue
-      },
-      set: (newValue: any) => {
-        let emitValue = newValue
-        if (!Array.isArray(props.modelValue)) {
-          emitValue = newValue ? props.value : props.uncheckedValue
-        } else {
-          if (props.uncheckedValue) {
-            emitValue = props.modelValue
-            if (newValue) {
-              if (emitValue.indexOf(props.uncheckedValue) > -1)
-                emitValue.splice(emitValue.indexOf(props.uncheckedValue), 1)
-              emitValue.push(props.value)
-            } else {
-              if (emitValue.indexOf(props.value) > -1)
-                emitValue.splice(emitValue.indexOf(props.value), 1)
-              emitValue.push(props.uncheckedValue)
-            }
-          }
-        }
-        emit('input', emitValue)
-        emit('update:modelValue', emitValue)
-        emit('change', emitValue)
-      },
-    })
+const props = withDefaults(defineProps<BFormCheckboxProps>(), {
+  id: undefined,
+  autofocus: false,
+  plain: false,
+  button: false,
+  switch: false,
+  disabled: false,
+  buttonVariant: 'secondary',
+  inline: false,
+  required: undefined,
+  size: 'md',
+  state: undefined,
+  uncheckedValue: false,
+  value: true,
+  modelValue: undefined,
+})
 
-    const isChecked = computed(() => {
-      if (Array.isArray(props.modelValue)) {
-        return props.modelValue.indexOf(props.value) > -1
+interface BFormCheckboxEmits {
+  (e: 'update:modelValue', value: unknown): void
+  (e: 'input', value: unknown): void
+  (e: 'change', value: unknown): void
+}
+
+const emit = defineEmits<BFormCheckboxEmits>()
+
+const computedId = useId(props.id, 'form-check')
+const input = ref<HTMLElement>(null as unknown as HTMLElement)
+const isFocused = ref<boolean>(false)
+
+const localValue = computed({
+  get: () => {
+    if (props.uncheckedValue) {
+      if (!Array.isArray(props.modelValue)) {
+        return props.modelValue === props.value
       }
-      return JSON.stringify(props.modelValue) === JSON.stringify(props.value)
-    })
-
-    const classes = getClasses(props)
-    const inputClasses = getInputClasses(props)
-    const labelClasses = getLabelClasses(props)
-
-    // TODO: make tests compatible with the v-focus directive
-    if (props.autofocus) {
-      onMounted(() => {
-        input.value.focus()
-      })
+      return props.modelValue.indexOf(props.value) > -1
     }
-
-    return {
-      input,
-      computedId,
-      classes,
-      inputClasses,
-      labelClasses,
-      localValue,
-      isChecked,
-      isFocused,
-    }
+    return props.modelValue
   },
+  set: (newValue: any) => {
+    let emitValue = newValue
+    if (!Array.isArray(props.modelValue)) {
+      emitValue = newValue ? props.value : props.uncheckedValue
+    } else {
+      if (props.uncheckedValue) {
+        emitValue = props.modelValue
+        if (newValue) {
+          if (emitValue.indexOf(props.uncheckedValue) > -1)
+            emitValue.splice(emitValue.indexOf(props.uncheckedValue), 1)
+          emitValue.push(props.value)
+        } else {
+          if (emitValue.indexOf(props.value) > -1)
+            emitValue.splice(emitValue.indexOf(props.value), 1)
+          emitValue.push(props.uncheckedValue)
+        }
+      }
+    }
+    emit('input', emitValue)
+    emit('update:modelValue', emitValue)
+    emit('change', emitValue)
+  },
+})
+
+const isChecked = computed<boolean>(() => {
+  if (Array.isArray(props.modelValue)) {
+    return props.modelValue.indexOf(props.value) > -1
+  }
+  return JSON.stringify(props.modelValue) === JSON.stringify(props.value)
+})
+
+const classes = getClasses(props)
+const inputClasses = getInputClasses(props)
+const labelClasses = getLabelClasses(props)
+
+// TODO: make tests compatible with the v-focus directive
+onMounted((): void => {
+  if (props.autofocus) {
+    input.value.focus()
+  }
+})
+</script>
+
+<script lang="ts">
+import {computed, defineComponent, onMounted, ref} from 'vue'
+export default defineComponent({
+  inheritAttrs: false,
 })
 </script>

--- a/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -18,87 +18,104 @@
   </div>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent, PropType} from 'vue'
+<script setup lang="ts">
+// import type {BFormCheckboxGroupEmits, BFormCheckboxGroupProps} from '@/types/components'
+import {computed, useSlots} from 'vue'
 import BFormCheckbox from './BFormCheckbox.vue'
-import {ColorVariant, Size} from '../../types'
-import useId from '../../composables/useId'
+import type {ButtonVariant, Size} from '@/types'
+import useId from '@/composables/useId'
 import {
   bindGroupProps,
   getGroupAttr,
   getGroupClasses,
   optionToElement,
   slotsToElements,
-} from '../../composables/useFormCheck'
+} from '@/composables/useFormCheck'
 
-export default defineComponent({
-  name: 'BFormCheckboxGroup',
-  components: {BFormCheckbox},
-  props: {
-    modelValue: {type: Array, default: () => []},
-    ariaInvalid: {type: [Boolean, String], default: null},
-    autofocus: {type: Boolean, default: false},
-    buttonVariant: {type: String as PropType<ColorVariant>, default: 'secondary'},
-    buttons: {type: Boolean, default: false},
-    disabled: {type: Boolean, default: false},
-    disabledField: {type: String, default: 'disabled'},
-    form: {type: String},
-    htmlField: {type: String, default: 'html'},
-    id: {type: String},
-    name: {type: String},
-    options: {type: Array, default: () => []}, // Objects are not supported yet
-    plain: {type: Boolean, default: false},
-    required: {type: Boolean, default: false},
-    size: {type: String as PropType<Size>},
-    stacked: {type: Boolean, default: false},
-    state: {type: Boolean, default: null},
-    switches: {type: Boolean, default: false},
-    textField: {type: String, default: 'text'},
-    validated: {type: Boolean, default: false},
-    valueField: {type: String, default: 'value'},
-  },
-  emits: ['update:modelValue', 'change', 'input'],
-  setup(props, {emit, slots}) {
-    const slotsName = 'BFormCheckbox'
-    const computedId = useId(props.id, 'checkbox')
-    const computedName = useId(props.name, 'checkbox')
+interface BFormCheckboxGroupProps {
+  id?: string
+  form?: string
+  modelValue?: Array<unknown>
+  ariaInvalid?: boolean | string
+  autofocus?: boolean
+  buttonVariant?: ButtonVariant
+  buttons?: boolean
+  disabled?: boolean
+  disabledField?: string
+  htmlField?: string
+  name?: string
+  options?: Array<unknown> // Objects are not supported yet
+  plain?: boolean
+  required?: boolean
+  size?: Size
+  stacked?: boolean
+  state?: boolean
+  switches?: boolean
+  textField?: string
+  validated?: boolean
+  valueField?: string
+}
 
-    const localValue = computed({
-      get: () => props.modelValue,
-      set: (newValue: any) => {
-        if (JSON.stringify(newValue) === JSON.stringify(props.modelValue)) return
-        emit('input', newValue)
-        emit('update:modelValue', newValue)
-        emit('change', newValue)
-      },
-    })
+const props = withDefaults(defineProps<BFormCheckboxGroupProps>(), {
+  modelValue: () => [],
+  ariaInvalid: undefined,
+  autofocus: false,
+  buttonVariant: 'secondary',
+  buttons: false,
+  disabled: false,
+  disabledField: 'disabled',
+  htmlField: 'html',
+  options: () => [],
+  plain: false,
+  required: false,
+  stacked: false,
+  state: undefined,
+  switches: false,
+  textField: 'text',
+  validated: false,
+  valueField: 'value',
+})
 
-    const checkboxList = computed(() =>
-      (slots.first ? slotsToElements(slots.first(), slotsName, props.disabled) : [])
-        .concat(props.options.map((e) => optionToElement(e, props)))
-        .concat(slots.default ? slotsToElements(slots.default(), slotsName, props.disabled) : [])
-        .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
-        .map((e) => ({
-          ...e,
-          props: {
-            switch: props.switches,
-            ...e.props,
-          },
-        }))
-    )
+interface BFormCheckboxGroupEmits {
+  (e: 'input', value: unknown): void
+  (e: 'update:modelValue', value: unknown): void
+  (e: 'change', value: unknown): void
+}
 
-    const attrs = getGroupAttr(props)
-    const classes = getGroupClasses(props)
+const emit = defineEmits<BFormCheckboxGroupEmits>()
 
-    // TODO: make tests compatible with the v-focus directive
+const slots = useSlots()
 
-    return {
-      attrs,
-      classes,
-      checkboxList,
-      computedId,
-      localValue,
-    }
+const slotsName = 'BFormCheckbox'
+const computedId = useId(props.id, 'checkbox')
+const computedName = useId(props.name, 'checkbox')
+
+const localValue = computed({
+  get: () => props.modelValue,
+  set: (newValue: any) => {
+    if (JSON.stringify(newValue) === JSON.stringify(props.modelValue)) return
+    emit('input', newValue)
+    emit('update:modelValue', newValue)
+    emit('change', newValue)
   },
 })
+
+const checkboxList = computed(() =>
+  (slots.first ? slotsToElements(slots.first(), slotsName, props.disabled) : [])
+    .concat(props.options.map((e) => optionToElement(e, props)))
+    .concat(slots.default ? slotsToElements(slots.default(), slotsName, props.disabled) : [])
+    .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
+    .map((e) => ({
+      ...e,
+      props: {
+        switch: props.switches,
+        ...e.props,
+      },
+    }))
+)
+
+const attrs = getGroupAttr(props)
+const classes = getGroupClasses(props)
+
+// TODO: make tests compatible with the v-focus directive
 </script>

--- a/src/components/BFormCheckbox/form-checkbox.spec.js
+++ b/src/components/BFormCheckbox/form-checkbox.spec.js
@@ -1178,8 +1178,7 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
 
     wrapper.unmount()
   })
@@ -1238,8 +1237,7 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $input = wrapper.find('input')
@@ -1274,8 +1272,7 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')
@@ -1311,8 +1308,7 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $input = wrapper.find('input')
@@ -1341,8 +1337,7 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')

--- a/src/components/BFormInput/BFormInput.vue
+++ b/src/components/BFormInput/BFormInput.vue
@@ -25,9 +25,9 @@
 </template>
 
 <script lang="ts">
-import {InputType} from '../../types'
+import type {InputType} from '@/types'
 import {computed, defineComponent, PropType} from 'vue'
-import useFormInput, {COMMON_INPUT_PROPS} from '../../composables/useFormInput'
+import useFormInput, {COMMON_INPUT_PROPS} from '@/composables/useFormInput'
 
 const allowedTypes = [
   'text',
@@ -74,7 +74,9 @@ export default defineComponent({
       }
     })
 
-    const localType = computed(() => (allowedTypes.includes(props.type) ? props.type : 'text'))
+    const localType = computed<InputType>(() =>
+      allowedTypes.includes(props.type) ? props.type : 'text'
+    )
 
     const {input, computedId, computedAriaInvalid, onInput, onChange, onBlur, focus, blur} =
       useFormInput(props, emit)

--- a/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/src/components/BFormRadio/BFormRadioGroup.vue
@@ -18,81 +18,97 @@
   </div>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent, PropType} from 'vue'
+<script setup lang="ts">
+// import type {BFormRadioGroupEmits, BFormRadioGroupProps} from '@/types/components'
+import type {ButtonVariant, Size} from '@/types'
+import {computed, useSlots} from 'vue'
 import BFormRadio from './BFormRadio.vue'
-import {ColorVariant, Size} from '../../types'
 import {
   bindGroupProps,
   getGroupAttr,
   getGroupClasses,
   optionToElement,
   slotsToElements,
-} from '../../composables/useFormCheck'
-import useId from '../../composables/useId'
+} from '@/composables/useFormCheck'
+import useId from '@/composables/useId'
 
-export default defineComponent({
-  name: 'BFormRadioGroup',
-  components: {BFormRadio},
-  props: {
-    modelValue: {type: [String, Boolean, Array, Object, Number], default: ''},
-    ariaInvalid: {type: [Boolean, String], default: null},
-    autofocus: {type: Boolean, default: false},
-    buttonVariant: {type: String as PropType<ColorVariant>, default: 'secondary'},
-    buttons: {type: Boolean, default: false},
-    disabled: {type: Boolean, default: false},
-    disabledField: {type: String, default: 'disabled'},
-    form: {type: String},
-    htmlField: {type: String, default: 'html'},
-    id: {type: String},
-    name: {type: String},
-    options: {type: Array, default: () => []}, // Objects are not supported yet
-    plain: {type: Boolean, default: false},
-    required: {type: Boolean, default: false},
-    size: {type: String as PropType<Size>},
-    stacked: {type: Boolean, default: false},
-    state: {type: Boolean, default: null},
-    textField: {type: String, default: 'text'},
-    validated: {type: Boolean, default: false},
-    valueField: {type: String, default: 'value'},
-  },
-  emits: ['update:modelValue', 'input', 'change'],
-  setup(props, {emit, slots}) {
-    const slotsName = 'BFormRadio'
-    const computedId = useId(props.id, 'radio')
-    const computedName = useId(props.name, 'checkbox')
+interface BFormRadioGroupProps {
+  size?: Size
+  form?: string
+  id?: string
+  name?: string
+  modelValue?: string | boolean | Array<unknown> | Record<string, unknown> | number
+  ariaInvalid?: boolean | string
+  autofocus?: boolean
+  buttonVariant?: ButtonVariant
+  buttons?: boolean
+  disabled?: boolean
+  disabledField?: string
+  htmlField?: string
+  options?: Array<unknown> // Objects are not supported yet
+  plain?: boolean
+  required?: boolean
+  stacked?: boolean
+  state?: boolean
+  textField?: string
+  validated?: boolean
+  valueField?: string
+}
 
-    const localValue = computed({
-      get: () => props.modelValue,
-      set: (newValue: any) => {
-        emit('input', newValue)
-        emit('update:modelValue', newValue)
-        emit('change', newValue)
-      },
-    })
+const props = withDefaults(defineProps<BFormRadioGroupProps>(), {
+  modelValue: '',
+  ariaInvalid: undefined,
+  autofocus: false,
+  buttonVariant: 'secondary',
+  buttons: false,
+  disabled: false,
+  disabledField: 'disabled',
+  htmlField: 'html',
+  options: () => [],
+  plain: false,
+  required: false,
+  stacked: false,
+  state: undefined,
+  textField: 'text',
+  validated: false,
+  valueField: 'value',
+})
 
-    const checkboxList = computed(() =>
-      (slots.first ? slotsToElements(slots.first(), slotsName, props.disabled) : [])
-        .concat(props.options.map((e) => optionToElement(e, props)))
-        .concat(slots.default ? slotsToElements(slots.default(), slotsName, props.disabled) : [])
-        .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
-        .map((e) => ({
-          ...e,
-        }))
-    )
+interface BFormRadioGroupEmits {
+  (e: 'input', value: unknown): void
+  (e: 'update:modelValue', value: unknown): void
+  (e: 'change', value: unknown): void
+}
 
-    const attrs = getGroupAttr(props)
-    const classes = getGroupClasses(props)
+const emit = defineEmits<BFormRadioGroupEmits>()
 
-    // TODO: make tests compatible with the v-focus directive
+const slots = useSlots()
 
-    return {
-      attrs,
-      classes,
-      checkboxList,
-      computedId,
-      localValue,
-    }
+const slotsName = 'BFormRadio'
+const computedId = useId(props.id, 'radio')
+const computedName = useId(props.name, 'checkbox')
+
+const localValue = computed<string | boolean | Array<unknown> | Record<string, unknown> | number>({
+  get: () => props.modelValue,
+  set: (newValue: any) => {
+    emit('input', newValue)
+    emit('update:modelValue', newValue)
+    emit('change', newValue)
   },
 })
+
+const checkboxList = computed<Array<any>>(() =>
+  (slots.first ? slotsToElements(slots.first(), slotsName, props.disabled) : [])
+    .concat(props.options.map((e) => optionToElement(e, props)))
+    .concat(slots.default ? slotsToElements(slots.default(), slotsName, props.disabled) : [])
+    .map((e, idx) => bindGroupProps(e, idx, props, computedName, computedId))
+    .map((e) => ({
+      ...e,
+    }))
+)
+
+const attrs = getGroupAttr(props)
+const classes = getGroupClasses(props)
+
+// TODO: make tests compatible with the v-focus directive
 </script>

--- a/src/components/BFormRadio/form-radio.spec.js
+++ b/src/components/BFormRadio/form-radio.spec.js
@@ -969,8 +969,8 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
+
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')
@@ -1003,8 +1003,8 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
+
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $input = wrapper.find('input')
@@ -1030,8 +1030,7 @@ describe('form-radio', () => {
     })
 
     expect(wrapper.vm).toBeDefined()
-    expect(wrapper.vm.modelValue).toBeDefined()
-    expect(wrapper.vm.modelValue).toBe(null)
+    expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
     const $label = wrapper.find('label')

--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -6,12 +6,12 @@
     v-model="localValue"
     :class="classes"
     :name="name"
-    :form="form || null"
-    :multiple="multiple || null"
+    :form="form || undefined"
+    :multiple="multiple || undefined"
     :size="computedSelectSize"
     :disabled="disabled"
     :required="required"
-    :aria-required="required ? 'true' : null"
+    :aria-required="required ? true : undefined"
     :aria-invalid="computedAriaInvalid"
   >
     <slot name="first" />
@@ -36,122 +36,137 @@
   </select>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent, nextTick, onActivated, onMounted, PropType, ref} from 'vue'
+<script setup lang="ts">
+// import type {BFormSelectEmits, BFormSelectProps} from '@/types/components'
+import type {Size} from '@/types'
+import {computed, nextTick, onActivated, onMounted, ref} from 'vue'
 import BFormSelectOption from './BFormSelectOption.vue'
 import BFormSelectOptionGroup from './BFormSelectOptionGroup.vue'
-import useId from '../../composables/useId'
-import {Size} from '../../types'
-import {normalizeOptions} from '../../composables/useFormSelect'
+import useId from '@/composables/useId'
+import {normalizeOptions} from '@/composables/useFormSelect'
 
-export default defineComponent({
-  name: 'BFormSelect',
-  components: {BFormSelectOption, BFormSelectOptionGroup},
-  props: {
-    ariaInvalid: {
-      type: [Boolean, String] as PropType<boolean | 'false' | 'true' | 'grammar' | 'spelling'>,
-      default: false,
-    },
-    autofocus: {type: Boolean, default: false},
-    disabled: {type: Boolean, default: false},
-    disabledField: {type: String, default: 'disabled'},
-    form: {type: String, required: false},
-    htmlField: {type: String, default: 'html'},
-    id: {type: String, required: false},
-    labelField: {type: String, default: 'label'},
-    multiple: {type: Boolean, default: false},
-    name: {type: String, required: false},
-    options: {type: [Array, Object], default: () => []},
-    optionsField: {type: String, default: 'options'},
-    plain: {type: Boolean, default: false},
-    required: {type: Boolean, default: false},
-    selectSize: {type: Number, default: 0},
-    size: {type: String as PropType<Size>, required: false},
-    state: {
-      type: Boolean as PropType<boolean | null | undefined>,
-      default: null,
-    },
-    textField: {type: String, default: 'text'},
-    valueField: {type: String, default: 'value'},
-    modelValue: {type: [String, Array, Object, Number], default: ''},
+interface BFormSelectProps {
+  ariaInvalid?: boolean | 'grammar' | 'spelling'
+  autofocus?: boolean
+  disabled?: boolean
+  disabledField?: string
+  form?: string
+  htmlField?: string
+  id?: string
+  labelField?: string
+  multiple?: boolean
+  name?: string
+  options?: Array<unknown> | Record<string, unknown>
+  optionsField?: string
+  plain?: boolean
+  required?: boolean
+  selectSize?: number
+  size?: Size
+  state?: boolean
+  textField?: string
+  valueField?: string
+  modelValue?: string | Array<unknown> | Record<string, unknown> | number
+}
+
+const props = withDefaults(defineProps<BFormSelectProps>(), {
+  ariaInvalid: false,
+  autofocus: false,
+  disabled: false,
+  disabledField: 'disabled',
+  htmlField: 'html',
+  labelField: 'label',
+  multiple: false,
+  options: () => [],
+  optionsField: 'options',
+  plain: false,
+  required: false,
+  selectSize: 0,
+  state: undefined,
+  textField: 'text',
+  valueField: 'value',
+  modelValue: '',
+})
+
+interface BFormSelectEmits {
+  (e: 'input', value: unknown): void
+  (e: 'update:modelValue', value: unknown): void
+  (e: 'change', value: unknown): void
+}
+
+const emit = defineEmits<BFormSelectEmits>()
+
+const input = ref<HTMLElement>()
+const computedId = useId(props.id, 'input')
+
+// lifecycle events
+const handleAutofocus = () => {
+  nextTick(() => {
+    if (props.autofocus) input.value?.focus()
+  })
+}
+onMounted(handleAutofocus)
+onActivated(handleAutofocus)
+// /lifecycle events
+
+// computed
+const classes = computed(() => ({
+  'form-control': props.plain,
+  [`form-control-${props.size}`]: props.size && props.plain,
+  'form-select': !props.plain,
+  [`form-select-${props.size}`]: props.size && !props.plain,
+  'is-valid': props.state === true,
+  'is-invalid': props.state === false,
+}))
+
+const computedSelectSize = computed<number | undefined>(() => {
+  if (props.selectSize || props.plain) {
+    return props.selectSize
+  }
+  return undefined
+})
+
+const computedAriaInvalid = computed<'grammar' | 'spelling' | boolean | undefined>(() => {
+  if (props.state === false) {
+    return true
+  }
+  if (props.state === true) {
+    return undefined
+  }
+  if (typeof props.ariaInvalid === 'boolean') {
+    if (props.ariaInvalid === false) {
+      return undefined
+    }
+    return props.ariaInvalid
+  }
+  return props.ariaInvalid
+})
+
+const formOptions = computed(() =>
+  normalizeOptions(props.options as Array<any>, 'BFormSelect', props)
+)
+const localValue = computed({
+  get() {
+    return props.modelValue
   },
-  emits: ['update:modelValue', 'change', 'input'],
-  setup(props, {emit}) {
-    const input = ref<HTMLElement>()
-    const computedId = useId(props.id, 'input')
-
-    // lifecycle events
-    const handleAutofocus = () => {
-      nextTick(() => {
-        if (props.autofocus) input.value?.focus()
-      })
-    }
-    onMounted(handleAutofocus)
-    onActivated(handleAutofocus)
-    // /lifecycle events
-
-    // computed
-    const classes = computed(() => ({
-      'form-control': props.plain,
-      [`form-control-${props.size}`]: props.size && props.plain,
-      'form-select': !props.plain,
-      [`form-select-${props.size}`]: props.size && !props.plain,
-      'is-valid': props.state === true,
-      'is-invalid': props.state === false,
-    }))
-
-    const computedSelectSize = computed(() => {
-      if (props.selectSize || props.plain) {
-        return props.selectSize
-      }
-      return null
-    })
-
-    const computedAriaInvalid = computed(() => {
-      if (props.ariaInvalid) {
-        return props.ariaInvalid.toString()
-      }
-      return props.state === false ? 'true' : null
-    })
-
-    const formOptions = computed(() => normalizeOptions(props.options, 'BFormSelect', props))
-    const localValue = computed({
-      get() {
-        return props.modelValue
-      },
-      set(newValue: any) {
-        emit('change', newValue)
-        emit('update:modelValue', newValue)
-        emit('input', newValue)
-      },
-    })
-
-    // /computed
-
-    // methods
-
-    const focus = () => {
-      if (!props.disabled) input.value?.focus()
-    }
-
-    const blur = () => {
-      if (!props.disabled) {
-        input.value?.blur()
-      }
-    }
-    // /methods
-
-    return {
-      input,
-      computedId,
-      computedSelectSize,
-      computedAriaInvalid,
-      classes,
-      formOptions,
-      localValue,
-      focus,
-      blur,
-    }
+  set(newValue: any) {
+    emit('change', newValue)
+    emit('update:modelValue', newValue)
+    emit('input', newValue)
   },
 })
+
+// /computed
+
+// methods
+
+const focus = () => {
+  if (!props.disabled) input.value?.focus()
+}
+
+const blur = () => {
+  if (!props.disabled) {
+    input.value?.blur()
+  }
+}
+// /methods
 </script>

--- a/src/components/BFormSelect/BFormSelectOption.vue
+++ b/src/components/BFormSelect/BFormSelectOption.vue
@@ -4,15 +4,15 @@
   </option>
 </template>
 
-<script lang="ts">
-import {defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BFormSelectOptionProps} from '@/types/components'
 
-export default defineComponent({
-  name: 'BFormSelectOption',
-  props: {
-    // eslint-disable-next-line vue/require-prop-types
-    value: {required: true},
-    disabled: {type: Boolean, default: false},
-  },
+interface BFormSelectOptionProps {
+  value: unknown
+  disabled?: boolean
+}
+
+withDefaults(defineProps<BFormSelectOptionProps>(), {
+  disabled: false,
 })
 </script>

--- a/src/components/BFormSelect/BFormSelectOptionGroup.vue
+++ b/src/components/BFormSelect/BFormSelectOptionGroup.vue
@@ -15,30 +15,30 @@
   </optgroup>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BFormSelectOptionGroupProps} from '@/types/components'
+import {computed} from 'vue'
 import BFormSelectOption from './BFormSelectOption.vue'
-import {normalizeOptions} from '../../composables/useFormSelect'
+import {normalizeOptions} from '@/composables/useFormSelect'
 
-export default defineComponent({
-  name: 'BFormSelectOptionGroup',
-  components: {BFormSelectOption},
-  props: {
-    label: {type: String, required: true},
-    disabledField: {type: String, default: 'disabled'},
-    htmlField: {type: String, default: 'html'},
-    options: {type: [Array, Object], default: () => []},
-    textField: {type: String, default: 'text'},
-    valueField: {type: String, default: 'value'},
-  },
-  setup(props) {
-    const formOptions = computed(() =>
-      normalizeOptions(props.options as any, 'BFormSelectOptionGroup', props)
-    )
+interface BFormSelectOptionGroupProps {
+  label?: string
+  disabledField?: string
+  htmlField?: string
+  options?: Array<unknown> | Record<string, unknown>
+  textField?: string
+  valueField?: string
+}
 
-    return {
-      formOptions,
-    }
-  },
+const props = withDefaults(defineProps<BFormSelectOptionGroupProps>(), {
+  disabledField: 'disabled',
+  htmlField: 'html',
+  options: () => [],
+  textField: 'text',
+  valueField: 'value',
 })
+
+const formOptions = computed(() =>
+  normalizeOptions(props.options as Array<any>, 'BFormSelectOptionGroup', props)
+)
 </script>

--- a/src/components/BFormTags/BFormTag.vue
+++ b/src/components/BFormTags/BFormTag.vue
@@ -21,33 +21,50 @@
       }"
       :aria-controls="id"
       :aria-describedby="taglabelId"
-      @click="$emit('remove', tagText)"
+      @click="emit('remove', tagText)"
     ></button>
   </component>
 </template>
 
 <script setup lang="ts">
-import {computed, useSlots} from 'vue'
-import useId from '../../composables/useId'
+// import type {BFormTagEmits, BFormTagProps} from '@/types/components'
+import {computed, useSlots, VNodeNormalizedChildren} from 'vue'
+import useId from '@/composables/useId'
+import type {ColorVariant} from '@/types'
 
-const props = defineProps({
-  disabled: {type: Boolean, default: false},
-  id: {type: String},
-  noRemove: {type: Boolean, default: false},
-  pill: {type: Boolean, default: false},
-  removeLabel: {type: String, default: 'Remove tag'},
-  tag: {type: String, default: 'span'},
-  title: {type: String},
-  variant: {type: String, default: 'secondary'},
+interface BFormTagProps {
+  id?: string
+  title?: string
+  disabled?: boolean
+  noRemove?: boolean
+  pill?: boolean
+  removeLabel?: string
+  tag?: string
+  variant?: ColorVariant
+}
+
+const props = withDefaults(defineProps<BFormTagProps>(), {
+  disabled: false,
+  noRemove: false,
+  pill: false,
+  removeLabel: 'Remove tag',
+  tag: 'span',
+  variant: 'secondary',
 })
 
-defineEmits(['remove'])
+interface BFormTagEmits {
+  (e: 'remove', value?: VNodeNormalizedChildren): void
+}
+
+const emit = defineEmits<BFormTagEmits>()
 
 const slots = useSlots()
 
-const tagText = computed(() => slots.default?.()[0].children || props.title)
+const tagText = computed<string>(
+  () => (slots.default?.()[0].children?.toString() || props.title) ?? ''
+)
 const computedId = useId(props.id)
-const taglabelId = computed(() => `${computedId.value}taglabel__`)
+const taglabelId = computed<string>(() => `${computedId.value}taglabel__`)
 
 const classes = computed(() => [
   `bg-${props.variant}`,

--- a/src/components/BFormTextarea/BFormTextarea.vue
+++ b/src/components/BFormTextarea/BFormTextarea.vue
@@ -23,8 +23,8 @@
 </template>
 
 <script lang="ts">
-import {computed, defineComponent} from 'vue'
-import useFormInput, {COMMON_INPUT_PROPS} from '../../composables/useFormInput'
+import {computed, defineComponent, StyleValue} from 'vue'
+import useFormInput, {COMMON_INPUT_PROPS} from '@/composables/useFormInput'
 
 export default defineComponent({
   name: 'BFormTextarea',
@@ -44,7 +44,9 @@ export default defineComponent({
       'is-invalid': props.state === false,
     }))
 
-    const computedStyles = computed(() => (props.noResize ? {resize: 'none'} : undefined))
+    const computedStyles = computed<StyleValue | undefined>(() =>
+      props.noResize ? {resize: 'none'} : undefined
+    )
 
     const {input, computedId, computedAriaInvalid, onInput, onChange, onBlur, focus, blur} =
       useFormInput(props, emit)

--- a/src/components/BInputGroup/BInputGroup.vue
+++ b/src/components/BInputGroup/BInputGroup.vue
@@ -1,4 +1,4 @@
-/* eslint-disable vue/no-v-html */
+<!-- eslint-disable vue/no-v-html -->
 <template>
   <component :is="tag" :id="id" class="input-group" :class="classes" role="group">
     <slot name="prepend">
@@ -19,38 +19,31 @@
   </component>
 </template>
 
-<script lang="ts">
-import {InputSize} from '../../types'
-import {computed, defineComponent, PropType} from 'vue'
+<script setup lang="ts">
+import type {InputSize} from '@/types'
+import {computed} from 'vue'
 
-export default defineComponent({
-  name: 'BInputGroup',
-  props: {
-    append: {type: String, required: false},
-    appendHtml: {type: String, required: false},
-    id: {type: String, required: false},
-    prepend: {type: String, required: false},
-    prependHtml: {type: String, required: false},
-    size: {type: String as PropType<InputSize>, required: false},
-    tag: {type: String, default: 'div'},
-  },
-  setup(props) {
-    const classes = computed(() => ({
-      'input-group-sm': props.size === 'sm',
-      'input-group-lg': props.size === 'lg',
-    }))
+interface BInputGroupProps {
+  append?: string
+  appendHtml?: string
+  id?: string
+  prepend?: string
+  prependHtml?: string
+  size?: InputSize
+  tag?: string
+}
 
-    const hasAppend = computed(() => props.append || props.appendHtml)
-    const hasPrepend = computed(() => props.prepend || props.prependHtml)
-    const showAppendHtml = computed(() => !!props.appendHtml)
-    const showPrependHtml = computed(() => !!props.prependHtml)
-    return {
-      classes,
-      hasAppend,
-      hasPrepend,
-      showAppendHtml,
-      showPrependHtml,
-    }
-  },
+const props = withDefaults(defineProps<BInputGroupProps>(), {
+  tag: 'div',
 })
+
+const classes = computed(() => ({
+  'input-group-sm': props.size === 'sm',
+  'input-group-lg': props.size === 'lg',
+}))
+
+const hasAppend = computed<boolean>(() => !!props.append || !!props.appendHtml)
+const hasPrepend = computed<boolean>(() => !!props.prepend || !!props.prependHtml)
+const showAppendHtml = computed<boolean>(() => !!props.appendHtml)
+const showPrependHtml = computed<boolean>(() => !!props.prependHtml)
 </script>

--- a/src/components/BInputGroup/BInputGroupAddon.vue
+++ b/src/components/BInputGroup/BInputGroupAddon.vue
@@ -7,28 +7,25 @@
   </component>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BInputGroupAddonProps} from '@/types/components'
+import {computed} from 'vue'
 import BInputGroupText from './BInputGroupText.vue'
 
-export default defineComponent({
-  name: 'BInputGroupAddon',
-  components: {BInputGroupText},
-  props: {
-    append: {type: Boolean, default: false},
-    id: {type: String, required: false},
-    isText: {type: Boolean, default: false},
-    tag: {type: String, default: 'div'},
-  },
-  setup(props) {
-    const computedClasses = computed(() => ({
-      'input-group-append': props.append,
-      'input-group-prepend': !props.append,
-    }))
+interface BInputGroupAddonProps {
+  append?: boolean
+  id?: string
+  isText?: boolean
+  tag?: string
+}
 
-    return {
-      computedClasses,
-    }
-  },
+const props = withDefaults(defineProps<BInputGroupAddonProps>(), {
+  append: false,
+  tag: 'div',
 })
+
+const computedClasses = computed(() => ({
+  'input-group-append': props.append,
+  'input-group-prepend': !props.append,
+}))
 </script>

--- a/src/components/BInputGroup/BInputGroupAppend.vue
+++ b/src/components/BInputGroup/BInputGroupAppend.vue
@@ -4,17 +4,17 @@
   </b-input-group-addon>
 </template>
 
-<script lang="ts">
-import {defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BInputGroupAppendProps} from '@/types/components'
 import BInputGroupAddon from './BInputGroupAddon.vue'
 
-export default defineComponent({
-  name: 'BInputGroupAppend',
-  components: {BInputGroupAddon},
-  props: {
-    id: {type: String, required: false},
-    isText: {type: Boolean, default: false},
-    tag: {type: String, default: 'div'},
-  },
+interface BInputGroupAppendProps {
+  id?: string
+  isText?: boolean
+  tag?: string
+}
+
+withDefaults(defineProps<BInputGroupAppendProps>(), {
+  tag: 'div',
 })
 </script>

--- a/src/components/BInputGroup/BInputGroupPrepend.vue
+++ b/src/components/BInputGroup/BInputGroupPrepend.vue
@@ -4,17 +4,17 @@
   </b-input-group-addon>
 </template>
 
-<script lang="ts">
-import {defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BInputGroupPrependProps} from '@/types/components'
 import BInputGroupAddon from './BInputGroupAddon.vue'
 
-export default defineComponent({
-  name: 'BInputGroupPrepend',
-  components: {BInputGroupAddon},
-  props: {
-    id: {type: String, required: false},
-    isText: {type: Boolean, default: false},
-    tag: {type: String, default: 'div'},
-  },
+interface BInputGroupPrependProps {
+  id?: string
+  isText?: boolean
+  tag?: string
+}
+
+withDefaults(defineProps<BInputGroupPrependProps>(), {
+  tag: 'div',
 })
 </script>

--- a/src/components/BInputGroup/BInputGroupText.vue
+++ b/src/components/BInputGroup/BInputGroupText.vue
@@ -4,13 +4,14 @@
   </component>
 </template>
 
-<script lang="ts">
-import {defineComponent} from 'vue'
+<script setup lang="ts">
+// import type {BInputGroupTextProps} from '@/types/components'
 
-export default defineComponent({
-  name: 'BInputGroupText',
-  props: {
-    tag: {type: String, default: 'div'},
-  },
+interface BInputGroupTextProps {
+  tag?: string
+}
+
+withDefaults(defineProps<BInputGroupTextProps>(), {
+  tag: 'div',
 })
 </script>

--- a/src/components/BListGroup/BListGroup.vue
+++ b/src/components/BListGroup/BListGroup.vue
@@ -4,57 +4,43 @@
   </component>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent, InjectionKey, PropType, provide, ref, watch} from 'vue'
-import {Breakpoint} from '../../types'
+<script setup lang="ts">
+// import type {BListGroupProps} from '@/types/components'
+import {computed, InjectionKey, provide} from 'vue'
+import type {Breakpoint} from '@/types'
 
-export interface ParentData {
-  numbered: boolean
+interface BListGroupProps {
+  flush?: boolean
+  horizontal?: boolean | Breakpoint
+  numbered?: boolean
+  tag?: string
 }
 
-export const injectionKey: InjectionKey<ParentData> = Symbol()
-
-export default defineComponent({
-  name: 'BListGroup',
-  props: {
-    flush: {type: Boolean, default: false},
-    horizontal: {type: [Boolean, String] as PropType<boolean | Breakpoint>, default: false},
-    numbered: {type: Boolean, default: false},
-    tag: {type: String, default: 'div'},
-  },
-  setup(props) {
-    const classes = computed(() => {
-      const horizontal = props.flush ? false : props.horizontal
-      return {
-        'list-group-flush': props.flush,
-        'list-group-horizontal': horizontal === true,
-        [`list-group-horizontal-${horizontal}`]: typeof horizontal === 'string',
-        'list-group-numbered': props.numbered,
-      }
-    })
-    //    const computedTag = () => (props.numbered === true ? 'div' : props.tag)
-
-    const calculateTag = () => (props.numbered === true ? 'ol' : props.tag)
-    const computedTag = ref(calculateTag())
-
-    // for some reason a computed for tag calculation does not always work. So I used watches
-    watch(
-      () => props.tag,
-      () => (computedTag.value = calculateTag())
-    )
-    watch(
-      () => props.numbered,
-      () => (computedTag.value = calculateTag())
-    )
-
-    provide(injectionKey, {
-      numbered: props.numbered,
-    })
-
-    return {
-      classes,
-      computedTag,
-    }
-  },
+const props = withDefaults(defineProps<BListGroupProps>(), {
+  flush: false,
+  horizontal: false,
+  numbered: false,
+  tag: 'div',
 })
+
+const classes = computed(() => {
+  const horizontal = props.flush ? false : props.horizontal
+  return {
+    'list-group-flush': props.flush,
+    'list-group-horizontal': horizontal === true,
+    [`list-group-horizontal-${horizontal}`]: typeof horizontal === 'string',
+    'list-group-numbered': props.numbered,
+  }
+})
+
+const computedTag = computed<string>(() => (props.numbered === true ? 'ol' : props.tag))
+
+provide(injectionKey, {
+  numbered: props.numbered,
+})
+</script>
+
+<script lang="ts">
+import type {BListGroupParentData} from '@/types/components'
+export const injectionKey: InjectionKey<BListGroupParentData> = Symbol()
 </script>

--- a/src/components/BListGroup/BListGroupItem.vue
+++ b/src/components/BListGroup/BListGroupItem.vue
@@ -7,87 +7,91 @@
     :aria-disabled="disabled ? true : null"
     :target="link ? target : null"
     :href="!button ? href : null"
-    v-bind="attrs"
+    v-bind="computedAttrs"
   >
     <slot />
   </component>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent, inject, PropType} from 'vue'
-import {ColorVariant} from '../../types'
+<script setup lang="ts">
+// import type {BListGroupItemProps} from '@/types/components'
+import {computed, inject, useAttrs} from 'vue'
+import type {ColorVariant, LinkTarget} from '@/types'
 import {injectionKey} from './BListGroup.vue'
 
-const ACTION_TAGS = ['a', 'router-link', 'button', 'b-link']
+interface BListGroupItemProps {
+  action?: boolean
+  active?: boolean
+  // activeClass: string
+  // append?: boolean
+  button?: boolean
+  disabled?: boolean
+  // exact?: boolean
+  // exactActiveClass: string
+  href?: string
+  // noPrefetch?: Boolean
+  // prefetch?: Boolean
+  // rel?: String
+  // replace?: Boolean
+  // routerComponentName?: String
+  tag?: string
+  target?: LinkTarget
+  //to: string | Record<string, unknown>
+  variant?: ColorVariant
+}
 
-export default defineComponent({
-  name: 'BListGroupItem',
-  props: {
-    action: {type: Boolean, default: false},
-    active: {type: Boolean, default: false},
-    // activeClass: {type: String},
-    // append: {type: Boolean, default: false},
-    button: {type: Boolean, default: false},
-    disabled: {type: Boolean, default: false},
-    // exact: {type: Boolean, default: false},
-    // exactActiveClass: {type: String},
-    href: {type: String},
-    // noPrefetch: {type: Boolean, default: false},
-    // prefetch: {type: Boolean, default: null},
-    // rel: {type: String, default: null},
-    // replace: {type: Boolean, default: false},
-    // routerComponentName: {type: String, default: null},
-    tag: {type: String, default: 'div'},
-    target: {type: String, default: '_self'},
-    //to: {type: [String, Object]},
-    variant: {type: String as PropType<ColorVariant>},
-  },
-  setup(props, context) {
-    const parentData = inject(injectionKey, null)
+const props = withDefaults(defineProps<BListGroupItemProps>(), {
+  action: false,
+  active: false,
+  button: false,
+  disabled: false,
+  tag: 'div',
+  target: '_self',
+})
 
-    const link = computed(() => !props.button && props.href)
-    const tagComputed = computed(
-      () =>
-        parentData?.numbered
-          ? 'li'
-          : props.button
-          ? 'button'
-          : !link.value
-          ? props.tag
-          : 'a' /* BLink */
-    )
+const attrs = useAttrs()
 
-    const classes = computed(() => {
-      const action = props.action || link.value || props.button || ACTION_TAGS.includes(props.tag)
-      return {
-        [`list-group-item-${props.variant}`]: props.variant,
-        'list-group-item-action': action,
-        'active': props.active,
-        'disabled': props.disabled,
-      }
-    })
+const parentData = inject(injectionKey, null)
 
-    const attrs = computed(() => {
-      const attrs = {} as {type?: string; disabled?: boolean}
-      if (props.button) {
-        if (!context.attrs || !context.attrs.type) {
-          // Add a type for button is one not provided in passed attributes
-          attrs.type = 'button'
-        }
-        if (props.disabled) {
-          // Set disabled attribute if button and disabled
-          attrs.disabled = true
-        }
-      }
-      return attrs
-    })
+const link = computed<boolean>(() => !props.button && !!props.href)
 
-    return {
-      tagComputed,
-      classes,
-      attrs,
-      link,
+const tagComputed = computed<string>(
+  () =>
+    parentData?.numbered
+      ? 'li'
+      : props.button
+      ? 'button'
+      : !link.value
+      ? props.tag
+      : 'a' /* BLink */
+)
+
+const classes = computed(() => {
+  const action =
+    props.action ||
+    link.value ||
+    props.button ||
+    ['a', 'router-link', 'button', 'b-link'].includes(props.tag)
+  return {
+    [`list-group-item-${props.variant}`]: props.variant,
+    'list-group-item-action': action,
+    'active': props.active,
+    'disabled': props.disabled,
+  }
+})
+
+const computedAttrs = computed(() => {
+  const localAttrs = {} as {type?: string; disabled?: boolean}
+  if (props.button) {
+    if (!attrs || !attrs.type) {
+      // Add a type for button is one not provided in passed attributes
+      localAttrs.type = 'button'
     }
-  },
+    if (props.disabled) {
+      // Set disabled attribute if button and disabled
+      localAttrs.disabled = true
+    }
+  }
+  return localAttrs
 })
 </script>

--- a/src/components/BSkeleton/BSkeleton.vue
+++ b/src/components/BSkeleton/BSkeleton.vue
@@ -3,16 +3,22 @@
 </template>
 
 <script setup lang="ts">
-import {computed, PropType, StyleValue} from 'vue'
-import type {ColorVariant, SkeletonAnimation, SkeletonType} from '../../types'
+// import type {BSkeletonProps} from '@/types/components'
+import {computed, StyleValue} from 'vue'
+import type {ColorVariant, SkeletonAnimation, SkeletonType} from '@/types'
 
-const props = defineProps({
-  animation: {type: String as PropType<SkeletonAnimation>, default: 'wave'},
-  height: {type: String},
-  size: {type: String},
-  type: {type: String as PropType<SkeletonType>, default: 'text'},
-  variant: {type: String as PropType<ColorVariant>},
-  width: {type: String},
+interface BSkeletonProps {
+  height?: string
+  width?: string
+  size?: string
+  animation?: SkeletonAnimation
+  type?: SkeletonType
+  variant?: ColorVariant
+}
+
+const props = withDefaults(defineProps<BSkeletonProps>(), {
+  animation: 'wave',
+  type: 'text',
 })
 
 const classes = computed(() => [

--- a/src/components/BSkeleton/BSkeletonIcon.vue
+++ b/src/components/BSkeleton/BSkeletonIcon.vue
@@ -8,11 +8,16 @@
 </template>
 
 <script setup lang="ts">
-import {computed, PropType} from 'vue'
-import type {SkeletonAnimation} from '../../types'
+// import type {BSkeletonIconProps} from '@/types/components'
+import {computed} from 'vue'
+import type {SkeletonAnimation} from '@/types'
 
-const props = defineProps({
-  animation: {type: String as PropType<SkeletonAnimation>, default: 'wave'},
+interface BSkeletonIconProps {
+  animation?: SkeletonAnimation
+}
+
+const props = withDefaults(defineProps<BSkeletonIconProps>(), {
+  animation: 'wave',
 })
 
 const classes = computed(() => [`b-skeleton-animate-${props.animation}`])

--- a/src/components/BSkeleton/BSkeletonTable.vue
+++ b/src/components/BSkeleton/BSkeletonTable.vue
@@ -25,15 +25,25 @@
 </template>
 
 <script setup lang="ts">
+// import type {BSkeletonTableProps} from '@/types/components'
+import type {SkeletonAnimation} from '@/types'
 import BTableSimple from '../BTable/BTableSimple.vue'
 import BSkeleton from './BSkeleton.vue'
 
-defineProps({
-  animation: {type: String, default: 'wave'},
-  columns: {type: Number, default: 5},
-  hideHeader: {type: Boolean, default: false},
-  rows: {type: Number, default: 3},
-  showFooter: {type: Boolean, default: false},
-  tableProps: {type: Object},
+interface BSkeletonTableProps {
+  animation?: SkeletonAnimation
+  columns?: number
+  hideHeader?: boolean
+  rows?: number
+  showFooter?: boolean
+  tableProps: Record<string, unknown>
+}
+
+withDefaults(defineProps<BSkeletonTableProps>(), {
+  animation: 'wave',
+  columns: 5,
+  hideHeader: false,
+  rows: 3,
+  showFooter: false,
 })
 </script>

--- a/src/components/BSkeleton/BSkeletonWrapper.vue
+++ b/src/components/BSkeleton/BSkeletonWrapper.vue
@@ -4,7 +4,13 @@
 </template>
 
 <script setup lang="ts">
-defineProps({
-  loading: {type: Boolean, default: false},
+// import type {BSkeletonWrapperProps} from '@/types/components'
+
+interface BSkeletonWrapperProps {
+  loading?: boolean
+}
+
+withDefaults(defineProps<BSkeletonWrapperProps>(), {
+  loading: false,
 })
 </script>

--- a/src/components/BTable/BTbody.vue
+++ b/src/components/BTable/BTbody.vue
@@ -5,10 +5,15 @@
 </template>
 
 <script setup lang="ts">
+// import type {BTBodyProps} from '@/types/components'
 import {computed} from 'vue'
 
-const props = defineProps({
-  headVariant: {type: Boolean, default: false},
+interface BTBodyProps {
+  headVariant?: boolean
+}
+
+const props = withDefaults(defineProps<BTBodyProps>(), {
+  headVariant: false,
 })
 
 const classes = computed(() => ({

--- a/src/components/BTable/BTfoot.vue
+++ b/src/components/BTable/BTfoot.vue
@@ -5,11 +5,14 @@
 </template>
 
 <script setup lang="ts">
+// import type {BTfootProps} from '@/types/components'
 import {computed} from 'vue'
 
-const props = defineProps({
-  footVariant: {type: String},
-})
+interface BTfootProps {
+  footVariant: string
+}
+
+const props = defineProps<BTfootProps>()
 
 const classes = computed(() => ({
   [`table-${props.footVariant}`]: props.footVariant,

--- a/src/components/BTable/BThead.vue
+++ b/src/components/BTable/BThead.vue
@@ -5,11 +5,14 @@
 </template>
 
 <script setup lang="ts">
+// import type {BTheadProps} from '@/types/components'
 import {computed} from 'vue'
 
-const props = defineProps({
-  headVariant: {type: String},
-})
+interface BTheadProps {
+  headVariant: string
+}
+
+const props = defineProps<BTheadProps>()
 
 const classes = computed(() => ({
   [`table-${props.headVariant}`]: props.headVariant,

--- a/src/components/BTable/BTr.vue
+++ b/src/components/BTable/BTr.vue
@@ -5,11 +5,14 @@
 </template>
 
 <script setup lang="ts">
+// import type {BTrProps} from '@/types/components'
 import {computed} from 'vue'
 
-const props = defineProps({
-  variant: {type: String},
-})
+interface BTrProps {
+  variant: string
+}
+
+const props = defineProps<BTrProps>()
 
 const classes = computed(() => ({
   [`table-${props.variant}`]: props.variant,

--- a/src/components/BTable/itemHelper.ts
+++ b/src/components/BTable/itemHelper.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import type {TableField, TableFieldObject, TableItem} from '../../types'
-import {isObject, isString} from '../../utils/inspect'
-import {startCase} from '../../utils/stringUtils'
+import type {TableField, TableFieldObject, TableItem} from '@/types'
+import {isObject, isString} from '@/utils/inspect'
+import {startCase} from '@/utils/stringUtils'
 
 const useItemHelper = () => {
   const normaliseFields = (origFields: TableField[], items: TableItem[]): TableFieldObject[] => {

--- a/src/components/BTabs/BTab.vue
+++ b/src/components/BTabs/BTab.vue
@@ -11,44 +11,45 @@
   </component>
 </template>
 
-<script lang="ts">
-import {computed, defineComponent, inject} from 'vue'
-import {injectionKey, ParentData} from './BTabs.vue'
+<script setup lang="ts">
+// import type {BTabProps} from '@/types/components'
+import {computed, inject} from 'vue'
+import {injectionKey} from './BTabs.vue'
 
-export default defineComponent({
-  name: 'BTab',
-  props: {
-    active: {type: Boolean, default: false},
-    buttonId: {type: String, default: null},
-    disabled: {type: Boolean, default: false},
-    id: {type: String},
-    lazy: {type: Boolean, default: false},
-    noBody: {type: [Boolean, String], default: false},
-    tag: {type: String, default: 'div'},
-    title: {type: String},
-    titleItemClass: {type: [Array, Object, String], default: null},
-    titleLinkAttributes: {type: Object, default: null},
-    titleLinkClass: {type: [Array, Object, String], default: null},
-  },
-  setup(props) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const parentData: ParentData = inject(injectionKey)!
+interface BTabProps {
+  id: string
+  title: string
+  active?: boolean
+  buttonId?: string
+  disabled?: boolean
+  lazy?: boolean
+  noBody?: boolean | string
+  tag?: string
+  titleItemClass?: Array<unknown> | Record<string, unknown> | string
+  titleLinkAttributes?: Record<string, unknown>
+  titleLinkClass?: Array<unknown> | Record<string, unknown> | string
+}
 
-    const computedLazy = computed(() => parentData?.lazy || props.lazy)
-    const computedActive = computed(() => props.active && !props.disabled)
-    const showSlot = computed(() => computedActive.value || !computedLazy.value)
-    const classes = computed(() => ({
-      'active': props.active,
-      'show': props.active,
-      'card-body': parentData.card && props.noBody === false,
-    }))
-
-    return {
-      classes,
-      computedLazy,
-      computedActive,
-      showSlot,
-    }
-  },
+const props = withDefaults(defineProps<BTabProps>(), {
+  active: false,
+  buttonId: undefined,
+  disabled: false,
+  lazy: false,
+  noBody: false,
+  tag: 'div',
+  titleItemClass: undefined,
+  titleLinkAttributes: undefined,
+  titleLinkClass: undefined,
 })
+
+const parentData = inject(injectionKey, null)
+
+const computedLazy = computed<boolean>(() => parentData?.lazy || props.lazy)
+const computedActive = computed<boolean>(() => props.active && !props.disabled)
+const showSlot = computed<boolean>(() => computedActive.value || !computedLazy.value)
+const classes = computed(() => ({
+  'active': props.active,
+  'show': props.active,
+  'card-body': parentData?.card && props.noBody === false,
+}))
 </script>

--- a/src/components/BTabs/BTabs.vue
+++ b/src/components/BTabs/BTabs.vue
@@ -49,29 +49,181 @@
   </component>
 </template>
 
-<script lang="ts">
-import {
-  computed,
-  defineComponent,
-  InjectionKey,
-  onMounted,
-  PropType,
-  provide,
-  ref,
-  watch,
-} from 'vue'
-import getID from '../../utils/getID'
-import type {Alignment} from '../../types'
-import {BvEvent} from '../../utils/bvEvent'
-import {mathMax} from '../../utils/math'
-import {isFunction} from '../../utils/inspect'
+<script setup lang="ts">
+// import type {BTabsProps, BTabsEmits} from '@/types/components'
+import {computed, InjectionKey, onMounted, provide, ref, useSlots, watch} from 'vue'
+import getID from '@/utils/getID'
+import type {Alignment} from '@/types'
+import {BvEvent} from '@/utils/bvEvent'
+import {mathMax} from '@/utils/math'
+import {isFunction} from '@/utils/inspect'
 
-export interface ParentData {
-  lazy: boolean
-  card: boolean
+interface BTabsProps {
+  activeNavItemClass?: Array<unknown> | Record<string, unknown> | string
+  activeTabClass?: Array<unknown> | Record<string, unknown> | string
+  align?: Alignment
+  card?: boolean
+  contentClass?: Array<unknown> | Record<string, unknown> | string
+  end?: boolean
+  fill?: boolean
+  id?: string
+  justified?: boolean
+  lazy?: boolean
+  navClass?: Array<unknown> | Record<string, unknown> | string
+  navWrapperClass?: Array<unknown> | Record<string, unknown> | string
+  noFade?: boolean
+  // noKeyNav?: boolean
+  noNavStyle?: boolean
+  pills?: boolean
+  small?: boolean
+  tag?: string
+  vertical?: boolean
+  modelValue?: number
 }
 
-export const injectionKey: InjectionKey<ParentData> = Symbol()
+const props = withDefaults(defineProps<BTabsProps>(), {
+  activeNavItemClass: undefined,
+  activeTabClass: undefined,
+  align: undefined,
+  card: false,
+  contentClass: undefined,
+  end: false,
+  fill: false,
+  id: undefined,
+  justified: false,
+  lazy: false,
+  navClass: undefined,
+  navWrapperClass: undefined,
+  noFade: false,
+  noNavStyle: false,
+  pills: false,
+  small: false,
+  tag: 'div',
+  vertical: false,
+  modelValue: -1,
+})
+
+interface BTabsEmits {
+  (e: 'update:modelValue', value: number): void
+  (e: 'activate-tab', v1: number, v2: number, v3: BvEvent): void
+  (e: 'click'): void
+}
+
+const emit = defineEmits<BTabsEmits>()
+
+const slots = useSlots()
+
+const _tabIndex = ref(props.modelValue)
+const _currentTabButton = ref('')
+
+const tabIndex = computed({
+  get: () => _tabIndex.value,
+  set: (value: number) => {
+    _tabIndex.value = value
+    if (tabs.value.length > 0 && value >= 0 && value < tabs.value.length) {
+      _currentTabButton.value = tabs.value[value].buttonId
+    } else {
+      _currentTabButton.value = ''
+    }
+    emit('update:modelValue', value)
+  },
+})
+
+const tabs = computed(() => {
+  let tabs: any[] = []
+
+  if (slots.default) {
+    tabs = getTabs(slots).map((tab: any, idx) => {
+      if (!tab.props) tab.props = {}
+
+      const buttonId = tab.props['button-id'] || getID('tab')
+      const contentId = tab.props.id || getID()
+      const active = tabIndex.value > -1 ? idx === tabIndex.value : tab.props.active === ''
+      const titleItemClass = tab.props['title-item-class']
+      const titleLinkAttributes = tab.props['title-link-attributes']
+
+      return {
+        buttonId,
+        contentId,
+        active,
+        disabled: tab.props.disabled === '' || tab.props.disabled === true,
+        navItemClasses: [
+          {
+            active,
+            disabled: tab.props.disabled === '' || tab.props.disabled === true,
+          },
+          active && props.activeNavItemClass ? props.activeNavItemClass : null,
+          tab.props['title-link-class'],
+        ],
+        tabClasses: [
+          {
+            fade: !props.noFade,
+          },
+          active && props.activeTabClass ? props.activeTabClass : null,
+        ],
+        target: `#${contentId}`,
+        title: tab.props.title,
+        titleItemClass,
+        titleLinkAttributes,
+        onClick: tab.props.onClick,
+        tab,
+      }
+    })
+  }
+  return tabs
+})
+
+const showEmpty = computed(() => !(tabs?.value && tabs.value.length > 0))
+
+const classes = computed(() => ({
+  'd-flex align-items-start': props.vertical,
+}))
+
+const navTabsClasses = computed(() => ({
+  'nav-pills': props.pills,
+  'flex-column me-3': props.vertical,
+  [`justify-content-${props.align}`]: !!props.align,
+  'nav-fill': props.fill,
+  'card-header-tabs': props.card,
+  'nav-justified': props.justified,
+  'nav-tabs': !props.noNavStyle && !props.pills,
+  'small': props.small,
+}))
+
+const activateTab = (index: number): boolean => {
+  let result = false
+  if (index !== undefined) {
+    if (
+      index > -1 &&
+      index < tabs.value.length &&
+      !tabs.value[index].disabled &&
+      (tabIndex.value < 0 || tabs.value[index].buttonId !== _currentTabButton.value)
+    ) {
+      const tabEvent = new BvEvent('activate-tab', {cancelable: true, vueTarget: this})
+      emit('activate-tab', index, tabIndex.value, tabEvent)
+      if (!tabEvent.defaultPrevented) {
+        tabIndex.value = index
+        result = true
+      }
+    }
+  }
+  if (!result && props.modelValue !== tabIndex.value) {
+    emit('update:modelValue', tabIndex.value)
+  }
+  return result
+}
+
+const handleClick = (event: MouseEvent, index: number) => {
+  activateTab(index)
+  if (
+    index >= 0 &&
+    !tabs.value[index].disabled &&
+    tabs.value[index]?.onClick &&
+    isFunction(tabs.value[index].onClick)
+  ) {
+    tabs.value[index].onClick(event)
+  }
+}
 
 const getTabs = (slots: any): any[] => {
   if (!slots || !slots.default) return []
@@ -89,230 +241,80 @@ const getTabs = (slots: any): any[] => {
     .filter((child: any) => child.type?.name === 'BTab')
 }
 
-export default defineComponent({
-  name: 'BTabs',
-  props: {
-    activeNavItemClass: {type: [Array, Object, String], default: null},
-    activeTabClass: {type: [Array, Object, String], default: null},
-    align: {type: String as PropType<Alignment>, default: null},
-    card: {type: Boolean, default: false},
-    contentClass: {type: [Array, Object, String], default: null},
-    end: {type: Boolean, default: false},
-    fill: {type: Boolean, default: false},
-    id: {type: String, default: null},
-    justified: {type: Boolean, default: false},
-    lazy: {type: Boolean, default: false},
-    navClass: {type: [Array, Object, String], default: null},
-    navWrapperClass: {type: [Array, Object, String], default: null},
-    noFade: {type: Boolean, default: false},
-    // noKeyNav: { type: Boolean, default: false },
-    noNavStyle: {type: Boolean, default: false},
-    pills: {type: Boolean, default: false},
-    small: {type: Boolean, default: false},
-    tag: {type: String, default: 'div'},
-    vertical: {type: Boolean, default: false},
-    modelValue: {type: Number, default: -1},
-  },
-  emits: ['update:modelValue', 'activate-tab', 'click'],
-  setup(props, {slots, emit}) {
-    const _tabIndex = ref(props.modelValue)
-    const _currentTabButton = ref('')
+activateTab(_tabIndex.value)
 
-    const tabIndex = computed({
-      get: () => _tabIndex.value,
-      set: (value: number) => {
-        _tabIndex.value = value
-        if (tabs.value.length > 0 && value >= 0 && value < tabs.value.length) {
-          _currentTabButton.value = tabs.value[value].buttonId
-        } else {
-          _currentTabButton.value = ''
-        }
-        emit('update:modelValue', value)
-      },
-    })
+watch(
+  () => props.modelValue,
+  (newValue, oldValue) => {
+    if (newValue === oldValue) return
+    newValue = mathMax(newValue, -1)
+    oldValue = mathMax(oldValue, -1)
 
-    const tabs = computed(() => {
-      let tabs: any[] = []
-
-      if (slots.default) {
-        tabs = getTabs(slots).map((tab: any, idx) => {
-          if (!tab.props) tab.props = {}
-
-          const buttonId = tab.props['button-id'] || getID('tab')
-          const contentId = tab.props.id || getID()
-          const active = tabIndex.value > -1 ? idx === tabIndex.value : tab.props.active === ''
-          const titleItemClass = tab.props['title-item-class']
-          const titleLinkAttributes = tab.props['title-link-attributes']
-
-          return {
-            buttonId,
-            contentId,
-            active,
-            disabled: tab.props.disabled === '' || tab.props.disabled === true,
-            navItemClasses: [
-              {
-                active,
-                disabled: tab.props.disabled === '' || tab.props.disabled === true,
-              },
-              active && props.activeNavItemClass ? props.activeNavItemClass : null,
-              tab.props['title-link-class'],
-            ],
-            tabClasses: [
-              {
-                fade: !props.noFade,
-              },
-              active && props.activeTabClass ? props.activeTabClass : null,
-            ],
-            target: `#${contentId}`,
-            title: tab.props.title,
-            titleItemClass,
-            titleLinkAttributes,
-            onClick: tab.props.onClick,
-            tab,
-          }
-        })
-      }
-      return tabs
-    })
-
-    const showEmpty = computed(() => !(tabs?.value && tabs.value.length > 0))
-
-    const classes = computed(() => ({
-      'd-flex align-items-start': props.vertical,
-    }))
-
-    const navTabsClasses = computed(() => ({
-      'nav-pills': props.pills,
-      'flex-column me-3': props.vertical,
-      [`justify-content-${props.align}`]: !!props.align,
-      'nav-fill': props.fill,
-      'card-header-tabs': props.card,
-      'nav-justified': props.justified,
-      'nav-tabs': !props.noNavStyle && !props.pills,
-      'small': props.small,
-    }))
-
-    const activateTab = (index: number): boolean => {
-      let result = false
-      if (index !== undefined) {
-        if (
-          index > -1 &&
-          index < tabs.value.length &&
-          !tabs.value[index].disabled &&
-          (tabIndex.value < 0 || tabs.value[index].buttonId !== _currentTabButton.value)
-        ) {
-          const tabEvent = new BvEvent('activate-tab', {cancelable: true, vueTarget: this})
-          emit('activate-tab', index, tabIndex.value, tabEvent)
-          if (!tabEvent.defaultPrevented) {
-            tabIndex.value = index
-            result = true
-          }
-        }
-      }
-      if (!result && props.modelValue !== tabIndex.value) {
-        emit('update:modelValue', tabIndex.value)
-      }
-      return result
+    if (tabs.value.length <= 0) {
+      tabIndex.value = -1
+      return
     }
 
-    const handleClick = (event: MouseEvent, index: number) => {
-      activateTab(index)
-      if (
-        index >= 0 &&
-        !tabs.value[index].disabled &&
-        tabs.value[index]?.onClick &&
-        isFunction(tabs.value[index].onClick)
-      ) {
-        tabs.value[index].onClick(event)
-      }
+    const goForward = newValue > oldValue
+    let index = newValue
+    const maxIdx = tabs.value.length - 1
+    while (index >= 0 && index <= maxIdx && tabs.value[index].disabled) {
+      index += goForward ? 1 : -1
     }
 
-    activateTab(_tabIndex.value)
-
-    watch(
-      () => props.modelValue,
-      (newValue, oldValue) => {
-        if (newValue === oldValue) return
-        newValue = mathMax(newValue, -1)
-        oldValue = mathMax(oldValue, -1)
-
-        if (tabs.value.length <= 0) {
-          tabIndex.value = -1
-          return
-        }
-
-        const goForward = newValue > oldValue
-        let index = newValue
-        const maxIdx = tabs.value.length - 1
-        while (index >= 0 && index <= maxIdx && tabs.value[index].disabled) {
-          index += goForward ? 1 : -1
-        }
-
-        if (index < 0) {
-          activateTab(0)
-          return
-        }
-        if (index >= tabs.value.length) {
-          activateTab(tabs.value.length - 1)
-          return
-        }
-        activateTab(index)
-      }
-    )
-
-    watch(
-      () => tabs.value,
-      () => {
-        // find last active tab
-        let activeTabIndex = tabs.value
-          .map((tab: any) => tab.active && !tab.disabled)
-          .lastIndexOf(true)
-
-        if (activeTabIndex < 0) {
-          if (tabIndex.value >= tabs.value.length) {
-            // handle last tab removed, so find the last non-disabled tab
-            activeTabIndex = tabs.value.map((tab: any) => !tab.disabled).lastIndexOf(true)
-          } else {
-            if (tabs.value[tabIndex.value] && !tabs.value[tabIndex.value].disabled)
-              activeTabIndex = tabIndex.value
-          }
-        }
-        // still no active tab found, find first non-disabled tab
-        if (activeTabIndex < 0) {
-          activeTabIndex = tabs.value.map((tab: any) => !tab.disabled).indexOf(true)
-        }
-        // ensure only one tab active at a time
-        tabs.value.forEach((tab: any, idx: number) => (tab.active = idx === activeTabIndex))
-
-        activateTab(activeTabIndex)
-      }
-    )
-
-    onMounted(() => {
-      // If there are tabs available, make sure a tab is set active
-      if (
-        tabIndex.value < 0 &&
-        tabs.value.length > 0 &&
-        !tabs.value.some((tab: any) => tab.active)
-      ) {
-        const firstTab = tabs.value.map((t) => !t.disabled).indexOf(true)
-        activateTab(firstTab >= 0 ? firstTab : -1)
-      }
-    })
-
-    provide(injectionKey, {
-      lazy: props.lazy,
-      card: props.card,
-    })
-
-    return {
-      tabs,
-      showEmpty,
-      classes,
-      navTabsClasses,
-      tabIndex,
-      handleClick,
+    if (index < 0) {
+      activateTab(0)
+      return
     }
-  },
+    if (index >= tabs.value.length) {
+      activateTab(tabs.value.length - 1)
+      return
+    }
+    activateTab(index)
+  }
+)
+
+watch(
+  () => tabs.value,
+  () => {
+    // find last active tab
+    let activeTabIndex = tabs.value.map((tab: any) => tab.active && !tab.disabled).lastIndexOf(true)
+
+    if (activeTabIndex < 0) {
+      if (tabIndex.value >= tabs.value.length) {
+        // handle last tab removed, so find the last non-disabled tab
+        activeTabIndex = tabs.value.map((tab: any) => !tab.disabled).lastIndexOf(true)
+      } else {
+        if (tabs.value[tabIndex.value] && !tabs.value[tabIndex.value].disabled)
+          activeTabIndex = tabIndex.value
+      }
+    }
+    // still no active tab found, find first non-disabled tab
+    if (activeTabIndex < 0) {
+      activeTabIndex = tabs.value.map((tab: any) => !tab.disabled).indexOf(true)
+    }
+    // ensure only one tab active at a time
+    tabs.value.forEach((tab: any, idx: number) => (tab.active = idx === activeTabIndex))
+
+    activateTab(activeTabIndex)
+  }
+)
+
+onMounted(() => {
+  // If there are tabs available, make sure a tab is set active
+  if (tabIndex.value < 0 && tabs.value.length > 0 && !tabs.value.some((tab: any) => tab.active)) {
+    const firstTab = tabs.value.map((t) => !t.disabled).indexOf(true)
+    activateTab(firstTab >= 0 ? firstTab : -1)
+  }
 })
+
+provide(injectionKey, {
+  lazy: props.lazy,
+  card: props.card,
+})
+</script>
+
+<script lang="ts">
+import {BTabsParentData} from '@/types/components'
+export const injectionKey: InjectionKey<BTabsParentData> = Symbol()
 </script>

--- a/src/composables/useFormInput.ts
+++ b/src/composables/useFormInput.ts
@@ -81,11 +81,26 @@ function useFormInput(props: Readonly<InputProps>, emit: InputEmitType) {
 
   onActivated(handleAutofocus)
 
-  const computedAriaInvalid = computed(() => {
-    if (props.ariaInvalid) {
-      return props.ariaInvalid.toString()
+  const computedAriaInvalid = computed<'grammar' | 'spelling' | boolean | undefined>(() => {
+    if (props.state === false) {
+      return true
     }
-    return props.state === false ? 'true' : undefined
+    if (props.state === true) {
+      return undefined
+    }
+    if (typeof props.ariaInvalid === 'boolean') {
+      if (props.ariaInvalid === false) {
+        return undefined
+      }
+      return props.ariaInvalid
+    }
+    if (props.ariaInvalid === 'true') {
+      return true
+    }
+    if (props.ariaInvalid === 'false') {
+      return undefined
+    }
+    return props.ariaInvalid
   })
 
   const onInput = (evt: Event) => {

--- a/src/composables/useFormInput.ts
+++ b/src/composables/useFormInput.ts
@@ -13,7 +13,7 @@ import useId from './useId'
 
 export const COMMON_INPUT_PROPS = {
   ariaInvalid: {
-    type: [Boolean, String] as PropType<boolean | 'false' | 'true' | 'grammar' | 'spelling'>,
+    type: [Boolean, String] as PropType<'grammar' | 'spelling' | boolean | undefined>,
     default: false,
   },
   autocomplete: {type: String, required: false},
@@ -93,12 +93,6 @@ function useFormInput(props: Readonly<InputProps>, emit: InputEmitType) {
         return undefined
       }
       return props.ariaInvalid
-    }
-    if (props.ariaInvalid === 'true') {
-      return true
-    }
-    if (props.ariaInvalid === 'false') {
-      return undefined
     }
     return props.ariaInvalid
   })

--- a/src/types/components/BFormSelect/BFormSelect.d.ts
+++ b/src/types/components/BFormSelect/BFormSelect.d.ts
@@ -18,6 +18,9 @@ export interface Props {
   selectSize?: number
   size?: Size
   state?: boolean | null
+  textField?: string
+  valueField?: value
+  modelValue?: string | Array<unknown> | Record<string, unknown> | number
 }
 // Emits
 export interface Emits {

--- a/src/types/components/BFormSelect/BFormSelectOptionGroup.d.ts
+++ b/src/types/components/BFormSelect/BFormSelectOptionGroup.d.ts
@@ -3,7 +3,7 @@ export interface Props {
   label?: string
   disabledField?: string
   htmlField?: string
-  options?: Array | Record<string, unknown>
+  options?: Array<unknown> | Record<string, unknown>
   textField?: string
   valueField?: string
 }

--- a/src/types/components/BFormTags/BFormTags.d.ts
+++ b/src/types/components/BFormTags/BFormTags.d.ts
@@ -1,14 +1,14 @@
-import type {InputSize, InputType} from '@/types'
+import type {ButtonVariant, ColorVariant, InputSize, InputType} from '@/types'
 // Props
 export interface Props {
   addButtonText?: string
-  addButtonVariant?: string
+  addButtonVariant?: ButtonVariant
   addOnChange?: boolean
   autofocus?: boolean
   disabled?: boolean
   duplicateTagText?: string
   inputAttrs: Record<string, unknown>
-  inputClass: Array | Record<string, unknown> | string
+  inputClass: Array<unknown> | Record<string, unknown> | string
   inputId: string
   inputType?: InputType
   invalidTagText?: string
@@ -26,12 +26,12 @@ export interface Props {
   separator: string | Array<unknown>
   state?: boolean
   size: InputSize
-  tagClass: string | Array | Record<string, unknown>
+  tagClass: string | Array<unknown> | Record<string, unknown>
   tagPills?: boolean
   tagRemoveLabel: string
   tagRemovedLabel?: string
   tagValidator?: () => boolean
-  tagVariant?: string
+  tagVariant?: ColorVariant
 }
 // Emits
 export interface Emits {

--- a/src/types/components/BListGroup/BListGroup.d.ts
+++ b/src/types/components/BListGroup/BListGroup.d.ts
@@ -9,3 +9,6 @@ export interface Props {
 // Emits
 
 // Other
+export interface ParentData {
+  numbered: boolean
+}

--- a/src/types/components/BSkeleton/BSkeletonTable.d.ts
+++ b/src/types/components/BSkeleton/BSkeletonTable.d.ts
@@ -1,6 +1,7 @@
+import type {SkeletonAnimation} from '@/types'
 // Props
 export interface Props {
-  animation?: string
+  animation?: SkeletonAnimation
   columns?: number
   hideHeader?: boolean
   rows?: number

--- a/src/types/components/BTable/BTfoot.d.ts
+++ b/src/types/components/BTable/BTfoot.d.ts
@@ -1,6 +1,6 @@
 // Props
 export interface Props {
-  footerVariant: string
+  footVariant: string
 }
 // Emits
 

--- a/src/types/components/BTabs/BTabs.d.ts
+++ b/src/types/components/BTabs/BTabs.d.ts
@@ -23,5 +23,13 @@ export interface Props {
   modelValue?: number
 }
 // Emits
-
+export interface Emits {
+  (e: 'update:modelValue', value: number): void
+  (e: 'activate-tab'): void
+  (e: 'click'): void
+}
 // Other
+export interface ParentData {
+  lazy: boolean
+  card: boolean
+}

--- a/src/types/components/index.ts
+++ b/src/types/components/index.ts
@@ -114,6 +114,8 @@ export type {Props as BTrProps} from './BTable/BTr'
 // BTabs
 export type {Props as BTabProps} from './BTabs/BTab'
 export type {Props as BTabsProps} from './BTabs/BTabs'
+export type {Emits as BTabsEmits} from './BTabs/BTabs'
+export type {ParentData as BTabsParentData} from './BTabs/BTabs'
 // BToast
 export type {Props as BToastProps} from './BToast/BToast'
 export type {Emits as BToastEmits} from './BToast/BToast'

--- a/src/types/components/index.ts
+++ b/src/types/components/index.ts
@@ -88,6 +88,7 @@ export type {Props as BLinkProps} from './BLink/BLink'
 export type {Emits as BLinkEmits} from './BLink/BLink'
 // BListGroup
 export type {Props as BListGroupProps} from './BListGroup/BListGroup'
+export type {ParentData as BListGroupParentData} from './BListGroup/BListGroup'
 export type {Props as BListGroupItemProps} from './BListGroup/BListGroupItem'
 // BOverlay
 export type {Props as BOverlayProps} from './BOverlay/BOverlay'


### PR DESCRIPTION
BFormCheckbox converted, Note; contains a breaking migration change read https://github.com/cdmoro/bootstrap-vue-3/pull/417#issuecomment-1164462527
UseFormInput contains a fix to actually make it assignable to the HTML attribute, rather than causing an error.
BFromRadio converted and fixed.
BFormSelect, didn't need to be converted, just fixed and improved.

BFormTags, converted. Note: This one contains an odd issue because it uses this following code `slots.default?.()[0].children` This type returns Vue's `VNodeNormalizedChildren`. This caused some issues, but I attempted to simply call toString() on it to cast it to a string, since further down the `removeTag` function needs it to be a string... Since there is no tests for it, I cannot be positive it even works, (without creating my own tests, maybe later though). There are no errors, but I'm not sure if it works when using slots. 
If the unknown reality of it is simply too much to bear, causing sleepless nights and terrors, you can deny the PR and I can exclude it for now. 