### PR TITLE
fix(BCardBody): subTitleTag typo fix

### DIFF
--- a/src/components/BCard/BCardBody.vue
+++ b/src/components/BCard/BCardBody.vue
@@ -35,6 +35,7 @@ const props = withDefaults(defineProps<BCardBodyProps>(), {
   bodyTag: 'div',
   overlay: false,
   titleTag: 'h4',
+  subTitleTag: 'h4',
 })
 
 const classes = computed(() => ({


### PR DESCRIPTION
The previous #471 was supposed to be subTitleTag, rather than removed outright