### PR TITLE
Chore/tsconfig vuepress

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@vuepress/client/types", "vite/client"]
+  },
+  "include": ["./**/*.ts", "./**/*.vue", ".vuepress/**/*.ts", ".vuepress/**/*.vue"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,10 @@
     "docs": {
       "version": "1.0.0",
       "devDependencies": {
-        "@vuepress/plugin-search": "^2.0.0-beta.41",
+        "@vuepress/plugin-register-components": "^2.0.0-beta.48",
+        "@vuepress/plugin-search": "^2.0.0-beta.48",
         "bootstrap-vue-3": "file:../",
-        "vuepress": "^2.0.0-beta.41"
+        "vuepress": "^2.0.0-beta.48"
       },
       "peerDependencies": {
         "bootstrap": "5.x.x"
@@ -351,6 +352,92 @@
       "engines": {
         "node": ">= 10.18.0"
       }
+    },
+    "node_modules/@mdit-vue/plugin-component": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-component/-/plugin-component-0.6.0.tgz",
+      "integrity": "sha512-S/Dd0eoOipbUAMdJ6A7M20dDizJxbtGAcL6T1iiJ0cEzjTrHP1kRT421+JMGPL8gcdsrIxgVSW8bI/R6laqBtA==",
+      "dev": true,
+      "dependencies": {
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-frontmatter": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-0.6.0.tgz",
+      "integrity": "sha512-cRunxy0q1gcqxUHAAiV8hMKh2qZOTDKXt8YOWfWNtf7IzaAL0v/nCOfh+O7AsHRmyc25Th8sL3H85HKWnNJtdw==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-headers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-headers/-/plugin-headers-0.6.0.tgz",
+      "integrity": "sha512-pg56w9/UooYuIZIoM0iQ021hrXt450fuRG3duxcwngw3unmE80rkvG3C0lT9ZnNXHSSYC9vGWUJh6EEN4nB34A==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/shared": "0.6.0",
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-sfc": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-sfc/-/plugin-sfc-0.6.0.tgz",
+      "integrity": "sha512-R7mwUz2MxEopVQwpcOqCcqqvKx3ibRNcZ7QC31w4VblRb3Srk1st1UuGwHJxZ6Biro8ZWdPpMfpSsSk+2G+mIg==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-title": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-title/-/plugin-title-0.6.0.tgz",
+      "integrity": "sha512-K2qUIrHmCp9w+/p1lWfkr808+Ge6FksM1ny/siiXHMHB0enArUd7G7SaEtro8JRb/hewd9qKq5xTOSWN2Q5jow==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/shared": "0.6.0",
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-toc": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-toc/-/plugin-toc-0.6.0.tgz",
+      "integrity": "sha512-5pgKY2++3w2/9Pqpgz7mZUiXs6jDcEyFPcf14QdiqSZ2eL+4VLuupcoC4JIDF+mAFHt+TJCfhk3oeG8Y6s6TBg==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/shared": "0.6.0",
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/shared": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-0.6.0.tgz",
+      "integrity": "sha512-RtV1P8jrEV/cl0WckOvpefiEWScw7omCQrIEtorlagG2XmnI9YbxMkLD53ETscA7lTVzqhGyzfoSrAiPi0Sjnw==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "node_modules/@mdit-vue/types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/types/-/types-0.6.0.tgz",
+      "integrity": "sha512-2Gf6MkEmoHrvO/IJsz48T+Ns9lW17ReC1vdhtCUGSCv0fFCm/L613uu/hpUrHuT3jTQHP90LcbXTQB2w4L1G8w==",
+      "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.28.3",
@@ -823,6 +910,15 @@
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/markdown-it-emoji": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
+      "integrity": "sha512-2ln8Wjbcj/0oRi/6VnuMeWEHHuK8uapFttvcLmDIe1GKCsFBLOLBX+D+xhDa9oWOQV0IpvxwrSfKKssAqqroog==",
+      "dev": true,
+      "dependencies": {
+        "@types/markdown-it": "*"
       }
     },
     "node_modules/@types/mdurl": {
@@ -1453,6 +1549,93 @@
       "dependencies": {
         "@vuepress/core": "2.0.0-beta.48",
         "prismjs": "^1.28.0"
+      }
+    },
+    "node_modules/@vuepress/plugin-register-components": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-2.0.0-beta.49.tgz",
+      "integrity": "sha512-OYnsLazh5f3ldwdh/qT8rdVjqMEh7eOiGrwucGRvlUwuQ71CE51OUrK6qIOaGZ5gkwmamYcAwLF37bs5lyZ+oA==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/core": "2.0.0-beta.49",
+        "@vuepress/utils": "2.0.0-beta.49",
+        "chokidar": "^3.5.3"
+      }
+    },
+    "node_modules/@vuepress/plugin-register-components/node_modules/@vuepress/client": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.49.tgz",
+      "integrity": "sha512-zfGlCAF/LwDOrZXZPqADsMgWRuH/2GFOGSOCvt7ZUZHnSrYBdK2FOez/ksWL8EwGNLsRLB8ny1IachMwTew5og==",
+      "dev": true,
+      "dependencies": {
+        "@vue/devtools-api": "^6.2.0",
+        "@vuepress/shared": "2.0.0-beta.49",
+        "vue": "^3.2.37",
+        "vue-router": "^4.1.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-register-components/node_modules/@vuepress/core": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.49.tgz",
+      "integrity": "sha512-40J74qGOPqF9yGdXdzPD1kW9mv5/jfJenmhsH1xaErPsr6qIM8jcraVRC+R7NoVTIecRk9cC9MJcDRnLmDDiAg==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/client": "2.0.0-beta.49",
+        "@vuepress/markdown": "2.0.0-beta.49",
+        "@vuepress/shared": "2.0.0-beta.49",
+        "@vuepress/utils": "2.0.0-beta.49",
+        "vue": "^3.2.37"
+      }
+    },
+    "node_modules/@vuepress/plugin-register-components/node_modules/@vuepress/markdown": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.49.tgz",
+      "integrity": "sha512-aAw41NArV5leIpZOFmElxzRG29LDdEQe7oIcZtIvKPhVmEfg9/mgx4ea2OqY5DaBvEhkG42SojjKvmHiJKrwJw==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/plugin-component": "^0.6.0",
+        "@mdit-vue/plugin-frontmatter": "^0.6.0",
+        "@mdit-vue/plugin-headers": "^0.6.0",
+        "@mdit-vue/plugin-sfc": "^0.6.0",
+        "@mdit-vue/plugin-title": "^0.6.0",
+        "@mdit-vue/plugin-toc": "^0.6.0",
+        "@mdit-vue/shared": "^0.6.0",
+        "@mdit-vue/types": "^0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it-emoji": "^2.0.2",
+        "@vuepress/shared": "2.0.0-beta.49",
+        "@vuepress/utils": "2.0.0-beta.49",
+        "markdown-it": "^13.0.1",
+        "markdown-it-anchor": "^8.6.4",
+        "markdown-it-emoji": "^2.0.2",
+        "mdurl": "^1.0.1"
+      }
+    },
+    "node_modules/@vuepress/plugin-register-components/node_modules/@vuepress/shared": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.49.tgz",
+      "integrity": "sha512-yoUgOtRUrIfe0O1HMTIMj0NYU3tAiUZ4rwVEtemtGa7/RK7qIZdBpAfv08Ve2CUpa3wrMb1Pux1aBsiz1EQx+g==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "^3.2.37"
+      }
+    },
+    "node_modules/@vuepress/plugin-register-components/node_modules/@vuepress/utils": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.49.tgz",
+      "integrity": "sha512-t5i0V9FqpKLGlu2kMP/Y9+wdgEmsD2yQAMGojxpMoFhJBmqn2L9Rkk4WYzHKzPGDkm1KbBFzYQqjAhZQ7xtY1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "@types/fs-extra": "^9.0.13",
+        "@vuepress/shared": "2.0.0-beta.49",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "globby": "^11.0.4",
+        "hash-sum": "^2.0.0",
+        "ora": "^5.4.1",
+        "upath": "^2.0.1"
       }
     },
     "node_modules/@vuepress/plugin-search": {
@@ -7396,9 +7579,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.1.tgz",
-      "integrity": "sha512-Wp1mEf2xCwT0ez7o9JvgpfBp9JGnVb+dPERzXDbugTatzJAJ60VWOhJKifQty85k+jOreoFHER4r5fu062PhPw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
       "dev": true,
       "dependencies": {
         "@vue/devtools-api": "^6.1.4"
@@ -8107,6 +8290,92 @@
         "npmlog": "^4.1.2"
       }
     },
