### PR TITLE
BFormTags does not need generic type for tagValidator

### DIFF
--- a/src/components/BFormTags/BFormTags.vue
+++ b/src/components/BFormTags/BFormTags.vue
@@ -141,7 +141,7 @@ interface BFormTagsProps {
   tagPills?: boolean
   tagRemoveLabel?: string
   tagRemovedLabel?: string
-  tagValidator?: <T>(t: T) => boolean
+  tagValidator?: (t: unknown) => boolean
   tagVariant?: ColorVariant
 }
 

--- a/src/types/components/BFormTags/BFormTags.d.ts
+++ b/src/types/components/BFormTags/BFormTags.d.ts
@@ -30,7 +30,7 @@ export interface Props {
   tagPills?: boolean
   tagRemoveLabel?: string
   tagRemovedLabel?: string
-  tagValidator?: <T>(t: T) => boolean
+  tagValidator?: (t: unknown) => boolean
   tagVariant?: ColorVariant
 }
 // Emits


### PR DESCRIPTION
Was a bad practice accident