### PR TITLE
Make BToast receive `delay` as prop

### DIFF
--- a/src/components/BToast/BToast.vue
+++ b/src/components/BToast/BToast.vue
@@ -22,7 +22,7 @@ import {BLINK_PROPS} from '../BLink/BLink.vue'
 import {BodyProp} from './plugin'
 
 export const SLOT_NAME_TOAST_TITLE = 'toast-title'
-const MIN_DURATION = 5000
+const MIN_DURATION = 1000
 
 export default defineComponent({
   name: 'BToast',

--- a/src/components/BToast/BToaster.vue
+++ b/src/components/BToast/BToaster.vue
@@ -5,6 +5,7 @@
       :id="toast.options.id"
       :key="toast.options.id"
       v-model="toast.options.value"
+      :delay="toast.options.delay"
       :title="toast.content.title"
       :body="toast.content.body"
       :component="toast.content.body"


### PR DESCRIPTION
### Goals
- Make `delay` accessible to the `BToast` component as a prop
- Return the minimum delay to 1000ms (the default delay is still 5000ms)