### PR TITLE
chore: update release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,9 @@ jobs:
         # these if statements ensure that a publication only occurs when
         # a new release is created:
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm install


### PR DESCRIPTION
I'm uncertain why the bot would fail it's last pr. Perhaps it has something to do with this. @mariusa are you able to simply do a manual release to npm for now while we wait to see if this works? (oddly I'm getting a similar issue with pnpm not installing peers...)