### PR TITLE
fix: allow workflow bot to use peerDep

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "5.x.x"
   },
   "devDependencies": {
+    "bootstrap": "5.x.x",
     "@vuepress/plugin-search": "^2.0.0-beta.48",
     "@vuepress/plugin-register-components": "^2.0.0-beta.48",
     "bootstrap-vue-3": "file:../",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "bootstrap": "5.x.x"
   },
   "devDependencies": {
+    "bootstrap": "5.x.x",
     "@types/bootstrap": "5.x.x",
     "@typescript-eslint/eslint-plugin": "5.x.x",
     "@typescript-eslint/parser": "5.x.x",


### PR DESCRIPTION
This was also fixed in the dev branch, but I might as well add it here. This fix should allow workflows to properly install peerDependencies and close https://github.com/cdmoro/bootstrap-vue-3/issues/467 (This could have also been fixed by having the bot use Node 16, rather than Node 12)