### PR TITLE
fix: drop{type} props are camelCase and chore: update deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "apps/*"
   ],
   "scripts": {
-    "audit": "improved-yarn-audit --ignore-dev-deps --min-severity moderate",
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "test": "turbo run test",
@@ -17,10 +16,9 @@
   },
   "devDependencies": {
     "eslint-config-custom": "workspace:*",
-    "husky": "^7.0.2",
-    "improved-yarn-audit": "3.x.x",
-    "lint-staged": "12.x.x",
-    "release-please": "^13.19.3",
+    "husky": "^8.0.1",
+    "lint-staged": "^13.0.3",
+    "release-please": "^14.1.0",
     "turbo": "latest"
   },
   "engines": {

--- a/packages/bootstrap-vue-3/src/components/BAccordion/accordion-item.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAccordion/accordion-item.spec.ts
@@ -1,0 +1,186 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BAccordionItem from './BAccordionItem.vue'
+import BCollapse from '../BCollapse.vue'
+
+describe('accordion-item', () => {
+  it('has static class accordion-item', () => {
+    const wrapper = mount(BAccordionItem)
+    expect(wrapper.classes()).toContain('accordion-item')
+
+    wrapper.unmount()
+  })
+
+  it('contains b-collapse', () => {
+    const wrapper = mount(BAccordionItem)
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    expect($bcollapse.exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse contains static class accordion-collapse', () => {
+    const wrapper = mount(BAccordionItem)
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    expect($bcollapse.classes()).toContain('accordion-collapse')
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse child div contains static class accordion-body', () => {
+    const wrapper = mount(BAccordionItem)
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    const [, $div] = $bcollapse.findAll('div')
+    expect($div.classes()).toContain('accordion-body')
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse child div contains default slot', () => {
+    const wrapper = mount(BAccordionItem, {
+      slots: {default: 'foobar'},
+    })
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    const [, $div] = $bcollapse.findAll('div')
+    expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse has id attr has default id', () => {
+    const wrapper = mount(BAccordionItem)
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    expect($bcollapse.attributes('id')).toBeDefined()
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse has id attr has prop id', () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {id: 'spam&eggs'},
+    })
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    expect($bcollapse.attributes('id')).toBe('spam&eggs')
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse has prop visible', async () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {visible: true},
+    })
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    expect($bcollapse.props('visible')).toBe(true)
+    await wrapper.setProps({visible: false})
+    expect($bcollapse.props('visible')).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('b-collapse has aria-labelledby with prop id', () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {id: 'foobar'},
+    })
+    const $bcollapse = wrapper.findComponent(BCollapse)
+    expect($bcollapse.attributes('aria-labelledby')).toBe('headingfoobar')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child has static class accordion-header', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    expect($h2.classes()).toContain('accordion-header')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child has id attr has default id', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    expect($h2.attributes('id')).toBeDefined()
+
+    wrapper.unmount()
+  })
+
+  it('h2 child has id attr has prop id', () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {id: 'foobar'},
+    })
+    const $h2 = wrapper.find('h2')
+    expect($h2.attributes('id')).toBe('foobarheading')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child has button child', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('h2 child button child has static class accordion-button', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.classes()).toContain('accordion-button')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child button child has type attribute button', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.attributes('type')).toBe('button')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child button child has aria-expanded false by default', () => {
+    const wrapper = mount(BAccordionItem)
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.attributes('aria-expanded')).toBe('false')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child button child has aria-expanded true when visible true', () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {visible: true},
+    })
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.attributes('aria-expanded')).toBe('true')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child button child has aria-controls as id', () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {id: 'foobar'},
+    })
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.attributes('aria-controls')).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('h2 child button child class collapsed when visible false', async () => {
+    const wrapper = mount(BAccordionItem, {
+      props: {visible: false},
+    })
+    const $h2 = wrapper.find('h2')
+    const $button = $h2.find('button')
+    expect($button.classes()).toContain('collapsed')
+    await wrapper.setProps({visible: true})
+    expect($button.classes()).not.toContain('collapsed')
+
+    wrapper.unmount()
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BAccordion/accordion.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAccordion/accordion.spec.ts
@@ -1,0 +1,39 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BAccordion from './BAccordion.vue'
+
+describe('accordion', () => {
+  it('has static class accordion', () => {
+    const wrapper = mount(BAccordion)
+    expect(wrapper.classes()).toContain('accordion')
+
+    wrapper.unmount()
+  })
+
+  it('has computed id by default', () => {
+    const wrapper = mount(BAccordion)
+    expect(wrapper.attributes('id')).toBeDefined()
+
+    wrapper.unmount()
+  })
+
+  it('has id when prop id is set', () => {
+    const wrapper = mount(BAccordion, {
+      props: {id: 'abc'},
+    })
+    expect(wrapper.attributes('id')).toBe('abc')
+
+    wrapper.unmount()
+  })
+
+  it('has class accordion-flush when flush is true', async () => {
+    const wrapper = mount(BAccordion, {
+      props: {flush: true},
+    })
+    expect(wrapper.classes()).toContain('accordion-flush')
+    await wrapper.setProps({flush: false})
+    expect(wrapper.classes()).not.toContain('accordion-flush')
+
+    wrapper.unmount()
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BAvatar/avatar-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/avatar-group.spec.ts
@@ -54,7 +54,7 @@ describe('avatar-group', () => {
   it.skip('div child has style attribute when size prop', () => {
     // TODO it doesn't seem that the computeSize function in BAvatar returns anything when string
     const wrapper = mount(BAvatarGroup, {
-      props: {size: 128},
+      props: {size: '128'},
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.html()).toBe('false')

--- a/packages/bootstrap-vue-3/src/components/BAvatar/avatar-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/avatar-group.spec.ts
@@ -1,0 +1,64 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BAvatarGroup from './BAvatarGroup.vue'
+
+describe('avatar-group', () => {
+  it('has static class b-avatar-group', () => {
+    const wrapper = mount(BAvatarGroup)
+    expect(wrapper.classes()).toContain('b-avatar-group')
+
+    wrapper.unmount()
+  })
+
+  it('has role group attribute', () => {
+    const wrapper = mount(BAvatarGroup)
+    expect(wrapper.attributes('role')).toBe('group')
+
+    wrapper.unmount()
+  })
+
+  it('tag is div by default', () => {
+    const wrapper = mount(BAvatarGroup)
+    expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
+  })
+
+  it('tag changes with prop tag', () => {
+    const wrapper = mount(BAvatarGroup, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+
+    wrapper.unmount()
+  })
+
+  it('div child has static class b-avatar-group-inner', () => {
+    const wrapper = mount(BAvatarGroup)
+    const [, $div] = wrapper.findAll('div')
+    expect($div.classes()).toContain('b-avatar-group-inner')
+
+    wrapper.unmount()
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BAvatarGroup, {
+      slots: {default: 'foobar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it.skip('div child has style attribute when size prop', () => {
+    // TODO it doesn't seem that the computeSize function in BAvatar returns anything when string
+    const wrapper = mount(BAvatarGroup, {
+      props: {size: 128},
+    })
+    const [, $div] = wrapper.findAll('div')
+    expect($div.html()).toBe('false')
+
+    wrapper.unmount()
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BAvatar/avatar.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/avatar.spec.ts
@@ -1,0 +1,39 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BAvatar from './BAvatar.vue'
+
+describe('accordion', () => {
+  it('has static b-avatar class', () => {
+    const wrapper = mount(BAvatar)
+    expect(wrapper.classes()).toContain('b-avatar')
+
+    wrapper.unmount()
+  })
+
+  it('tag is default button when prop button is true', () => {
+    const wrapper = mount(BAvatar, {
+      props: {button: true},
+    })
+    expect(wrapper.element.tagName).toBe('BUTTON')
+
+    wrapper.unmount()
+  })
+
+  it('tag is prop buttonType when prop button is true', () => {
+    const wrapper = mount(BAvatar, {
+      props: {button: true, buttonType: 'div'},
+    })
+    expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
+  })
+
+  it('tag is default span', () => {
+    const wrapper = mount(BAvatar)
+    expect(wrapper.element.tagName).toBe('SPAN')
+
+    wrapper.unmount()
+  })
+
+  // TODO not done
+})

--- a/packages/bootstrap-vue-3/src/components/BBadge/badge.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BBadge/badge.spec.ts
@@ -1,0 +1,169 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BBadge from './BBadge.vue'
+import BLink from '../BLink/BLink.vue'
+
+describe('badge', () => {
+  it('has static class badge', () => {
+    const wrapper = mount(BBadge)
+    expect(wrapper.classes()).toContain('badge')
+  })
+
+  it('tag is span by default', () => {
+    const wrapper = mount(BBadge)
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('contains BLink if to prop', () => {
+    const wrapper = mount(BBadge, {
+      props: {to: '/abc'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+  })
+
+  it('contains BLink if href prop', () => {
+    const wrapper = mount(BBadge, {
+      props: {href: '/abc'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+  })
+
+  it('does not contain BLink by default', () => {
+    const wrapper = mount(BBadge)
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(false)
+  })
+
+  it('is still blink even if prop tag exists, but is also link', () => {
+    const wrapper = mount(BBadge, {
+      props: {href: '/abc', tag: 'span'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+    expect(wrapper.element.tagName).toBe('A')
+  })
+
+  it('is prop tag when is not link', () => {
+    const wrapper = mount(BBadge, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('contains class bg-{type} when prop varaint', async () => {
+    const wrapper = mount(BBadge, {
+      props: {variant: 'primary'},
+    })
+    expect(wrapper.classes()).toContain('bg-primary')
+    await wrapper.setProps({variant: 'secondary'})
+    expect(wrapper.classes()).toContain('bg-secondary')
+    expect(wrapper.classes()).not.toContain('bg-primary')
+  })
+
+  it('contains class active when prop active', async () => {
+    const wrapper = mount(BBadge, {
+      props: {active: true},
+    })
+    expect(wrapper.classes()).toContain('active')
+    await wrapper.setProps({active: false})
+    expect(wrapper.classes()).not.toContain('active')
+  })
+
+  it('contains class disabled when prop disabled', async () => {
+    const wrapper = mount(BBadge, {
+      props: {disabled: true},
+    })
+    expect(wrapper.classes()).toContain('disabled')
+    await wrapper.setProps({disabled: false})
+    expect(wrapper.classes()).not.toContain('disabled')
+  })
+
+  it('contains class text-dark when prop variant is warning|info|light', async () => {
+    const wrapper = mount(BBadge, {
+      props: {variant: 'primary'},
+    })
+    expect(wrapper.classes()).not.toContain('text-dark')
+    await wrapper.setProps({variant: 'warning'})
+    expect(wrapper.classes()).toContain('text-dark')
+    await wrapper.setProps({variant: 'info'})
+    expect(wrapper.classes()).toContain('text-dark')
+    await wrapper.setProps({variant: 'light'})
+    expect(wrapper.classes()).toContain('text-dark')
+    await wrapper.setProps({variant: 'primary'})
+    expect(wrapper.classes()).not.toContain('text-dark')
+  })
+
+  it('contains class rounded-pill when prop pill', async () => {
+    const wrapper = mount(BBadge, {
+      props: {pill: true},
+    })
+    expect(wrapper.classes()).toContain('rounded-pill')
+    await wrapper.setProps({pill: false})
+    expect(wrapper.classes()).not.toContain('rounded-pill')
+  })
+
+  it('contains class text-decoration-none when prop to', async () => {
+    const wrapper = mount(BBadge, {
+      props: {to: '/abc'},
+    })
+    expect(wrapper.classes()).toContain('text-decoration-none')
+    await wrapper.setProps({to: undefined})
+    expect(wrapper.classes()).not.toContain('text-decoration-none')
+  })
+
+  it('contains class text-decoration-none when prop href', async () => {
+    const wrapper = mount(BBadge, {
+      props: {href: '/abc'},
+    })
+    expect(wrapper.classes()).toContain('text-decoration-none')
+    await wrapper.setProps({href: undefined})
+    expect(wrapper.classes()).not.toContain('text-decoration-none')
+  })
+
+  it('contains p-2 border border-light rounded-circle when prop dotIndicator', async () => {
+    const wrapper = mount(BBadge, {
+      props: {dotIndicator: true},
+    })
+    expect(wrapper.classes()).toContain('p-2')
+    expect(wrapper.classes()).toContain('border')
+    expect(wrapper.classes()).toContain('border-light')
+    expect(wrapper.classes()).toContain('rounded-circle')
+    await wrapper.setProps({dotIndicator: false})
+    expect(wrapper.classes()).not.toContain('p-2')
+    expect(wrapper.classes()).not.toContain('border')
+    expect(wrapper.classes()).not.toContain('border-light')
+    expect(wrapper.classes()).not.toContain('rounded-circle')
+  })
+
+  it('contains position-absolute top-0 start-100 translate-middle when prop dotIndicator', async () => {
+    const wrapper = mount(BBadge, {
+      props: {dotIndicator: true},
+    })
+    expect(wrapper.classes()).toContain('position-absolute')
+    expect(wrapper.classes()).toContain('top-0')
+    expect(wrapper.classes()).toContain('start-100')
+    expect(wrapper.classes()).toContain('translate-middle')
+    await wrapper.setProps({dotIndicator: false})
+    expect(wrapper.classes()).not.toContain('position-absolute')
+    expect(wrapper.classes()).not.toContain('top-0')
+    expect(wrapper.classes()).not.toContain('start-100')
+    expect(wrapper.classes()).not.toContain('translate-middle')
+  })
+
+  it('contains position-absolute top-0 start-100 translate-middle when prop textIndicator', async () => {
+    const wrapper = mount(BBadge, {
+      props: {textIndicator: true},
+    })
+    expect(wrapper.classes()).toContain('position-absolute')
+    expect(wrapper.classes()).toContain('top-0')
+    expect(wrapper.classes()).toContain('start-100')
+    expect(wrapper.classes()).toContain('translate-middle')
+    await wrapper.setProps({textIndicator: false})
+    expect(wrapper.classes()).not.toContain('position-absolute')
+    expect(wrapper.classes()).not.toContain('top-0')
+    expect(wrapper.classes()).not.toContain('start-100')
+    expect(wrapper.classes()).not.toContain('translate-middle')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrum.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrum.spec.ts
@@ -1,0 +1,24 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BBreadcrumb from './BBreadcrumb.vue'
+import BBreadcrumbItem from './BBreadcrumbItem.vue'
+
+describe('breadcrumb', () => {
+  it('contains aria-label breadcrumb', () => {
+    const wrapper = mount(BBreadcrumb)
+    expect(wrapper.attributes('aria-label')).toBe('breadcrumb')
+  })
+
+  it('tag is nav', () => {
+    const wrapper = mount(BBreadcrumb)
+    expect(wrapper.element.tagName).toBe('NAV')
+  })
+
+  it('child tag is ol', () => {
+    const wrapper = mount(BBreadcrumb)
+    // It should be noted, this doesn't determine if it's a child,
+    // Rather, only that it is deeply nested inside the component
+    const $ol = wrapper.find('ol')
+    expect($ol.exists()).toBe(true)
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BNav/BNavItemDropdown.vue
+++ b/packages/bootstrap-vue-3/src/components/BNav/BNavItemDropdown.vue
@@ -21,9 +21,9 @@ interface BNavItemDropdownProps {
   offset?: string
   autoClose?: boolean | 'inside' | 'outside'
   dark?: boolean
-  dropleft?: boolean
-  dropright?: boolean
-  dropup?: boolean
+  dropLeft?: boolean
+  dropRight?: boolean
+  dropUp?: boolean
   right?: boolean
   left?: boolean | string
   // offsetParent?: boolean // Breaks tests, does not exist on BDropdown
@@ -36,9 +36,9 @@ interface BNavItemDropdownProps {
 withDefaults(defineProps<BNavItemDropdownProps>(), {
   autoClose: true,
   dark: false,
-  dropleft: false,
-  dropright: false,
-  dropup: false,
+  dropLeft: false,
+  dropRight: false,
+  dropUp: false,
   right: false,
   left: false,
   // offsetParent: false,

--- a/packages/bootstrap-vue-3/src/components/BNavbar/navbar-toggle.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNavbar/navbar-toggle.spec.ts
@@ -65,7 +65,7 @@ describe('navbar-toggle', () => {
     wrapper.unmount()
   })
 
-  it('disabled attribute is undefined by default', () => {
+  it('disabled attribute is empty string when true', () => {
     const wrapper = mount(BNavbarToggle, {
       props: {disabled: true},
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,17 +5,15 @@ importers:
   .:
     specifiers:
       eslint-config-custom: workspace:*
-      husky: ^7.0.2
-      improved-yarn-audit: 3.x.x
-      lint-staged: 12.x.x
-      release-please: ^13.19.3
+      husky: ^8.0.1
+      lint-staged: ^13.0.3
+      release-please: ^14.1.0
       turbo: latest
     devDependencies:
       eslint-config-custom: link:packages/eslint-config-custom
-      husky: 7.0.4
-      improved-yarn-audit: 3.0.0
-      lint-staged: 12.5.0
-      release-please: 13.21.0
+      husky: 8.0.1
+      lint-staged: 13.0.3
+      release-please: 14.1.0
       turbo: 1.4.3
 
   apps/docs:
@@ -206,6 +204,15 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@google-automations/git-file-utils/1.1.0:
+    resolution: {integrity: sha512-MfrDlDLWbisVRdVCqn3Vy5uaJWZCB3v1zyWwTIYXWmHp1WSDUX4vP+T8d/mULvegDOnp/hLFOeOJC1jQObd2xw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/rest': 19.0.3
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /@humanwhocodes/config-array/0.10.4:
@@ -431,39 +438,43 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@octokit/auth-token/2.5.0:
-    resolution: {integrity: sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==}
+  /@octokit/auth-token/3.0.1:
+    resolution: {integrity: sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/types': 6.41.0
+      '@octokit/types': 7.1.0
     dev: true
 
-  /@octokit/core/3.6.0:
-    resolution: {integrity: sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==}
+  /@octokit/core/4.0.5:
+    resolution: {integrity: sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/auth-token': 2.5.0
-      '@octokit/graphql': 4.8.0
-      '@octokit/request': 5.6.3
-      '@octokit/request-error': 2.1.0
-      '@octokit/types': 6.41.0
+      '@octokit/auth-token': 3.0.1
+      '@octokit/graphql': 5.0.1
+      '@octokit/request': 6.2.1
+      '@octokit/request-error': 3.0.1
+      '@octokit/types': 7.1.0
       before-after-hook: 2.2.2
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
     dev: true
 
-  /@octokit/endpoint/6.0.12:
-    resolution: {integrity: sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==}
+  /@octokit/endpoint/7.0.1:
+    resolution: {integrity: sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/types': 6.41.0
+      '@octokit/types': 7.1.0
       is-plain-object: 5.0.0
       universal-user-agent: 6.0.0
     dev: true
 
-  /@octokit/graphql/4.8.0:
-    resolution: {integrity: sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==}
+  /@octokit/graphql/5.0.1:
+    resolution: {integrity: sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/request': 5.6.3
-      '@octokit/types': 6.41.0
+      '@octokit/request': 6.2.1
+      '@octokit/types': 7.1.0
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
@@ -473,47 +484,65 @@ packages:
     resolution: {integrity: sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==}
     dev: true
 
-  /@octokit/plugin-paginate-rest/2.21.3_@octokit+core@3.6.0:
-    resolution: {integrity: sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==}
+  /@octokit/openapi-types/13.3.0:
+    resolution: {integrity: sha512-LQGIQDpCUNVm+Egqtj9nZJ383HsuS/LFaSqV5uMjD9eev4x54IUaom3WV3PEdDeu/pEagL7FyrKmvYn+Yrb30A==}
+    dev: true
+
+  /@octokit/plugin-paginate-rest/3.1.0_@octokit+core@4.0.5:
+    resolution: {integrity: sha512-+cfc40pMzWcLkoDcLb1KXqjX0jTGYXjKuQdFQDc6UAknISJHnZTiBqld6HDwRJvD4DsouDKrWXNbNV0lE/3AXA==}
+    engines: {node: '>= 14'}
     peerDependencies:
-      '@octokit/core': '>=2'
+      '@octokit/core': '>=4'
     dependencies:
-      '@octokit/core': 3.6.0
+      '@octokit/core': 4.0.5
       '@octokit/types': 6.41.0
     dev: true
 
-  /@octokit/plugin-request-log/1.0.4_@octokit+core@3.6.0:
+  /@octokit/plugin-paginate-rest/4.0.0_@octokit+core@4.0.5:
+    resolution: {integrity: sha512-g4GJMt/7VDmIMMdQenN6bmsmRoZca1c7IxOdF2yMiMwQYrE2bmmypGQeQSD5rsaffsFMCUS7Br4pMVZamareYA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      '@octokit/core': '>=4'
+    dependencies:
+      '@octokit/core': 4.0.5
+      '@octokit/types': 7.1.0
+    dev: true
+
+  /@octokit/plugin-request-log/1.0.4_@octokit+core@4.0.5:
     resolution: {integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==}
     peerDependencies:
       '@octokit/core': '>=3'
     dependencies:
-      '@octokit/core': 3.6.0
+      '@octokit/core': 4.0.5
     dev: true
 
-  /@octokit/plugin-rest-endpoint-methods/5.16.2_@octokit+core@3.6.0:
-    resolution: {integrity: sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==}
+  /@octokit/plugin-rest-endpoint-methods/6.3.0_@octokit+core@4.0.5:
+    resolution: {integrity: sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==}
+    engines: {node: '>= 14'}
     peerDependencies:
       '@octokit/core': '>=3'
     dependencies:
-      '@octokit/core': 3.6.0
-      '@octokit/types': 6.41.0
+      '@octokit/core': 4.0.5
+      '@octokit/types': 7.1.0
       deprecation: 2.3.1
     dev: true
 
-  /@octokit/request-error/2.1.0:
-    resolution: {integrity: sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==}
+  /@octokit/request-error/3.0.1:
+    resolution: {integrity: sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/types': 6.41.0
+      '@octokit/types': 7.1.0
       deprecation: 2.3.1
       once: 1.4.0
     dev: true
 
-  /@octokit/request/5.6.3:
-    resolution: {integrity: sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==}
+  /@octokit/request/6.2.1:
+    resolution: {integrity: sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/endpoint': 6.0.12
-      '@octokit/request-error': 2.1.0
-      '@octokit/types': 6.41.0
+      '@octokit/endpoint': 7.0.1
+      '@octokit/request-error': 3.0.1
+      '@octokit/types': 7.1.0
       is-plain-object: 5.0.0
       node-fetch: 2.6.7
       universal-user-agent: 6.0.0
@@ -521,13 +550,26 @@ packages:
       - encoding
     dev: true
 
-  /@octokit/rest/18.12.0:
-    resolution: {integrity: sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==}
+  /@octokit/rest/19.0.3:
+    resolution: {integrity: sha512-5arkTsnnRT7/sbI4fqgSJ35KiFaN7zQm0uQiQtivNQLI8RQx8EHwJCajcTUwmaCMNDg7tdCvqAnc7uvHHPxrtQ==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@octokit/core': 3.6.0
-      '@octokit/plugin-paginate-rest': 2.21.3_@octokit+core@3.6.0
-      '@octokit/plugin-request-log': 1.0.4_@octokit+core@3.6.0
-      '@octokit/plugin-rest-endpoint-methods': 5.16.2_@octokit+core@3.6.0
+      '@octokit/core': 4.0.5
+      '@octokit/plugin-paginate-rest': 3.1.0_@octokit+core@4.0.5
+      '@octokit/plugin-request-log': 1.0.4_@octokit+core@4.0.5
+      '@octokit/plugin-rest-endpoint-methods': 6.3.0_@octokit+core@4.0.5
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /@octokit/rest/19.0.4:
+    resolution: {integrity: sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@octokit/core': 4.0.5
+      '@octokit/plugin-paginate-rest': 4.0.0_@octokit+core@4.0.5
+      '@octokit/plugin-request-log': 1.0.4_@octokit+core@4.0.5
+      '@octokit/plugin-rest-endpoint-methods': 6.3.0_@octokit+core@4.0.5
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -536,6 +578,12 @@ packages:
     resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
     dependencies:
       '@octokit/openapi-types': 12.11.0
+    dev: true
+
+  /@octokit/types/7.1.0:
+    resolution: {integrity: sha512-+ClA0jRc9zGFj5mfQeQNfgTlelzhpAexbAueQG1t2Xn8yhgnsjkF8bgLcUUpwrpqkv296uXyiGwkqXRSU7KYzQ==}
+    dependencies:
+      '@octokit/openapi-types': 13.3.0
     dev: true
 
   /@popperjs/core/2.11.6:
@@ -614,7 +662,7 @@ packages:
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.7.6
+      '@types/node': 18.7.7
     dev: true
 
   /@types/json-schema/7.0.11:
@@ -654,8 +702,8 @@ packages:
     resolution: {integrity: sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==}
     dev: true
 
-  /@types/node/18.7.6:
-    resolution: {integrity: sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==}
+  /@types/node/18.7.7:
+    resolution: {integrity: sha512-sTKYCtQmaUpsAT+AbUTKg0Ya0dYyh20t3TBQebWrGXQHFmkrEyeedok2/IpTthlJopPSbUoc1hAKoK6UeFRCZw==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -1681,12 +1729,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /code-suggester/3.0.0:
-    resolution: {integrity: sha512-DoTVTaMgU1VygKF84sZ4v6qCsb4yd0wDHVJFp+BywDr1+GUCTe0b3QL+GFB4a+RcTP9HQOYDDS59lVXRGcy3SA==}
-    engines: {node: '>=12.0.0'}
+  /code-suggester/4.0.1:
+    resolution: {integrity: sha512-qIC7EeCBY85WTU16N/QZCZd79bWMaZuSJc+xVl45E7i8wcxm0Mx9bqcEyeXdHk3a8RjlDQNu/ZgfNZ7NkVc2IQ==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      '@octokit/rest': 18.12.0
+      '@octokit/rest': 19.0.4
       '@types/yargs': 16.0.4
       async-retry: 1.3.3
       diff: 5.1.0
@@ -1873,19 +1921,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
-
-  /debug/4.3.4_supports-color@9.2.2:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-      supports-color: 9.2.2
     dev: true
 
   /decamelize-keys/1.1.0:
@@ -2506,6 +2541,21 @@ packages:
       strip-final-newline: 2.0.0
     dev: true
 
+  /execa/6.1.0:
+    resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 3.0.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: true
+
   /extend-shallow/2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -2827,9 +2877,14 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
-  /husky/7.0.4:
-    resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
-    engines: {node: '>=12'}
+  /human-signals/3.0.1:
+    resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
+    engines: {node: '>=12.20.0'}
+    dev: true
+
+  /husky/8.0.1:
+    resolution: {integrity: sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 
@@ -2864,11 +2919,6 @@ packages:
   /import-lazy/4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /improved-yarn-audit/3.0.0:
-    resolution: {integrity: sha512-b7CrBYYwMidtPciCBkW62C7vqGjAV10bxcAWHeJvGrltrcMSEnG5I9CQgi14nmAlUKUQiSvpz47Lo3d7Z3Vjcg==}
-    hasBin: true
     dev: true
 
   /imurmurhash/0.1.4:
@@ -2981,6 +3031,11 @@ packages:
   /is-stream/2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /is-stream/3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /is-unicode-supported/0.1.0:
@@ -3142,27 +3197,27 @@ packages:
       uc.micro: 1.0.6
     dev: true
 
-  /lint-staged/12.5.0:
-    resolution: {integrity: sha512-BKLUjWDsKquV/JuIcoQW4MSAI3ggwEImF1+sB4zaKvyVx1wBk3FsG7UK9bpnmBTN1pm7EH2BBcMwINJzCRv12g==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /lint-staged/13.0.3:
+    resolution: {integrity: sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==}
+    engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
     dependencies:
       cli-truncate: 3.1.0
       colorette: 2.0.19
       commander: 9.4.0
-      debug: 4.3.4_supports-color@9.2.2
-      execa: 5.1.1
+      debug: 4.3.4
+      execa: 6.1.0
       lilconfig: 2.0.5
       listr2: 4.0.5
       micromatch: 4.0.5
       normalize-path: 3.0.0
       object-inspect: 1.12.2
-      pidtree: 0.5.0
+      pidtree: 0.6.0
       string-argv: 0.3.1
-      supports-color: 9.2.2
-      yaml: 1.10.2
+      yaml: 2.1.1
     transitivePeerDependencies:
       - enquirer
+      - supports-color
     dev: true
 
   /listr2/4.0.5:
@@ -3375,6 +3430,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /mimic-fn/4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -3502,6 +3562,13 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /npm-run-path/5.1.0:
+    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: true
+
   /npmlog/4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
     dependencies:
@@ -3546,6 +3613,13 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
+    dev: true
+
+  /onetime/6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
     dev: true
 
   /open/8.4.0:
@@ -3706,6 +3780,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /path-key/4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: true
+
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
@@ -3727,8 +3806,8 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /pidtree/0.5.0:
-    resolution: {integrity: sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==}
+  /pidtree/0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
     dev: true
@@ -3873,25 +3952,26 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /release-please/13.21.0:
-    resolution: {integrity: sha512-j14Duo//+fxi1hmOwjwrG+QYaGGADEJYp3YvVkFfWjFFCweesE7hKCNaxhkSAhxbUhwxyBI7CfYWRvvO9ouR6A==}
-    engines: {node: '>=12.18.0'}
+  /release-please/14.1.0:
+    resolution: {integrity: sha512-K0DZry2TSFv1Oi0+cKiaxx7h7Cuj/H4RsBE512yxQu5qFBd7EsF5frbkEw1CeOy+fg0i0DZTL9dYFJIguCoD5g==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
       '@conventional-commits/parser': 0.4.1
+      '@google-automations/git-file-utils': 1.1.0
       '@iarna/toml': 2.2.5
       '@lerna/collect-updates': 4.0.0
       '@lerna/package': 4.0.0
       '@lerna/package-graph': 4.0.0
       '@lerna/run-topologically': 4.0.0
-      '@octokit/graphql': 4.8.0
-      '@octokit/request': 5.6.3
-      '@octokit/request-error': 2.1.0
-      '@octokit/rest': 18.12.0
+      '@octokit/graphql': 5.0.1
+      '@octokit/request': 6.2.1
+      '@octokit/request-error': 3.0.1
+      '@octokit/rest': 19.0.4
       '@types/npm-package-arg': 6.1.1
       '@xmldom/xmldom': 0.8.2
       chalk: 4.1.2
-      code-suggester: 3.0.0
+      code-suggester: 4.0.1
       conventional-changelog-conventionalcommits: 5.0.0
       conventional-changelog-writer: 5.0.1
       conventional-commits-filter: 2.0.7
@@ -4263,6 +4343,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /strip-final-newline/3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /strip-indent/3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -4297,11 +4382,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
-
-  /supports-color/9.2.2:
-    resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==}
-    engines: {node: '>=12'}
     dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
@@ -4817,7 +4897,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.7.6
+      '@types/node': 18.7.7
       chai: 4.3.6
       debug: 4.3.4
       jsdom: 20.0.0
@@ -5096,9 +5176,9 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
-  /yaml/1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
+  /yaml/2.1.1:
+    resolution: {integrity: sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==}
+    engines: {node: '>= 14'}
     dev: true
 
   /yargs-parser/20.2.9:


### PR DESCRIPTION
dropup dropleft and dropright are replaced with dropUp dropLeft and dropRight

chore: update deps and extend .x.x removal 

improved-yarn-audit was also removed. When you trying to run it, it will actually break because it detects using pnpm. Pretty sure an audit script could be created using pnpm to ignore dev deps, and min-security moderate. However, both are pretty useless since 'audit' itself is broken by design. Best to just remove the script we can't run. 

All breaking semver versions have been reviewed, and are generally a removal of node 12 support. Since release-please updated their dependencies, the "strict-peer-dependencies=false" can be removed warn us again. 