### PR TITLE
Fix BTooltip updates for Bootstrap 5.2

### DIFF
--- a/src/directives/BTooltip.ts
+++ b/src/directives/BTooltip.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {Directive, DirectiveBinding} from 'vue'
 import Tooltip from 'bootstrap/js/dist/tooltip'
 
@@ -59,6 +60,7 @@ const BTooltip: Directive<HTMLElement> = {
     const trigger = resolveTrigger(binding.modifiers)
     const placement = resolvePlacement(binding.modifiers)
     const delay = resolveDelay(binding.value)
+    const title = el.getAttribute('title')
 
     new Tooltip(el, {
       trigger,
@@ -66,16 +68,22 @@ const BTooltip: Directive<HTMLElement> = {
       delay,
       html: isHtml,
     })
+
+    if (title) {
+      el.setAttribute('data-bs-original-title', title)
+    }
   },
   updated(el) {
     const title = el.getAttribute('title')
+    const originalTitle = el.getAttribute('data-bs-original-title')
+    const instance = Tooltip.getInstance(el)
 
-    if (title !== '') {
-      const instance = Tooltip.getInstance(el)
-      instance?.toggle()
-      el.setAttribute('data-bs-original-title', title || '')
-      el.setAttribute('title', '')
-      instance?.toggle()
+    el.removeAttribute('title')
+
+    if (title && title !== originalTitle) {
+      // @ts-ignore
+      instance?.setContent({'.tooltip-inner': title})
+      el.setAttribute('data-bs-original-title', title)
     }
   },
   unmounted(el) {


### PR DESCRIPTION
Dear community, dear @cdmoro 

I hope you are all well :)

This pull request will add support for Bootstrap 5.2's new Tooltip API using the `Tooltip.setContent()` method for updating the Tooltip.

As a side effect it will also fix a bug with previous versions of `bootstrap-vue-3` using Bootstrap 5.2, which caused an unshown tooltip to flash up when setting its content via the old way on initialization.

Question remains whether we should keep support for Bootstrap 5.1 and lower?

Best regards
Markus