### PR TITLE
fix(workflows): release please bot will not update major versions for…

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,4 +10,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: node
-          package-name: release-please-action
+          package-name: package.json
+          bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true


### PR DESCRIPTION
… pre 1.0

Release please bot will now cause minor bumps for breaking changes and patch bumps for feat changes (rather than major/minor respectively)