### PR TITLE
fix: remove publish script to stop duplication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,6 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm install
-      - run: npm publish
+      - run: npm publish --tag develop
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm install
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --tag develop
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "npm run lint",
     "test:unit": "vitest",
-    "publish": "npm publish --tag develop",
     "prepare": "husky install && npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
All of the substrings of publish were taken, pub, pu, publ, everything was taken so I couldn't just rename the script. Doing "npm publish --tag develop" isn't that hard to remember so I just removed it instead. It can be added back, just pick a different name that isn't already builtin to npm.