### PR TITLE
fix: #540 prop w/ no value empty string is true

### DIFF
--- a/packages/bootstrap-vue-3/src/types/Booleanish.d.ts
+++ b/packages/bootstrap-vue-3/src/types/Booleanish.d.ts
@@ -1,3 +1,3 @@
-type Booleanish = 'true' | 'false' | boolean
+type Booleanish = 'true' | 'false' | '' | boolean
 
 export default Booleanish

--- a/packages/bootstrap-vue-3/src/utils/booleanish.ts
+++ b/packages/bootstrap-vue-3/src/utils/booleanish.ts
@@ -7,7 +7,7 @@ import type {Booleanish} from '../types'
  * @returns inputisBooleanish
  */
 export const isBooleanish = (input: unknown): input is Booleanish =>
-  typeof input === 'boolean' || input === 'true' || input === 'false'
+  typeof input === 'boolean' || input === '' || input === 'true' || input === 'false'
 
 /**
  * Converts a Booleanish type to boolean
@@ -16,4 +16,4 @@ export const isBooleanish = (input: unknown): input is Booleanish =>
  * @returns
  */
 export const resolveBooleanish = (input: Booleanish): boolean =>
-  typeof input === 'boolean' ? input : input === 'true' ? true : false
+  typeof input === 'boolean' ? input : input === '' ? true : input === 'true' ? true : false


### PR DESCRIPTION
Kind of not the perfect solution to allow empty strings as Booleanish, but it works how it should.