+    "@mdit-vue/plugin-component": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-component/-/plugin-component-0.6.0.tgz",
+      "integrity": "sha512-S/Dd0eoOipbUAMdJ6A7M20dDizJxbtGAcL6T1iiJ0cEzjTrHP1kRT421+JMGPL8gcdsrIxgVSW8bI/R6laqBtA==",
+      "dev": true,
+      "requires": {
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/plugin-frontmatter": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-0.6.0.tgz",
+      "integrity": "sha512-cRunxy0q1gcqxUHAAiV8hMKh2qZOTDKXt8YOWfWNtf7IzaAL0v/nCOfh+O7AsHRmyc25Th8sL3H85HKWnNJtdw==",
+      "dev": true,
+      "requires": {
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/plugin-headers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-headers/-/plugin-headers-0.6.0.tgz",
+      "integrity": "sha512-pg56w9/UooYuIZIoM0iQ021hrXt450fuRG3duxcwngw3unmE80rkvG3C0lT9ZnNXHSSYC9vGWUJh6EEN4nB34A==",
+      "dev": true,
+      "requires": {
+        "@mdit-vue/shared": "0.6.0",
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/plugin-sfc": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-sfc/-/plugin-sfc-0.6.0.tgz",
+      "integrity": "sha512-R7mwUz2MxEopVQwpcOqCcqqvKx3ibRNcZ7QC31w4VblRb3Srk1st1UuGwHJxZ6Biro8ZWdPpMfpSsSk+2G+mIg==",
+      "dev": true,
+      "requires": {
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/plugin-title": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-title/-/plugin-title-0.6.0.tgz",
+      "integrity": "sha512-K2qUIrHmCp9w+/p1lWfkr808+Ge6FksM1ny/siiXHMHB0enArUd7G7SaEtro8JRb/hewd9qKq5xTOSWN2Q5jow==",
+      "dev": true,
+      "requires": {
+        "@mdit-vue/shared": "0.6.0",
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/plugin-toc": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-toc/-/plugin-toc-0.6.0.tgz",
+      "integrity": "sha512-5pgKY2++3w2/9Pqpgz7mZUiXs6jDcEyFPcf14QdiqSZ2eL+4VLuupcoC4JIDF+mAFHt+TJCfhk3oeG8Y6s6TBg==",
+      "dev": true,
+      "requires": {
+        "@mdit-vue/shared": "0.6.0",
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/shared": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-0.6.0.tgz",
+      "integrity": "sha512-RtV1P8jrEV/cl0WckOvpefiEWScw7omCQrIEtorlagG2XmnI9YbxMkLD53ETscA7lTVzqhGyzfoSrAiPi0Sjnw==",
+      "dev": true,
+      "requires": {
+        "@mdit-vue/types": "0.6.0",
+        "@types/markdown-it": "^12.2.3",
+        "markdown-it": "^13.0.1"
+      }
+    },
+    "@mdit-vue/types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/types/-/types-0.6.0.tgz",
+      "integrity": "sha512-2Gf6MkEmoHrvO/IJsz48T+Ns9lW17ReC1vdhtCUGSCv0fFCm/L613uu/hpUrHuT3jTQHP90LcbXTQB2w4L1G8w==",
+      "dev": true
+    },
     "@microsoft/api-extractor": {
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.28.3.tgz",
@@ -8538,6 +8807,15 @@
       "requires": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
+      }
+    },
+    "@types/markdown-it-emoji": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
+      "integrity": "sha512-2ln8Wjbcj/0oRi/6VnuMeWEHHuK8uapFttvcLmDIe1GKCsFBLOLBX+D+xhDa9oWOQV0IpvxwrSfKKssAqqroog==",
+      "dev": true,
+      "requires": {
+        "@types/markdown-it": "*"
       }
     },
     "@types/mdurl": {
@@ -9058,6 +9336,95 @@
       "requires": {
         "@vuepress/core": "2.0.0-beta.48",
         "prismjs": "^1.28.0"
+      }
+    },
+    "@vuepress/plugin-register-components": {
+      "version": "2.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-2.0.0-beta.49.tgz",
+      "integrity": "sha512-OYnsLazh5f3ldwdh/qT8rdVjqMEh7eOiGrwucGRvlUwuQ71CE51OUrK6qIOaGZ5gkwmamYcAwLF37bs5lyZ+oA==",
+      "dev": true,
+      "requires": {
+        "@vuepress/core": "2.0.0-beta.49",
+        "@vuepress/utils": "2.0.0-beta.49",
+        "chokidar": "^3.5.3"
+      },
+      "dependencies": {
+        "@vuepress/client": {
+          "version": "2.0.0-beta.49",
+          "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.49.tgz",
+          "integrity": "sha512-zfGlCAF/LwDOrZXZPqADsMgWRuH/2GFOGSOCvt7ZUZHnSrYBdK2FOez/ksWL8EwGNLsRLB8ny1IachMwTew5og==",
+          "dev": true,
+          "requires": {
+            "@vue/devtools-api": "^6.2.0",
+            "@vuepress/shared": "2.0.0-beta.49",
+            "vue": "^3.2.37",
+            "vue-router": "^4.1.2"
+          }
+        },
+        "@vuepress/core": {
+          "version": "2.0.0-beta.49",
+          "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.49.tgz",
+          "integrity": "sha512-40J74qGOPqF9yGdXdzPD1kW9mv5/jfJenmhsH1xaErPsr6qIM8jcraVRC+R7NoVTIecRk9cC9MJcDRnLmDDiAg==",
+          "dev": true,
+          "requires": {
+            "@vuepress/client": "2.0.0-beta.49",
+            "@vuepress/markdown": "2.0.0-beta.49",
+            "@vuepress/shared": "2.0.0-beta.49",
+            "@vuepress/utils": "2.0.0-beta.49",
+            "vue": "^3.2.37"
+          }
+        },
+        "@vuepress/markdown": {
+          "version": "2.0.0-beta.49",
+          "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.49.tgz",
+          "integrity": "sha512-aAw41NArV5leIpZOFmElxzRG29LDdEQe7oIcZtIvKPhVmEfg9/mgx4ea2OqY5DaBvEhkG42SojjKvmHiJKrwJw==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/plugin-component": "^0.6.0",
+            "@mdit-vue/plugin-frontmatter": "^0.6.0",
+            "@mdit-vue/plugin-headers": "^0.6.0",
+            "@mdit-vue/plugin-sfc": "^0.6.0",
+            "@mdit-vue/plugin-title": "^0.6.0",
+            "@mdit-vue/plugin-toc": "^0.6.0",
+            "@mdit-vue/shared": "^0.6.0",
+            "@mdit-vue/types": "^0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "@types/markdown-it-emoji": "^2.0.2",
+            "@vuepress/shared": "2.0.0-beta.49",
+            "@vuepress/utils": "2.0.0-beta.49",
+            "markdown-it": "^13.0.1",
+            "markdown-it-anchor": "^8.6.4",
+            "markdown-it-emoji": "^2.0.2",
+            "mdurl": "^1.0.1"
+          }
+        },
+        "@vuepress/shared": {
+          "version": "2.0.0-beta.49",
+          "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.49.tgz",
+          "integrity": "sha512-yoUgOtRUrIfe0O1HMTIMj0NYU3tAiUZ4rwVEtemtGa7/RK7qIZdBpAfv08Ve2CUpa3wrMb1Pux1aBsiz1EQx+g==",
+          "dev": true,
+          "requires": {
+            "@vue/shared": "^3.2.37"
+          }
+        },
+        "@vuepress/utils": {
+          "version": "2.0.0-beta.49",
+          "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.49.tgz",
+          "integrity": "sha512-t5i0V9FqpKLGlu2kMP/Y9+wdgEmsD2yQAMGojxpMoFhJBmqn2L9Rkk4WYzHKzPGDkm1KbBFzYQqjAhZQ7xtY1A==",
+          "dev": true,
+          "requires": {
+            "@types/debug": "^4.1.7",
+            "@types/fs-extra": "^9.0.13",
+            "@vuepress/shared": "2.0.0-beta.49",
+            "chalk": "^4.1.2",
+            "debug": "^4.3.4",
+            "fs-extra": "^10.1.0",
+            "globby": "^11.0.4",
+            "hash-sum": "^2.0.0",
+            "ora": "^5.4.1",
+            "upath": "^2.0.1"
+          }
+        }
       }
     },
     "@vuepress/plugin-search": {
@@ -9707,6 +10074,92 @@
             "npmlog": "^4.1.2"
           }
         },
