### PR TITLE
Fix: Missing exposed methods using script setup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2091,11 +2091,11 @@ export default defineComponent({
       tag === tag.toLowerCase() && tag.length > 2 && tag.length < 6
 
     function onTagState(valid: string[], invalid: string[], duplicate: string[]) {
-      // console.log({
-      //   valid,
-      //   invalid,
-      //   duplicate,
-      // })
+      console.log({
+        valid,
+        invalid,
+        duplicate,
+      })
     }
 
     return {

--- a/src/components/BAvatar/BAvatar.vue
+++ b/src/components/BAvatar/BAvatar.vue
@@ -200,7 +200,6 @@ const onImgError = (e: Event): void => emit('img-error', e)
 </script>
 
 <script lang="ts">
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const computeSize = (value: any): string | null => {
   const calcValue = isString(value) && isNumeric(value) ? toFloat(value, 0) : value
   return isNumber(calcValue) ? `${calcValue}px` : calcValue || null

--- a/src/components/BAvatar/BAvatar.vue
+++ b/src/components/BAvatar/BAvatar.vue
@@ -148,13 +148,6 @@ const textClasses = computed<string>(() => {
   return `text-${textVariant}`
 })
 
-const iconName = computed<string | undefined>(() => {
-  // TODO this should work with any icon font, eg icon="fa fa-cogs"
-  if (props.icon) return props.icon
-  if (!props.text && !props.src) return 'person-fill'
-  return undefined
-})
-
 const badgeStyle = computed<StyleValue>(() => {
   const offset = props.badgeOffset || '0px'
   const fontSize =

--- a/src/components/BDropdown/BDropdown.vue
+++ b/src/components/BDropdown/BDropdown.vue
@@ -196,4 +196,8 @@ onMounted((): void => {
     },
   })
 })
+
+defineExpose({
+  hide,
+})
 </script>

--- a/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -60,7 +60,7 @@ interface BFormCheckboxProps {
     | Record<string, unknown>
     | number
   value?: Array<unknown> | Set<unknown> | boolean | string | Record<string, unknown> | number
-  modelValue?: Array<unknown> | Set<unknown> | boolean
+  modelValue?: Array<unknown> | Set<unknown> | boolean | string | Record<string, unknown> | number
 }
 
 const props = withDefaults(defineProps<BFormCheckboxProps>(), {
@@ -93,14 +93,14 @@ const input = ref<HTMLElement>(null as unknown as HTMLElement)
 const isFocused = ref<boolean>(false)
 
 const localValue = computed({
-  get: () => {
+  get: (): unknown[] | Set<unknown> | boolean | undefined => {
     if (props.uncheckedValue) {
       if (!Array.isArray(props.modelValue)) {
         return props.modelValue === props.value
       }
       return props.modelValue.indexOf(props.value) > -1
     }
-    return props.modelValue
+    return props.modelValue as unknown[] | Set<unknown> | boolean | undefined
   },
   set: (newValue: any) => {
     let emitValue = newValue

--- a/src/components/BFormRadio/form-radio.spec.js
+++ b/src/components/BFormRadio/form-radio.spec.js
@@ -795,7 +795,7 @@ describe('form-radio', () => {
     expect(label.classes()).toContain('btn-secondary')
     await input.setValue(true)
     //await input.trigger('click')
-    console.log(label.classes(), wrapper.vm.modelValue)
+    //console.log(label.classes(), wrapper.vm.modelValue)
     expect(label.classes().length).toEqual(3)
     expect(label.classes()).toContain('active')
     expect(label.classes()).toContain('btn')

--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -109,6 +109,7 @@ onActivated(handleAutofocus)
 // /lifecycle events
 
 // computed
+// noinspection PointlessBooleanExpressionJS
 const classes = computed(() => ({
   'form-control': props.plain,
   [`form-control-${props.size}`]: props.size && props.plain,
@@ -126,14 +127,15 @@ const computedSelectSize = computed<number | undefined>(() => {
 })
 
 const computedAriaInvalid = computed<'grammar' | 'spelling' | boolean | undefined>(() => {
-  if (props.state === false) {
-    return true
-  }
-  if (props.state === true) {
+  // noinspection SuspiciousTypeOfGuard
+  if (typeof props.state === 'boolean') {
+    if (!props.state) {
+      return true
+    }
     return undefined
   }
   if (typeof props.ariaInvalid === 'boolean') {
-    if (props.ariaInvalid === false) {
+    if (!props.ariaInvalid) {
       return undefined
     }
     return props.ariaInvalid

--- a/src/components/BFormSelect/BFormSelect.vue
+++ b/src/components/BFormSelect/BFormSelect.vue
@@ -169,4 +169,9 @@ const blur = () => {
   }
 }
 // /methods
+
+defineExpose({
+  blur,
+  focus,
+})
 </script>

--- a/src/components/BFormSelect/form-select-option.spec.js
+++ b/src/components/BFormSelect/form-select-option.spec.js
@@ -1,6 +1,6 @@
 import {mount} from '@vue/test-utils'
 import BFormSelectOption from './BFormSelectOption.vue'
-import {describe, expect, it, vitest} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 describe('form-select-option', () => {
   it('has expected default structure', async () => {

--- a/src/components/BFormTags/form-tag.spec.js
+++ b/src/components/BFormTags/form-tag.spec.js
@@ -1,6 +1,6 @@
 import {mount} from '@vue/test-utils'
 import BFormTag from './BFormTag.vue'
-import {describe, expect, it, vitest} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 describe('form-tag', () => {
   it('has expected structure', async () => {

--- a/src/components/BLink/link.spec.js
+++ b/src/components/BLink/link.spec.js
@@ -1,5 +1,5 @@
 import {mount} from '@vue/test-utils'
-import {createContainer} from '../../../tests/utils'
+//import {createContainer} from '../../../tests/utils'
 import BLink from './BLink.vue'
 import {describe, expect, it, vitest} from 'vitest'
 

--- a/src/components/BListGroup/list-group-item.spec.js
+++ b/src/components/BListGroup/list-group-item.spec.js
@@ -1,7 +1,7 @@
 import {mount} from '@vue/test-utils'
 import BListGroup from './BListGroup.vue'
 import BListGroupItem from './BListGroupItem.vue'
-import {describe, expect, it, vitest} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 describe('list-group > list-group-item', () => {
   it('default should have tag div', async () => {

--- a/src/components/BListGroup/list-group.spec.js
+++ b/src/components/BListGroup/list-group.spec.js
@@ -1,6 +1,6 @@
 import {mount} from '@vue/test-utils'
 import BListGroup from './BListGroup.vue'
-import {describe, expect, it, vitest} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 describe('list-group', () => {
   it('default should have tag div', async () => {

--- a/src/components/BPagination/BPagination.vue
+++ b/src/components/BPagination/BPagination.vue
@@ -75,7 +75,7 @@ export default defineComponent({
     )
 
     const startNumber = computed(() => {
-      let lStartNumber = 1
+      let lStartNumber: number
       const pagesLeft: number = numberOfPages.value - props.modelValue
 
       if (pagesLeft + 2 < props.limit && props.limit > ELLIPSIS_THRESHOLD) {
@@ -153,21 +153,6 @@ export default defineComponent({
         }
       }
 
-      return n
-    })
-
-    const pageNumberfinal = computed(() => {
-      let n: number = numberOfLinks.value
-
-      if (showFirstDots.value && props.firstNumber && startNumber.value < 4) {
-        n = n + 2
-      }
-      const lastPageNumber = startNumber.value + n - 1
-
-      if (showLastDots.value && props.lastNumber && lastPageNumber > numberOfPages.value - 3) {
-        n = n + (lastPageNumber === numberOfPages.value - 2 ? 2 : 3)
-      }
-      n = Math.min(n, numberOfPages.value - startNumber.value + 1)
       return n
     })
 
@@ -474,7 +459,8 @@ export default defineComponent({
         buttons.push(gotoLastPageButton)
       }
 
-      const $pagination = h(
+      //pagination
+      return h(
         'ul',
         {
           'class': ['pagination', btnSize.value, alignment.value, styleClass.value],
@@ -484,7 +470,6 @@ export default defineComponent({
         },
         buttons
       )
-      return $pagination
     }
   },
 })

--- a/src/components/BToast/BToast.vue
+++ b/src/components/BToast/BToast.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     let resumeDismiss: number
 
     const clearDismissTimer = () => {
-      if (dismissTimer === undefined) return
+      if (typeof dismissTimer === 'undefined') return
       clearTimeout(dismissTimer)
       dismissTimer = undefined
     }
@@ -121,14 +121,6 @@ export default defineComponent({
       startDismissTimer()
     }
 
-    const toggle = () => {
-      if (props.modelValue) {
-        hide()
-      } else {
-        show()
-      }
-    }
-
     watch(
       () => props.modelValue,
       (newValue) => {
@@ -165,15 +157,8 @@ export default defineComponent({
       emit('update:modelValue', false)
     }
 
-    const transitionHandlers = computed(() => ({
-      OnBeforeEnter,
-      OnAfterEnter,
-      OnBeforeLeave,
-      OnAfterLeave,
-    }))
-
     onUnmounted(() => {
-      //if there is time left on autohide or no autohide then keep toast alive
+      //if there is time left on autoHide or no autoHide then keep toast alive
       clearDismissTimer()
       if (!props.autoHide) {
         return
@@ -255,7 +240,8 @@ export default defineComponent({
           $innertoast
         )
       }
-      const $toast = h(
+      //toast
+      return h(
         'div',
         {
           'class': ['b-toast'],
@@ -280,8 +266,6 @@ export default defineComponent({
           ),
         ]
       )
-
-      return $toast
     }
   },
 })

--- a/src/components/BToast/b-toast.spec.js
+++ b/src/components/BToast/b-toast.spec.js
@@ -1,6 +1,6 @@
 import {mount} from '@vue/test-utils'
 import {waitNT, waitRAF} from '../../../tests/utils'
-import {describe, expect, it, vitest} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 import BToast from './BToast.vue'
 


### PR DESCRIPTION
Hi all,

I review the warnings reported by eslint, and I found that we transform some templates into script setup and we didn't expose some methods.

And also I clean up the rest of warnings.
In src/components/BFormCheckbox/BFormCheckbox.vue I guess the modelValue should have the same values as value, before the script setup tranformation was equal. I guess it was removed some because the <input type="checkbox"> was complaining about using string type, that's why I put a manual casting and return type definition for localValue  computed.


Last point, I review the warnings from test running (there it's where I found the warning from BFormCheckbox.ue) and the test are giving a false positive warning:

```
stderr | src/components/BListGroup/list-group.spec.js > list-group > should have class list-group-horizontal-md when prop horizontal=md                   
[Vue warn]: Invalid prop: type check failed for prop "horizontal". Expected Boolean | Null, got String with value "md".                                   
  at <BListGroup horizontal="md" ref="VTU_COMPONENT" >                                                                                                    
  at <VTUROOT>                                                                                                                                            
                                                                                                                                                          
stderr | src/components/BListGroup/list-group.spec.js > list-group > should not have class list-group-horizontal-lg when prop horizontal=lg and flush=true
[Vue warn]: Invalid prop: type check failed for prop "horizontal". Expected Boolean | Null, got String with value "lg".                                   
  at <BListGroup horizontal="lg" flush=true ref="VTU_COMPONENT" >                                                                                         
  at <VTUROOT>     
```

This warning should not happen, horizontal property could be boolean, closed list of strings or undefined.