### PR TITLE
Removed unnecessary -- and breaking packages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: ['@babel/preset-env'],
-  plugins: [['@babel/transform-runtime']],
-}

--- a/package.json
+++ b/package.json
@@ -39,23 +39,19 @@
     "test:lint": "npm run lint",
     "test:unit": "vitest",
     "publish": "npm publish --tag develop",
-    "release": "standard-version"
+    "prepare": "husky install && npm run build"
   },
   "dependencies": {
-    "core-js": "3.x.x"
+    "vue": "3.x.x"
   },
   "peerDependencies": {
     "bootstrap": "5.x.x"
   },
   "devDependencies": {
-    "@babel/core": "7.x.x",
-    "@babel/plugin-transform-runtime": "7.x.x",
-    "@babel/preset-env": "7.x.x",
     "@types/bootstrap": "5.x.x",
     "@typescript-eslint/eslint-plugin": "5.x.x",
     "@typescript-eslint/parser": "5.x.x",
     "@vitejs/plugin-vue": "2.x.x",
-    "@vue/compiler-sfc": "3.x.x",
     "@vue/eslint-config-typescript": "10.x.x",
     "@vue/test-utils": "^2.0.0-rc.18",
     "eslint": "8.x.x",
@@ -67,14 +63,13 @@
     "jsdom": "^19.0.0",
     "lint-staged": "12.x.x",
     "prettier": "^2.3.2",
+    "release-please": "^13.18.7",
     "rollup-plugin-visualizer": "5.x.x",
     "sass": "1.x.x",
-    "standard-version": "^9.3.2",
     "typescript": "4.x.x",
     "vite": "2.x.x",
     "vite-plugin-dts": "1.x.x",
     "vitest": "^0.10.4",
-    "vue": "3.x.x",
     "vue-router": "4.x.x",
     "vue-tsc": "^0.37.2"
   },


### PR DESCRIPTION
A list of changes and reasoning behind --

standard-version was deprecated and recommended https://github.com/googleapis/release-please for github users instead.

As such, the release script was replaced with a github action demonstrated here https://github.com/marketplace/actions/release-please-action

@vue/compiler-sfc is registered as a direct dependency to Vue , meaning it is no longer required.

Following a brand new "create vite" project, vue was moved as a main dependency. 

Babel and it's surrounding packages was removed. It was causing a bunch of issues with trying to compile Vue code. Babel is not included in a new create vite project, so I figured it could be removed. If one wants to add it back, I believe the best option would be to configure it better - I believe there's a direct plugin "vite-plugin-babel" that would work. 

As removing some of these packages (mainly babel) allows for building the library, the husky prepare script was reintroduced.

In addition, using the release-please package, it seems like the action only fires when using https://www.conventionalcommits.org/en/v1.0.0/ So, it would be beneficial to start using Conventional Commits

After this, I successfully got the library to build 🍾  (I've noticed that other places were able to get them to build... I really just seem to be in an issue where issues I have seen to resolve themselves on their own. My issue was that babel kept saying missing initializer in const declaration. But is it really our responsibility to give legacy code to users?)