+        "@mdit-vue/plugin-component": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-component/-/plugin-component-0.6.0.tgz",
+          "integrity": "sha512-S/Dd0eoOipbUAMdJ6A7M20dDizJxbtGAcL6T1iiJ0cEzjTrHP1kRT421+JMGPL8gcdsrIxgVSW8bI/R6laqBtA==",
+          "dev": true,
+          "requires": {
+            "@types/markdown-it": "^12.2.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/plugin-frontmatter": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-0.6.0.tgz",
+          "integrity": "sha512-cRunxy0q1gcqxUHAAiV8hMKh2qZOTDKXt8YOWfWNtf7IzaAL0v/nCOfh+O7AsHRmyc25Th8sL3H85HKWnNJtdw==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/types": "0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "gray-matter": "^4.0.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/plugin-headers": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-headers/-/plugin-headers-0.6.0.tgz",
+          "integrity": "sha512-pg56w9/UooYuIZIoM0iQ021hrXt450fuRG3duxcwngw3unmE80rkvG3C0lT9ZnNXHSSYC9vGWUJh6EEN4nB34A==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/shared": "0.6.0",
+            "@mdit-vue/types": "0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/plugin-sfc": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-sfc/-/plugin-sfc-0.6.0.tgz",
+          "integrity": "sha512-R7mwUz2MxEopVQwpcOqCcqqvKx3ibRNcZ7QC31w4VblRb3Srk1st1UuGwHJxZ6Biro8ZWdPpMfpSsSk+2G+mIg==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/types": "0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/plugin-title": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-title/-/plugin-title-0.6.0.tgz",
+          "integrity": "sha512-K2qUIrHmCp9w+/p1lWfkr808+Ge6FksM1ny/siiXHMHB0enArUd7G7SaEtro8JRb/hewd9qKq5xTOSWN2Q5jow==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/shared": "0.6.0",
+            "@mdit-vue/types": "0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/plugin-toc": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-toc/-/plugin-toc-0.6.0.tgz",
+          "integrity": "sha512-5pgKY2++3w2/9Pqpgz7mZUiXs6jDcEyFPcf14QdiqSZ2eL+4VLuupcoC4JIDF+mAFHt+TJCfhk3oeG8Y6s6TBg==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/shared": "0.6.0",
+            "@mdit-vue/types": "0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/shared": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-0.6.0.tgz",
+          "integrity": "sha512-RtV1P8jrEV/cl0WckOvpefiEWScw7omCQrIEtorlagG2XmnI9YbxMkLD53ETscA7lTVzqhGyzfoSrAiPi0Sjnw==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/types": "0.6.0",
+            "@types/markdown-it": "^12.2.3",
+            "markdown-it": "^13.0.1"
+          }
+        },
+        "@mdit-vue/types": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@mdit-vue/types/-/types-0.6.0.tgz",
+          "integrity": "sha512-2Gf6MkEmoHrvO/IJsz48T+Ns9lW17ReC1vdhtCUGSCv0fFCm/L613uu/hpUrHuT3jTQHP90LcbXTQB2w4L1G8w==",
+          "dev": true
+        },
         "@microsoft/api-extractor": {
           "version": "7.28.3",
           "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.28.3.tgz",
@@ -10138,6 +10591,15 @@
           "requires": {
             "@types/linkify-it": "*",
             "@types/mdurl": "*"
+          }
+        },
+        "@types/markdown-it-emoji": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@types/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
+          "integrity": "sha512-2ln8Wjbcj/0oRi/6VnuMeWEHHuK8uapFttvcLmDIe1GKCsFBLOLBX+D+xhDa9oWOQV0IpvxwrSfKKssAqqroog==",
+          "dev": true,
+          "requires": {
+            "@types/markdown-it": "*"
           }
         },
         "@types/mdurl": {
@@ -10658,6 +11120,95 @@
           "requires": {
             "@vuepress/core": "2.0.0-beta.48",
             "prismjs": "^1.28.0"
+          }
+        },
+        "@vuepress/plugin-register-components": {
+          "version": "2.0.0-beta.49",
+          "resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-2.0.0-beta.49.tgz",
+          "integrity": "sha512-OYnsLazh5f3ldwdh/qT8rdVjqMEh7eOiGrwucGRvlUwuQ71CE51OUrK6qIOaGZ5gkwmamYcAwLF37bs5lyZ+oA==",
+          "dev": true,
+          "requires": {
+            "@vuepress/core": "2.0.0-beta.49",
+            "@vuepress/utils": "2.0.0-beta.49",
+            "chokidar": "^3.5.3"
+          },
+          "dependencies": {
+            "@vuepress/client": {
+              "version": "2.0.0-beta.49",
+              "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.49.tgz",
+              "integrity": "sha512-zfGlCAF/LwDOrZXZPqADsMgWRuH/2GFOGSOCvt7ZUZHnSrYBdK2FOez/ksWL8EwGNLsRLB8ny1IachMwTew5og==",
+              "dev": true,
+              "requires": {
+                "@vue/devtools-api": "^6.2.0",
+                "@vuepress/shared": "2.0.0-beta.49",
+                "vue": "^3.2.37",
+                "vue-router": "^4.1.2"
+              }
+            },
+            "@vuepress/core": {
+              "version": "2.0.0-beta.49",
+              "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.49.tgz",
+              "integrity": "sha512-40J74qGOPqF9yGdXdzPD1kW9mv5/jfJenmhsH1xaErPsr6qIM8jcraVRC+R7NoVTIecRk9cC9MJcDRnLmDDiAg==",
+              "dev": true,
+              "requires": {
+                "@vuepress/client": "2.0.0-beta.49",
+                "@vuepress/markdown": "2.0.0-beta.49",
+                "@vuepress/shared": "2.0.0-beta.49",
+                "@vuepress/utils": "2.0.0-beta.49",
+                "vue": "^3.2.37"
+              }
+            },
+            "@vuepress/markdown": {
+              "version": "2.0.0-beta.49",
+              "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.49.tgz",
+              "integrity": "sha512-aAw41NArV5leIpZOFmElxzRG29LDdEQe7oIcZtIvKPhVmEfg9/mgx4ea2OqY5DaBvEhkG42SojjKvmHiJKrwJw==",
+              "dev": true,
+              "requires": {
+                "@mdit-vue/plugin-component": "^0.6.0",
+                "@mdit-vue/plugin-frontmatter": "^0.6.0",
+                "@mdit-vue/plugin-headers": "^0.6.0",
+                "@mdit-vue/plugin-sfc": "^0.6.0",
+                "@mdit-vue/plugin-title": "^0.6.0",
+                "@mdit-vue/plugin-toc": "^0.6.0",
+                "@mdit-vue/shared": "^0.6.0",
+                "@mdit-vue/types": "^0.6.0",
+                "@types/markdown-it": "^12.2.3",
+                "@types/markdown-it-emoji": "^2.0.2",
+                "@vuepress/shared": "2.0.0-beta.49",
+                "@vuepress/utils": "2.0.0-beta.49",
+                "markdown-it": "^13.0.1",
+                "markdown-it-anchor": "^8.6.4",
+                "markdown-it-emoji": "^2.0.2",
+                "mdurl": "^1.0.1"
+              }
+            },
+            "@vuepress/shared": {
+              "version": "2.0.0-beta.49",
+              "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.49.tgz",
+              "integrity": "sha512-yoUgOtRUrIfe0O1HMTIMj0NYU3tAiUZ4rwVEtemtGa7/RK7qIZdBpAfv08Ve2CUpa3wrMb1Pux1aBsiz1EQx+g==",
+              "dev": true,
+              "requires": {
+                "@vue/shared": "^3.2.37"
+              }
+            },
+            "@vuepress/utils": {
+              "version": "2.0.0-beta.49",
+              "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.49.tgz",
+              "integrity": "sha512-t5i0V9FqpKLGlu2kMP/Y9+wdgEmsD2yQAMGojxpMoFhJBmqn2L9Rkk4WYzHKzPGDkm1KbBFzYQqjAhZQ7xtY1A==",
+              "dev": true,
+              "requires": {
+                "@types/debug": "^4.1.7",
+                "@types/fs-extra": "^9.0.13",
+                "@vuepress/shared": "2.0.0-beta.49",
+                "chalk": "^4.1.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^10.1.0",
+                "globby": "^11.0.4",
+                "hash-sum": "^2.0.0",
+                "ora": "^5.4.1",
+                "upath": "^2.0.1"
+              }
+            }
           }
         },
         "@vuepress/plugin-search": {
@@ -11654,9 +12205,10 @@
         "docs": {
           "version": "file:docs",
           "requires": {
-            "@vuepress/plugin-search": "^2.0.0-beta.41",
+            "@vuepress/plugin-register-components": "^2.0.0-beta.48",
+            "@vuepress/plugin-search": "^2.0.0-beta.48",
             "bootstrap-vue-3": "file:..",
-            "vuepress": "^2.0.0-beta.41"
+            "vuepress": "^2.0.0-beta.48"
           }
         },
         "doctrine": {
@@ -14919,9 +15471,9 @@
           }
         },
         "vue-router": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.1.tgz",
