### PR TITLE
BFormCheckbox & BFormTags fixes

### DIFF
--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -52,8 +52,14 @@ interface BFormCheckboxProps {
   required?: boolean
   size?: InputSize
   state?: boolean
-  uncheckedValue?: Array<unknown> | Set<unknown> | boolean
-  value?: Array<unknown> | Set<unknown> | boolean
+  uncheckedValue?:
+    | Array<unknown>
+    | Set<unknown>
+    | boolean
+    | string
+    | Record<string, unknown>
+    | number
+  value?: Array<unknown> | Set<unknown> | boolean | string | Record<string, unknown> | number
   modelValue?: Array<unknown> | Set<unknown> | boolean
 }
 

--- a/src/components/BFormTags/BFormTags.vue
+++ b/src/components/BFormTags/BFormTags.vue
@@ -141,7 +141,7 @@ interface BFormTagsProps {
   tagPills?: boolean
   tagRemoveLabel?: string
   tagRemovedLabel?: string
-  tagValidator?: <T>(t: T) => boolean
+  tagValidator?: (t?: string) => boolean
   tagVariant?: ColorVariant
 }
 
@@ -170,9 +170,9 @@ const props = withDefaults(defineProps<BFormTagsProps>(), {
 })
 
 interface BFormTagsEmits {
-  (e: 'update:modelValue', value: Array<unknown>): void
-  (e: 'input', value: Array<unknown>): void
-  (e: 'tag-state', ...args: Array<unknown>): void
+  (e: 'update:modelValue', value: Array<string>): void
+  (e: 'input', value: Array<string>): void
+  (e: 'tag-state', ...args: Array<Array<string>>): void
   (e: 'focus', value: FocusEvent): void
   (e: 'focusin', value: FocusEvent): void
   (e: 'focusout', value: FocusEvent): void
@@ -282,7 +282,7 @@ const onInput = (e: Event | string): void => {
   invalidTags.value = props.tagValidator(value) ? [] : [value]
   duplicateTags.value = isDuplicate.value ? [value] : []
 
-  emit('tag-state', validTags, invalidTags, duplicateTags)
+  emit('tag-state', validTags.value, invalidTags.value, duplicateTags.value)
 }
 
 const onChange = (e: Event): void => {


### PR DESCRIPTION
Tag validator now explicit that it takes t?: string instead of unknown -- it was causing an error. I'm still slightly confused about why the error was happening...
The emits interface is now strongly typed to be `Array<string>` instead of unknowns. 
BFormCheckbox value/unchecked value not includes string, records, and number... I presented that they be removed before, but for some reason it seems to properly work now without any errors and allows "any" values just fine. Instead of explicitly using "any", I figured all those explicit types for _value_ are sufficient enough. 
