### PR TITLE
ci(workflow): runs npm i instead of ci

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
+      - run: npm install
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:


### PR DESCRIPTION
Bot was failing to use npm ci due to docs repo inside.