-          "integrity": "sha512-Wp1mEf2xCwT0ez7o9JvgpfBp9JGnVb+dPERzXDbugTatzJAJ60VWOhJKifQty85k+jOreoFHER4r5fu062PhPw==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+          "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
           "dev": true,
           "requires": {
             "@vue/devtools-api": "^6.1.4"
@@ -15894,9 +16446,10 @@
     "docs": {
       "version": "file:docs",
       "requires": {
-        "@vuepress/plugin-search": "^2.0.0-beta.41",
+        "@vuepress/plugin-register-components": "^2.0.0-beta.48",
+        "@vuepress/plugin-search": "^2.0.0-beta.48",
         "bootstrap-vue-3": "file:..",
-        "vuepress": "^2.0.0-beta.41"
+        "vuepress": "^2.0.0-beta.48"
       }
     },
     "doctrine": {
@@ -19159,9 +19712,9 @@
       }
     },
     "vue-router": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.1.tgz",
-      "integrity": "sha512-Wp1mEf2xCwT0ez7o9JvgpfBp9JGnVb+dPERzXDbugTatzJAJ60VWOhJKifQty85k+jOreoFHER4r5fu062PhPw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.2.tgz",
+      "integrity": "sha512-5BP1qXFncVRwgV/XnqzsKApdMjQPqWIpoUBdL1ynz8HyLxIX/UDAx7Ql2BjmA5CXT/p61JfZvkpiFWFpaqcfag==",
       "dev": true,
       "requires": {
         "@vue/devtools-api": "^6.1.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "baseUrl": ".",
-    "types": ["vitest/globals", "@vuepress/client/types", "vite/client"],
+    "types": ["vitest/globals", "vite/client"],
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx"],


### PR DESCRIPTION
To avoid errors like that, https://github.com/cdmoro/bootstrap-vue-3/runs/7303991400?check_suite_focus=true

```
TS2688: Cannot find type definition file for '@vuepress/client/types'.
  The file is in the program because:
    Entry point of type library '@vuepress/client/types' specified in compilerOptions
```

I moved the specific '@vuepress/client/types' typing to `./docs`

I updated also the `package-lock.json`