### PR TITLE
Alternative fixes to App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2087,8 +2087,8 @@ export default defineComponent({
       )
     }
 
-    const tagValidator = (tag: string | undefined) =>
-      !!tag && tag === tag.toLowerCase() && tag.length > 2 && tag.length < 6
+    const tagValidator = (tag: string) =>
+      tag === tag.toLowerCase() && tag.length > 2 && tag.length < 6
 
     function onTagState(valid: string[], invalid: string[], duplicate: string[]) {
       // console.log({

--- a/src/App.vue
+++ b/src/App.vue
@@ -133,9 +133,9 @@
 
     <h5 class="mt-3">None</h5>
     <b-card>
-      <b-skeleton width="85%"></b-skeleton>
-      <b-skeleton width="55%"></b-skeleton>
-      <b-skeleton width="70%"></b-skeleton>
+      <b-skeleton animation width="85%"></b-skeleton>
+      <b-skeleton animation width="55%"></b-skeleton>
+      <b-skeleton animation width="70%"></b-skeleton>
     </b-card>
     <b-table-simple responsive>
       <b-thead>

--- a/src/components/BFormTags/BFormTags.vue
+++ b/src/components/BFormTags/BFormTags.vue
@@ -141,7 +141,7 @@ interface BFormTagsProps {
   tagPills?: boolean
   tagRemoveLabel?: string
   tagRemovedLabel?: string
-  tagValidator?: (t?: string) => boolean
+  tagValidator?: (t: string) => boolean
   tagVariant?: ColorVariant
 }
 

--- a/src/components/BSkeleton/BSkeleton.vue
+++ b/src/components/BSkeleton/BSkeleton.vue
@@ -23,8 +23,9 @@ const props = withDefaults(defineProps<BSkeletonProps>(), {
 
 const classes = computed(() => [
   `b-skeleton-${props.type}`,
-  `b-skeleton-animate-${props.animation}`,
   {
+    [`b-skeleton-animate-${props.animation}`]:
+      typeof props.animation === 'boolean' ? undefined : props.animation,
     [`bg-${props.variant}`]: props.variant,
   },
 ])

--- a/src/types/SkeletonAnimation.d.ts
+++ b/src/types/SkeletonAnimation.d.ts
@@ -1,3 +1,3 @@
-type SkeletonAnimation = 'wave' | 'fade' | 'throb'
+type SkeletonAnimation = boolean | 'wave' | 'fade' | 'throb'
 
 export default SkeletonAnimation

--- a/src/types/components/BFormTags/BFormTags.d.ts
+++ b/src/types/components/BFormTags/BFormTags.d.ts
@@ -30,7 +30,7 @@ export interface Props {
   tagPills?: boolean
   tagRemoveLabel?: string
   tagRemovedLabel?: string
-  tagValidator?: (t: unknown) => boolean
+  tagValidator?: (t: string) => boolean
   tagVariant?: ColorVariant
 }
 // Emits


### PR DESCRIPTION
@VividLemon I have seen your fixes in App.vue (finally it compiles!), but some errors are easy enough to fix in components:

1. It can be seen from the implementation of BFormTags that the parameter passed to tagValidator cannot be null. So it's probably better to reflect this in the types and not force the user of the library to handle such case.
2. In bootstrap-vue "animation" property of BSkeleton component without value corresponds to no animation https://bootstrap-vue.org/docs/components/skeleton#skeleton-animations. I changed the component and type to reflect this behavior.

Do this changes look good to you?