### PR TITLE
refactor: remove extraneous import

### DIFF
--- a/docs/.vuepress/PluginComponentReference/client/components/component-doc.vue
+++ b/docs/.vuepress/PluginComponentReference/client/components/component-doc.vue
@@ -85,7 +85,7 @@
 <script lang="ts">
 import {resolveComponent, defineComponent, computed, ComputedRef, ConcreteComponent} from 'vue'
 import AnchoredHeading from './anchored-heading'
-import {hyphenate} from '@vue/shared/'
+import {hyphenate} from '../../../util'
 // type definitions
 const SORT_THRESHOLD: number = 10
 

--- a/docs/.vuepress/util/hyphenate.ts
+++ b/docs/.vuepress/util/hyphenate.ts
@@ -1,0 +1,1 @@
+export default (str: string) => str.replace(/\B([A-Z])/g, '-$1').toLowerCase()

--- a/docs/.vuepress/util/index.ts
+++ b/docs/.vuepress/util/index.ts
@@ -1,0 +1,1 @@
+export {default as hyphenate} from './hyphenate'


### PR DESCRIPTION
@vue/shared is not included in the docs direct dependencies, causing an extraneous dependency. Rather than include it as a dependency. I have copied the code used from vue and implemented it into a util function. Vue wraps the function in a caching wrapper, but I don't think the caching behavior is necessary for this use case.

I did only test to make sure that the docs portion built. I also attempted to use docs:dev, but it only came up with a generic 404 before and after the change so I don't think anything's broken. I really don't think that "cacheStringFunction" that vue contains is necessary, but I am not certain. Regardless, extraneous imports need to be fixed before migrating to pnpm and a proper monorepo workspace, as they will generally cause breaking, almost impossible to find, issues.