### PR TITLE
fix(docs): load the component reference inside the plugin

### DIFF
--- a/docs/.vuepress/PluginComponentReference/client.ts
+++ b/docs/.vuepress/PluginComponentReference/client.ts
@@ -1,0 +1,14 @@
+import {defineClientConfig} from '@vuepress/client'
+import ReferenceSection from './client/components/reference-section'
+import {h} from 'vue'
+
+export default defineClientConfig({
+  async enhance({app, router, siteData}) {
+    if (!__VUEPRESS_SSR__) {
+      // wrap the `<ComponentReference />` component with plugin options
+      app.component('ComponentReference', (props) => h(ReferenceSection, {}))
+    }
+  },
+  setup() {},
+  rootComponents: [],
+})

--- a/docs/.vuepress/PluginComponentReference/client/clientAppEnhance.ts
+++ b/docs/.vuepress/PluginComponentReference/client/clientAppEnhance.ts
@@ -1,7 +1,0 @@
-import {h} from 'vue'
-import {defineClientAppEnhance} from '@vuepress/client'
-import ReferenceSection from './components/reference-section'
-export default defineClientAppEnhance(({app}) => {
-  // wrap the `<ComponentReference />` component with plugin options
-  app.component('ComponentReference', (props) => h(ReferenceSection, {}))
-})

--- a/docs/.vuepress/PluginComponentReference/index.ts
+++ b/docs/.vuepress/PluginComponentReference/index.ts
@@ -23,7 +23,7 @@ export const componentReference: Plugin<ComponentReferenceOptions> = ({
   baseDir = 'component-references',
 }) => ({
   name: 'plugin-object',
-  clientAppEnhanceFiles: path.resolve(__dirname, './client/clientAppEnhance.ts'),
+  clientConfigFile: path.resolve(__dirname, './client.ts'),
   extendsPage(page, app: App) {
     const {filePath} = resolvePageComponentReferencePath(baseDir, page, app)
     let componentReference = null

--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -2,7 +2,6 @@ import {defineClientConfig} from '@vuepress/client'
 import 'bootstrap/scss/bootstrap.scss'
 import 'bootstrap-vue-3/dist/bootstrap-vue-3.css'
 import DocReference from './components/DocReference.vue'
-import ReferenceSection from './PluginComponentReference/client/components/reference-section'
 import {h} from 'vue'
 
 export default defineClientConfig({
@@ -12,7 +11,6 @@ export default defineClientConfig({
       app.use(BootstrapVue3)
       app.use(BToastPlugin)
       app.component('doc-reference', DocReference)
-      app.component('ComponentReference', (props) => h(ReferenceSection, {}))
     }
   },
   setup() {},


### PR DESCRIPTION
I created a client config for the client, to load the component, it's linked to 

https://github.com/vuepress/vuepress-next/blob/eb962a057a91142a46a071896de418bc9903c388/CHANGELOG.md#breaking-changes-1

> core: clientAppEnhanceFiles, clientAppRootComponentFiles and clientAppSetupFiles hooks are removed, use clientConfigFile hook instead