### PR TITLE
ci: fix filter to use package name instead of glob

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ contains(steps.release.outputs.paths_released, env.path) }}
 
       - name: Publish 
-        run: pnpm publish --tag develop --filter .\packages\bootstrap-vue-3\
+        run: pnpm publish --tag develop --filter bootstrap-vue-3
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ contains(steps.release.outputs.paths_released, env.path) }}


### PR DESCRIPTION
Not sure why filtering by path didn't work, works fine when running on local machine. Must be something weird with Windows vs I assume actions are using Linux.