### PR TITLE
test: various components

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BAccordion/accordion-item.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAccordion/accordion-item.spec.ts
@@ -89,7 +89,7 @@ describe('accordion-item', () => {
 
   it('h2 child has static class accordion-header', () => {
     const wrapper = mount(BAccordionItem)
-    const $h2 = wrapper.find('h2')
+    const $h2 = wrapper.get('h2')
     expect($h2.classes()).toContain('accordion-header')
 
     wrapper.unmount()
@@ -97,7 +97,7 @@ describe('accordion-item', () => {
 
   it('h2 child has id attr has default id', () => {
     const wrapper = mount(BAccordionItem)
-    const $h2 = wrapper.find('h2')
+    const $h2 = wrapper.get('h2')
     expect($h2.attributes('id')).toBeDefined()
 
     wrapper.unmount()
@@ -107,7 +107,7 @@ describe('accordion-item', () => {
     const wrapper = mount(BAccordionItem, {
       props: {id: 'foobar'},
     })
-    const $h2 = wrapper.find('h2')
+    const $h2 = wrapper.get('h2')
     expect($h2.attributes('id')).toBe('foobarheading')
 
     wrapper.unmount()
@@ -115,7 +115,7 @@ describe('accordion-item', () => {
 
   it('h2 child has button child', () => {
     const wrapper = mount(BAccordionItem)
-    const $h2 = wrapper.find('h2')
+    const $h2 = wrapper.get('h2')
     const $button = $h2.find('button')
     expect($button.exists()).toBe(true)
 
@@ -124,8 +124,8 @@ describe('accordion-item', () => {
 
   it('h2 child button child has static class accordion-button', () => {
     const wrapper = mount(BAccordionItem)
-    const $h2 = wrapper.find('h2')
-    const $button = $h2.find('button')
+    const $h2 = wrapper.get('h2')
+    const $button = $h2.get('button')
     expect($button.classes()).toContain('accordion-button')
 
     wrapper.unmount()
@@ -133,8 +133,8 @@ describe('accordion-item', () => {
 
   it('h2 child button child has type attribute button', () => {
     const wrapper = mount(BAccordionItem)
-    const $h2 = wrapper.find('h2')
-    const $button = $h2.find('button')
+    const $h2 = wrapper.get('h2')
+    const $button = $h2.get('button')
     expect($button.attributes('type')).toBe('button')
 
     wrapper.unmount()
@@ -142,8 +142,8 @@ describe('accordion-item', () => {
 
   it('h2 child button child has aria-expanded false by default', () => {
     const wrapper = mount(BAccordionItem)
-    const $h2 = wrapper.find('h2')
-    const $button = $h2.find('button')
+    const $h2 = wrapper.get('h2')
+    const $button = $h2.get('button')
     expect($button.attributes('aria-expanded')).toBe('false')
 
     wrapper.unmount()
@@ -153,8 +153,8 @@ describe('accordion-item', () => {
     const wrapper = mount(BAccordionItem, {
       props: {visible: true},
     })
-    const $h2 = wrapper.find('h2')
-    const $button = $h2.find('button')
+    const $h2 = wrapper.get('h2')
+    const $button = $h2.get('button')
     expect($button.attributes('aria-expanded')).toBe('true')
 
     wrapper.unmount()
@@ -164,8 +164,8 @@ describe('accordion-item', () => {
     const wrapper = mount(BAccordionItem, {
       props: {id: 'foobar'},
     })
-    const $h2 = wrapper.find('h2')
-    const $button = $h2.find('button')
+    const $h2 = wrapper.get('h2')
+    const $button = $h2.get('button')
     expect($button.attributes('aria-controls')).toBe('foobar')
 
     wrapper.unmount()
@@ -175,8 +175,8 @@ describe('accordion-item', () => {
     const wrapper = mount(BAccordionItem, {
       props: {visible: false},
     })
-    const $h2 = wrapper.find('h2')
-    const $button = $h2.find('button')
+    const $h2 = wrapper.get('h2')
+    const $button = $h2.get('button')
     expect($button.classes()).toContain('collapsed')
     await wrapper.setProps({visible: true})
     expect($button.classes()).not.toContain('collapsed')

--- a/packages/bootstrap-vue-3/src/components/BAlert.vue
+++ b/packages/bootstrap-vue-3/src/components/BAlert.vue
@@ -55,11 +55,11 @@ const emit = defineEmits<BAlertEmits>()
 const element = ref<HTMLElement>()
 const instance = ref<Alert>()
 const classes = computed(() => ({
-  [`alert-${props.variant}`]: props.variant,
-  'show': props.modelValue,
+  [`alert-${props.variant}`]: !!props.variant,
+  'show': !!props.modelValue,
   'alert-dismissible': dismissibleBoolean.value,
   // TODO it seems like fade is probably used here
-  'fade': props.modelValue,
+  'fade': !!props.modelValue,
 }))
 
 let _countDownTimeout: undefined | ReturnType<typeof setTimeout>

--- a/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrum.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrum.spec.ts
@@ -3,15 +3,19 @@ import {describe, expect, it} from 'vitest'
 import BBreadcrumb from './BBreadcrumb.vue'
 import BBreadcrumbItem from './BBreadcrumbItem.vue'
 
-describe('breadcrumb', () => {
+describe.skip('breadcrumb', () => {
   it('contains aria-label breadcrumb', () => {
     const wrapper = mount(BBreadcrumb)
     expect(wrapper.attributes('aria-label')).toBe('breadcrumb')
+
+    wrapper.unmount()
   })
 
   it('tag is nav', () => {
     const wrapper = mount(BBreadcrumb)
     expect(wrapper.element.tagName).toBe('NAV')
+
+    wrapper.unmount()
   })
 
   it('child tag is ol', () => {
@@ -20,5 +24,7 @@ describe('breadcrumb', () => {
     // Rather, only that it is deeply nested inside the component
     const $ol = wrapper.find('ol')
     expect($ol.exists()).toBe(true)
+
+    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BCol.vue
+++ b/packages/bootstrap-vue-3/src/components/BCol.vue
@@ -35,13 +35,12 @@ export default defineComponent({
       {content: breakpointOrder, propPrefix: 'order'},
     ]
 
-    // TODO is this supposed to be computed
-    const classList: Array<string> = properties.flatMap((el) =>
-      getClasses(props, el.content, el.propPrefix, el.classPrefix)
+    const classList = computed(() =>
+      properties.flatMap((el) => getClasses(props, el.content, el.propPrefix, el.classPrefix))
     )
 
     const classes = computed(() => ({
-      col: colBoolean.value || !classList.some((e) => /^col-/.test(e) && !props.cols),
+      col: colBoolean.value || !classList.value.some((e) => /^col-/.test(e) && !props.cols),
       [`col-${props.cols}`]: !!props.cols,
       [`offset-${props.offset}`]: !!props.offset,
       [`order-${props.order}`]: !!props.order,

--- a/packages/bootstrap-vue-3/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-3/src/components/BCollapse.vue
@@ -8,7 +8,7 @@
     :data-bs-parent="accordion || null"
     :is-nav="isNavBoolean"
   >
-    <slot :visible="modelValue" :close="close" />
+    <slot :visible="modelValueBoolean" :close="close" />
   </component>
 </template>
 

--- a/packages/bootstrap-vue-3/src/components/BFormCheckbox/form-checkbox.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormCheckbox/form-checkbox.spec.js
@@ -57,7 +57,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('type')).toBeDefined()
     expect($input.attributes('type')).toEqual('checkbox')
 
@@ -74,7 +74,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    expect(wrapper.find('input').attributes('aria-label')).toBeUndefined()
+    expect(wrapper.get('input').attributes('aria-label')).toBeUndefined()
 
     wrapper.unmount()
   })
@@ -90,7 +90,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    expect(wrapper.find('input').attributes('aria-label')).toBe('bar')
+    expect(wrapper.get('input').attributes('aria-label')).toBe('bar')
 
     wrapper.unmount()
   })
@@ -105,7 +105,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('form-check-input')
     expect($input.classes()).not.toContain('position-static')
@@ -123,7 +123,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.classes().length).toEqual(1)
     expect($label.classes()).toContain('form-check-label')
 
@@ -140,7 +140,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.text()).toEqual('foobar')
 
     wrapper.unmount()
@@ -153,7 +153,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.text()).toEqual('')
 
     wrapper.unmount()
@@ -169,7 +169,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeUndefined()
 
     wrapper.unmount()
@@ -186,7 +186,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeDefined()
 
     wrapper.unmount()
@@ -202,7 +202,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('required')).toBeUndefined()
 
     wrapper.unmount()
@@ -219,7 +219,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('required')).toBeUndefined()
 
     wrapper.unmount()
@@ -237,7 +237,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('required')).toBeDefined()
 
     wrapper.unmount()
@@ -253,7 +253,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('name')).toBeUndefined()
 
     wrapper.unmount()
@@ -270,7 +270,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('name')).toBeDefined()
     expect($input.attributes('name')).toEqual('test')
 
@@ -287,7 +287,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('form')).toBeUndefined()
 
     wrapper.unmount()
@@ -304,7 +304,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('form')).toBeDefined()
     expect($input.attributes('form')).toEqual('test')
 
@@ -319,7 +319,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('foo')).toBeDefined()
     expect($input.attributes('foo')).toEqual('bar')
 
@@ -354,7 +354,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
@@ -373,7 +373,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
@@ -392,7 +392,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).toContain('is-valid')
@@ -411,7 +411,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
@@ -430,7 +430,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
     expect($input.attributes('id')).toEqual('test')
 
@@ -447,7 +447,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
 
     wrapper.unmount()
@@ -464,7 +464,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($label.attributes('for')).toEqual('test')
 
@@ -481,10 +481,10 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($input.attributes('id')).toEqual($label.attributes('for'))
 
@@ -510,8 +510,8 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
-    const $input2 = wrapper2.find('input')
+    const $input = wrapper.get('input')
+    const $input2 = wrapper2.get('input')
     expect($input.attributes('id')).toBeDefined()
     expect($input2.attributes('id')).toBeDefined()
     expect($input.attributes('id')).not.toEqual($input2.attributes('id'))
@@ -573,7 +573,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('type')).toBeDefined()
     expect($input.attributes('type')).toEqual('checkbox')
 
@@ -591,7 +591,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(0)
     expect($input.classes()).not.toContain('form-check-input')
 
@@ -609,7 +609,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.classes()).not.toContain('form-check-label')
     expect($label.classes().length).toEqual(0)
 
@@ -627,7 +627,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.text()).toEqual('foobar')
 
     wrapper.unmount()
@@ -644,7 +644,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    expect(wrapper.find('input').classes()).not.toContain('position-static')
+    expect(wrapper.get('input').classes()).not.toContain('position-static')
 
     wrapper.unmount()
   })
@@ -689,7 +689,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
@@ -709,7 +709,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
@@ -729,7 +729,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).toContain('is-valid')
@@ -749,7 +749,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.classes()).toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
@@ -813,7 +813,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('type')).toBeDefined()
     expect($input.attributes('type')).toEqual('checkbox')
 
@@ -831,7 +831,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('form-check-input')
 
@@ -849,7 +849,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.classes().length).toEqual(1)
     expect($label.classes()).toContain('form-check-label')
 
@@ -893,7 +893,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('btn-check')
 
@@ -912,7 +912,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
     expect($label.classes().length).toEqual(2)
     expect($label.classes()).not.toContain('active')
@@ -935,7 +935,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
     expect($label.classes().length).toEqual(3)
     expect($label.classes()).not.toContain('focus')
@@ -961,10 +961,10 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($label.classes().length).toEqual(2)
     expect($label.classes()).not.toContain('focus')
@@ -994,10 +994,10 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($label.classes().length).toEqual(2)
     expect($label.classes()).not.toContain('focus')
     expect($label.classes()).not.toContain('active')
@@ -1029,7 +1029,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
     expect($label.classes().length).toEqual(2)
     expect($label.classes()).not.toContain('focus')
@@ -1054,7 +1054,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('btn-check')
 
@@ -1073,7 +1073,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.indeterminate).toBe(false)
 
@@ -1091,7 +1091,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.indeterminate).toBe(true)
 
@@ -1109,7 +1109,7 @@ describe('form-checkbox', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.indeterminate).toBe(false)
 
@@ -1138,7 +1138,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toEqual(false)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(false)
 
@@ -1159,7 +1159,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toEqual(true)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(true)
 
@@ -1240,7 +1240,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
 
     await $input.setValue(true)
@@ -1275,7 +1275,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
 
     await $label.trigger('click')
@@ -1311,7 +1311,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
 
     await $input.trigger('click')
@@ -1340,7 +1340,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
 
     await $label.trigger('click')
@@ -1370,7 +1370,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue.length).toBe(1)
     expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(false)
 
@@ -1448,7 +1448,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue.length).toBe(1)
     expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(false)
 
@@ -1487,7 +1487,7 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue.length).toBe(1)
     expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
 
     await $input.trigger('click')

--- a/packages/bootstrap-vue-3/src/components/BFormInput/form-input.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormInput/form-input.spec.js
@@ -8,7 +8,7 @@ describe('form-input', () => {
   it('has class form-control', () => {
     const wrapper = mount(BFormInput)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control')
 
     wrapper.unmount()
@@ -21,7 +21,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-lg')
 
     wrapper.unmount()
@@ -34,7 +34,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-sm')
 
     wrapper.unmount()
@@ -43,7 +43,7 @@ describe('form-input', () => {
   it('does not have class form-control-plaintext when plaintext not set', () => {
     const wrapper = mount(BFormInput)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).not.toContain('form-control-plaintext')
     expect($input.attributes('readonly')).toBeUndefined()
 
@@ -57,7 +57,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-plaintext')
 
     wrapper.unmount()
@@ -70,7 +70,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-plaintext')
     expect($input.attributes('readonly')).toBeDefined()
 
@@ -84,7 +84,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-range')
     expect($input.classes()).not.toContain('form-control')
 
@@ -99,7 +99,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-range')
     expect($input.classes()).not.toContain('form-control')
     expect($input.classes()).not.toContain('form-control-plaintext')
@@ -115,7 +115,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).not.toContain('custom-range')
     expect($input.classes()).not.toContain('form-control-plaintext')
     expect($input.classes()).toContain('form-control')
@@ -130,7 +130,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBe('foobar')
 
     wrapper.unmount()
@@ -144,7 +144,7 @@ describe('form-input', () => {
     // We need to wait a tick for `safeId` to be generated
     await waitNT(wrapper.vm)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
 
     wrapper.unmount()
@@ -157,7 +157,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('form')).toBe('foobar')
 
     wrapper.unmount()
@@ -166,7 +166,7 @@ describe('form-input', () => {
   it('does not have list attribute when list prop not set', () => {
     const wrapper = mount(BFormInput)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('list')).toBeUndefined()
 
     wrapper.unmount()
@@ -179,7 +179,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('list')).toBe('foobar')
 
     wrapper.unmount()
@@ -193,7 +193,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('list')).toBeUndefined()
 
     wrapper.unmount()
@@ -202,7 +202,7 @@ describe('form-input', () => {
   it('renders text input by default', () => {
     const wrapper = mount(BFormInput)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('type')).toBe('text')
 
     wrapper.unmount()
@@ -215,7 +215,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('type')).toBe('number')
 
     wrapper.unmount()
@@ -235,7 +235,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('type')).toBe('text')
 
     expect(warnHandler).toHaveBeenCalled()
@@ -246,7 +246,7 @@ describe('form-input', () => {
   it('does not have is-valid or is-invalid classes when state is default', () => {
     const wrapper = mount(BFormInput)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).not.toContain('is-valid')
     expect($input.classes()).not.toContain('is-invalid')
 
@@ -260,7 +260,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('is-valid')
     expect($input.classes()).not.toContain('is-invalid')
 
@@ -274,7 +274,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes()).toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
 
@@ -308,7 +308,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('true')
 
     wrapper.unmount()
@@ -321,7 +321,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('true')
 
     wrapper.unmount()
@@ -334,7 +334,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('true')
 
     wrapper.unmount()
@@ -347,7 +347,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('spelling')
 
     wrapper.unmount()
@@ -360,7 +360,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeDefined()
     expect($input.element.disabled).toBe(true)
 
@@ -374,7 +374,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeUndefined()
     expect($input.element.disabled).toBe(false)
 
@@ -384,7 +384,7 @@ describe('form-input', () => {
   it('emits an input event', async () => {
     const wrapper = mount(BFormInput)
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     $input.element.value = 'test'
     await $input.trigger('input')
 
@@ -403,7 +403,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     await $input.trigger('focus')
 
     expect(wrapper.emitted()).toMatchObject({})
@@ -419,7 +419,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     await $input.trigger('blur')
 
     expect(wrapper.emitted('blur')).toBeDefined()
@@ -440,7 +440,7 @@ describe('form-input', () => {
       attachTo: createContainer(),
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     $input.element.value = 'TEST'
     await $input.trigger('input')
 
@@ -469,7 +469,7 @@ describe('form-input', () => {
       attachTo: createContainer(),
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     $input.element.value = 'TEST'
     await $input.trigger('input')
 
@@ -500,7 +500,7 @@ describe('form-input', () => {
       attachTo: createContainer(),
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
 
     // Input event needed to set initial value
     $input.element.value = 'TEST'
@@ -556,7 +556,7 @@ describe('form-input', () => {
       attachTo: createContainer(),
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     await wrapper.setProps({modelValue: 'TEST'})
 
     expect($input.element.value).toEqual('TEST')
@@ -580,7 +580,7 @@ describe('form-input', () => {
       attachTo: createContainer(),
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     await wrapper.setProps({modelValue: 'TEST'})
 
     expect($input.element.value).toEqual('TEST')
@@ -734,7 +734,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     $input.element.value = '123.450'
     await $input.trigger('input')
 
@@ -780,7 +780,7 @@ describe('form-input', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     $input.element.value = 'a'
     await $input.trigger('input')
     expect($input.element.value).toBe('a')
@@ -834,7 +834,7 @@ describe('form-input', () => {
       }
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     $input.element.value = 'a'
     await $input.trigger('input')
     expect($input.element.value).toBe('a')

--- a/packages/bootstrap-vue-3/src/components/BFormRadio/form-radio.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormRadio/form-radio.spec.js
@@ -53,7 +53,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('radio')
 
@@ -70,7 +70,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-input')
 
@@ -87,7 +87,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('label')
+    const input = wrapper.get('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-label')
 
@@ -104,7 +104,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label.text()).toEqual('foobar')
 
     wrapper.unmount()
@@ -120,7 +120,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('disabled')).toBeUndefined()
 
     wrapper.unmount()
@@ -137,7 +137,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('disabled')).toBeDefined()
 
     wrapper.unmount()
@@ -153,7 +153,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('required')).toBeUndefined()
 
     wrapper.unmount()
@@ -170,7 +170,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('required')).toBeUndefined()
     expect(input.attributes('aria-required')).toBeUndefined()
 
@@ -189,7 +189,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('required')).toBeDefined()
     expect(input.attributes('aria-required')).toBeDefined()
 
@@ -206,7 +206,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('name')).toBeUndefined()
 
     wrapper.unmount()
@@ -223,7 +223,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('name')).toBeDefined()
     expect(input.attributes('name')).toEqual('test')
 
@@ -240,7 +240,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('form')).toBeUndefined()
 
     wrapper.unmount()
@@ -257,7 +257,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('form')).toBeDefined()
     expect(input.attributes('form')).toEqual('test')
 
@@ -271,7 +271,7 @@ describe('form-radio', () => {
         foo: 'bar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('foo')).toBeDefined()
     expect(input.attributes('foo')).toEqual('bar')
 
@@ -306,7 +306,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
@@ -325,7 +325,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
@@ -344,7 +344,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
@@ -363,7 +363,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
@@ -382,7 +382,7 @@ describe('form-radio', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
     expect($input.attributes('id')).toEqual('test')
 
@@ -399,7 +399,7 @@ describe('form-radio', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
 
     wrapper.unmount()
@@ -416,7 +416,7 @@ describe('form-radio', () => {
       },
     })
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($label.attributes('for')).toEqual('test')
 
@@ -433,10 +433,10 @@ describe('form-radio', () => {
       },
     })
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($input.attributes('id')).toEqual($label.attributes('for'))
 
@@ -462,8 +462,8 @@ describe('form-radio', () => {
       },
     })
 
-    const $input = wrapper.find('input')
-    const $input2 = wrapper2.find('input')
+    const $input = wrapper.get('input')
+    const $input2 = wrapper2.get('input')
     expect($input.attributes('id')).toBeDefined()
     expect($input2.attributes('id')).toBeDefined()
     expect($input.attributes('id')).not.toEqual($input2.attributes('id'))
@@ -521,7 +521,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('radio')
 
@@ -539,7 +539,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input.classes()).not.toContain('form-check-input')
     expect(input.classes().length).toEqual(0)
 
@@ -557,7 +557,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('label')
+    const input = wrapper.get('label')
     expect(input.classes()).not.toContain('form-check-label')
     expect(input.classes().length).toEqual(0)
 
@@ -575,7 +575,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label.text()).toEqual('foobar')
 
     wrapper.unmount()
@@ -592,7 +592,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
@@ -612,7 +612,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
@@ -632,7 +632,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
@@ -652,7 +652,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
@@ -695,7 +695,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('btn-check')
 
@@ -713,7 +713,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label).toBeDefined()
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('active')
@@ -736,7 +736,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label).toBeDefined()
     expect(label.classes().length).toEqual(3)
     expect(label.classes()).not.toContain('active')
@@ -759,7 +759,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label).toBeDefined()
     expect(label.classes().length).toEqual(3)
     expect(label.classes()).not.toContain('focus')
@@ -784,9 +784,9 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label).toBeDefined()
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('focus')
@@ -817,10 +817,10 @@ describe('form-radio', () => {
       },
     })
 
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label).toBeDefined()
 
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('focus')
     expect(label.classes()).not.toContain('active')
@@ -851,7 +851,7 @@ describe('form-radio', () => {
         default: 'foobar',
       },
     })
-    const label = wrapper.find('label')
+    const label = wrapper.get('label')
     expect(label).toBeDefined()
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('focus')
@@ -942,7 +942,7 @@ describe('form-radio', () => {
     expect(wrapper.vm.modelValue).toBe(false)
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
 
     await input.trigger('click')
@@ -973,7 +973,7 @@ describe('form-radio', () => {
 
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
 
     await $label.trigger('click')
@@ -1007,7 +1007,7 @@ describe('form-radio', () => {
 
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
 
     await $input.trigger('click')
@@ -1033,7 +1033,7 @@ describe('form-radio', () => {
     expect(wrapper.vm.modelValue).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
 
-    const $label = wrapper.find('label')
+    const $label = wrapper.get('label')
     expect($label).toBeDefined()
 
     await $label.trigger('click')
@@ -1063,7 +1063,7 @@ describe('form-radio', () => {
     expect(wrapper.vm.modelValue.length).toBe(1)
     expect(wrapper.vm.modelValue[0]).toEqual('foo')
 
-    const $input = wrapper.find('input')
+    const $input = wrapper.get('input')
     expect($input).toBeDefined()
 
     await $input.trigger('click')
@@ -1125,7 +1125,7 @@ describe('form-radio', () => {
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toEqual(false)
 
-    const input = wrapper.find('input')
+    const input = wrapper.get('input')
     expect(input).toBeDefined()
 
     await input.trigger('click')

--- a/packages/bootstrap-vue-3/src/components/BFormSelect/form-select-option.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormSelect/form-select-option.spec.js
@@ -47,7 +47,7 @@ describe('form-select-option', () => {
     expect(wrapper.element.tagName).toBe('OPTION')
     expect(wrapper.attributes('value')).toEqual('foo')
 
-    const $bold = wrapper.find('b')
+    const $bold = wrapper.get('b')
     expect($bold.text()).toEqual('Bold')
 
     wrapper.unmount()

--- a/packages/bootstrap-vue-3/src/components/BFormTextarea/form-textarea.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormTextarea/form-textarea.spec.js
@@ -7,7 +7,7 @@ describe('form-textarea', () => {
   it('has class form-control', () => {
     const wrapper = mount(BFormTextarea)
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control')
 
     wrapper.unmount()
@@ -20,7 +20,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-lg')
 
     wrapper.unmount()
@@ -33,7 +33,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-sm')
 
     wrapper.unmount()
@@ -42,7 +42,7 @@ describe('form-textarea', () => {
   it('does not have class form-control-plaintext when plaintext not set', () => {
     const wrapper = mount(BFormTextarea)
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).not.toContain('form-control-plaintext')
     expect($textarea.attributes('readonly')).toBeUndefined()
 
@@ -56,7 +56,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-plaintext')
 
     wrapper.unmount()
@@ -69,7 +69,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-plaintext')
     expect($textarea.attributes('readonly')).toBeDefined()
 
@@ -83,7 +83,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('id')).toBe('foobar')
 
     wrapper.unmount()
@@ -97,7 +97,7 @@ describe('form-textarea', () => {
     // We need to wait a tick for `safeId` to be generated
     await waitNT(wrapper.vm)
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('id')).toBeDefined()
 
     wrapper.unmount()
@@ -110,7 +110,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('form')).toBe('foobar')
 
     wrapper.unmount()
@@ -119,7 +119,7 @@ describe('form-textarea', () => {
   it('does not have is-valid or is-invalid classes when state is default', () => {
     const wrapper = mount(BFormTextarea)
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).not.toContain('is-valid')
     expect($textarea.classes()).not.toContain('is-invalid')
 
@@ -133,7 +133,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('is-valid')
     expect($textarea.classes()).not.toContain('is-invalid')
 
@@ -147,7 +147,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('is-invalid')
     expect($textarea.classes()).not.toContain('is-valid')
 
@@ -181,7 +181,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('true')
 
     wrapper.unmount()
@@ -194,7 +194,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('true')
 
     wrapper.unmount()
@@ -207,7 +207,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('true')
 
     wrapper.unmount()
@@ -220,7 +220,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('spelling')
 
     wrapper.unmount()
@@ -233,7 +233,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('rows')).toBeDefined()
     expect($textarea.element.rows).toBe(8)
 
@@ -247,7 +247,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('disabled')).toBeDefined()
     expect($textarea.element.disabled).toBe(true)
 
@@ -261,7 +261,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('disabled')).toBeUndefined()
     expect($textarea.element.disabled).toBe(false)
 
@@ -271,7 +271,7 @@ describe('form-textarea', () => {
   it('emits an input event', async () => {
     const wrapper = mount(BFormTextarea)
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     $textarea.element.value = 'test'
     await $textarea.trigger('input')
 
@@ -290,7 +290,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     await $textarea.trigger('focus')
 
     expect(wrapper.emitted()).toMatchObject({})
@@ -306,7 +306,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     await $textarea.trigger('blur')
 
     expect(wrapper.emitted('blur')).toBeDefined()
@@ -327,7 +327,7 @@ describe('form-textarea', () => {
       attachTo: createContainer(),
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     $textarea.element.value = 'TEST'
     await $textarea.trigger('input')
 
@@ -356,7 +356,7 @@ describe('form-textarea', () => {
       attachTo: createContainer(),
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     $textarea.element.value = 'TEST'
     await $textarea.trigger('input')
 
@@ -387,7 +387,7 @@ describe('form-textarea', () => {
       attachTo: createContainer(),
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
 
     // Input event needed to set initial value
     $textarea.element.value = 'TEST'
@@ -443,7 +443,7 @@ describe('form-textarea', () => {
       attachTo: createContainer(),
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     await wrapper.setProps({modelValue: 'TEST'})
 
     expect($textarea.element.value).toEqual('TEST')
@@ -467,7 +467,7 @@ describe('form-textarea', () => {
       attachTo: createContainer(),
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     await wrapper.setProps({modelValue: 'TEST'})
 
     expect($textarea.element.value).toEqual('TEST')
@@ -621,7 +621,7 @@ describe('form-textarea', () => {
       },
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     $textarea.element.value = 'a'
     await $textarea.trigger('input')
     expect($textarea.element.value).toBe('a')
@@ -675,7 +675,7 @@ describe('form-textarea', () => {
       }
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
     $textarea.element.value = 'a'
     await $textarea.trigger('input')
     expect($textarea.element.value).toBe('a')
@@ -771,7 +771,7 @@ describe('form-textarea', () => {
       attachTo: createContainer(),
     })
 
-    const $textarea = wrapper.find('textarea')
+    const $textarea = wrapper.get('textarea')
 
     expect(typeof wrapper.vm.focus).toBe('function')
     expect(typeof wrapper.vm.blur).toBe('function')

--- a/packages/bootstrap-vue-3/src/components/BImg.vue
+++ b/packages/bootstrap-vue-3/src/components/BImg.vue
@@ -116,25 +116,23 @@ const attrs = computed(() => {
   }
 })
 
-const classes = computed(() => {
-  let align = ''
-  let block = blockBoolean.value
-  if (leftBoolean.value) {
-    align = 'float-start'
-  } else if (rightBoolean.value) {
-    align = 'float-end'
-  } else if (centerBoolean.value) {
-    align = 'mx-auto'
-    block = true
-  }
-  return {
-    'img-thumbnail': thumbnailBoolean.value,
-    'img-fluid': fluidBoolean.value || fluidGrowBoolean.value,
-    'w-100': fluidGrowBoolean.value,
-    'rounded': props.rounded === '' || props.rounded === true,
-    [`rounded-${props.rounded}`]: typeof props.rounded === 'string' && props.rounded !== '',
-    [align]: !!align,
-    'd-block': block,
-  }
-})
+const alignment = computed(() =>
+  leftBoolean.value
+    ? 'float-start'
+    : rightBoolean.value
+    ? 'float-end'
+    : centerBoolean.value
+    ? 'mx-auto'
+    : undefined
+)
+
+const classes = computed(() => ({
+  'img-thumbnail': thumbnailBoolean.value,
+  'img-fluid': fluidBoolean.value || fluidGrowBoolean.value,
+  'w-100': fluidGrowBoolean.value,
+  'rounded': props.rounded === '' || props.rounded === true,
+  [`rounded-${props.rounded}`]: typeof props.rounded === 'string' && props.rounded !== '',
+  [`${alignment.value}`]: alignment.value !== undefined,
+  'd-block': blockBoolean.value || centerBoolean.value,
+}))
 </script>

--- a/packages/bootstrap-vue-3/src/components/BLink/link.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BLink/link.spec.js
@@ -199,7 +199,7 @@ describe('b-link', () => {
       expect(called).toBe(0)
       expect(evt).toEqual(null)
 
-      await wrapper.find('a').trigger('click')
+      await wrapper.get('a').trigger('click')
       expect(called).toBe(1)
       expect(evt).toBeInstanceOf(MouseEvent)
 
@@ -219,7 +219,7 @@ describe('b-link', () => {
       expect(spy1).not.toHaveBeenCalled()
       expect(spy2).not.toHaveBeenCalled()
 
-      await wrapper.find('a').trigger('click')
+      await wrapper.get('a').trigger('click')
       expect(spy1).toHaveBeenCalled()
       expect(spy2).toHaveBeenCalled()
 
@@ -245,7 +245,7 @@ describe('b-link', () => {
       expect(called).toBe(0)
       expect(evt).toEqual(null)
 
-      await wrapper.find('a').trigger('click')
+      await wrapper.get('a').trigger('click')
       expect(called).toBe(0)
       expect(evt).toEqual(null)
 
@@ -261,9 +261,9 @@ describe('b-link', () => {
       })
 
       expect(wrapper.element.tagName).toBe('A')
-      wrapper.find('a').element.addEventListener('click', spy)
+      wrapper.get('a').element.addEventListener('click', spy)
 
-      await wrapper.find('a').trigger('click')
+      await wrapper.get('a').trigger('click')
       expect(spy).not.toHaveBeenCalled()
 
       wrapper.unmount()

--- a/packages/bootstrap-vue-3/src/components/BNavbar/navbar.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNavbar/navbar.spec.ts
@@ -157,7 +157,7 @@ describe('navbar', () => {
       props: {container: true},
       slots: {default: 'foobar'},
     })
-    const $div = wrapper.find('div')
+    const $div = wrapper.get('div')
     expect($div.text()).toBe('foobar')
 
     wrapper.unmount()
@@ -167,7 +167,7 @@ describe('navbar', () => {
     const wrapper = mount(BNavbar, {
       slots: {default: 'foobar'},
     })
-    const $div = wrapper.find('div')
+    const $div = wrapper.get('div')
     expect($div.text()).toBe('foobar')
 
     wrapper.unmount()

--- a/packages/bootstrap-vue-3/src/components/BOffcanvas.vue
+++ b/packages/bootstrap-vue-3/src/components/BOffcanvas.vue
@@ -20,6 +20,11 @@
         data-bs-dismiss="offcanvas"
         aria-label="Close"
       />
+      <!-- TODO this aria-label is static -->
+      <!-- This presents a problem for i18n applications -->
+      <!-- Perhaps we should refactor to be a bit more i18n friendly? -->
+      <!-- Proposal, either follow Vuetify in implementing multilanguage native support -->
+      <!-- OR, the simpler route, and to make the property a dynamic prop. Or both -->
     </div>
     <div class="offcanvas-body">
       <slot />

--- a/packages/bootstrap-vue-3/src/components/BPopover.vue
+++ b/packages/bootstrap-vue-3/src/components/BPopover.vue
@@ -81,7 +81,7 @@ export default defineComponent({
     const titleRef = ref<HTMLElement>()
     const contentRef = ref<HTMLElement>()
     const classes = computed(() => ({
-      [`b-popover-${props.variant}`]: props.variant,
+      [`b-popover-${props.variant}`]: props.variant !== undefined,
     }))
 
     const cleanElementProp = (

--- a/packages/bootstrap-vue-3/src/components/BRow.vue
+++ b/packages/bootstrap-vue-3/src/components/BRow.vue
@@ -27,9 +27,9 @@ export default defineComponent({
     const classes = computed(() => ({
       [`gx-${props.gutterX}`]: props.gutterX !== null,
       [`gy-${props.gutterY}`]: props.gutterY !== null,
-      [`align-items-${props.alignV}`]: props.alignV,
-      [`justify-content-${props.alignH}`]: props.alignH,
-      [`align-content-${props.alignContent}`]: props.alignContent,
+      [`align-items-${props.alignV}`]: props.alignV !== null,
+      [`justify-content-${props.alignH}`]: props.alignH !== null,
+      [`align-content-${props.alignContent}`]: props.alignContent !== null,
     }))
 
     return {

--- a/packages/bootstrap-vue-3/src/components/BSpinner.vue
+++ b/packages/bootstrap-vue-3/src/components/BSpinner.vue
@@ -40,6 +40,6 @@ const classes = computed(() => ({
   'spinner-border-sm': props.type === 'border' && smallBoolean.value,
   'spinner-grow': props.type === 'grow',
   'spinner-grow-sm': props.type === 'grow' && smallBoolean.value,
-  [`text-${props.variant}`]: !!props.variant,
+  [`text-${props.variant}`]: props.variant !== undefined,
 }))
 </script>

--- a/packages/bootstrap-vue-3/src/components/BToast/b-toast.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BToast/b-toast.spec.js
@@ -24,20 +24,20 @@ describe('b-Toast', () => {
     await waitRAF()
 
     expect(wrapper.find('.toast').exists()).toBe(true)
-    const $toast = wrapper.find('.toast')
+    const $toast = wrapper.get('.toast')
     expect($toast.element.tagName).toBe('DIV')
     expect($toast.classes()).toContain('toast')
 
     expect($toast.find('.toast-header').exists()).toBe(true)
 
-    const $header = $toast.find('.toast-header')
-    expect($header.find('strong').text()).toEqual('Test')
-    expect($header.find('strong').classes()).toContain('me-auto')
+    const $header = $toast.get('.toast-header')
+    expect($header.get('strong').text()).toEqual('Test')
+    expect($header.get('strong').classes()).toContain('me-auto')
     expect($header.find('button').exists()).toBe(true)
-    expect($header.find('button').classes()).toContain('btn-close')
+    expect($header.get('button').classes()).toContain('btn-close')
 
     expect($toast.find('.toast-body').exists()).toBe(true)
-    const $body = $toast.find('.toast-body')
+    const $body = $toast.get('.toast-body')
     expect($body.element.tagName).toBe('DIV')
     expect($body.classes().length).toBe(1)
     expect($body.text()).toEqual('Test Body')

--- a/packages/bootstrap-vue-3/src/components/alert.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/alert.spec.ts
@@ -1,0 +1,235 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BAlert from './BAlert.vue'
+
+describe('alert', () => {
+  it('has static class alert', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true},
+    })
+    expect(wrapper.classes()).toContain('alert')
+
+    wrapper.unmount()
+  })
+
+  it('has static role set to alert', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true},
+    })
+    expect(wrapper.attributes('role')).toBe('alert')
+
+    wrapper.unmount()
+  })
+
+  it('has class alert-{type} when prop variant', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, variant: 'primary'},
+    })
+    expect(wrapper.classes()).toContain('alert-primary')
+    await wrapper.setProps({variant: undefined})
+    expect(wrapper.classes()).not.toContain('alert-primary')
+
+    wrapper.unmount()
+  })
+
+  it('has class show when prop modelValue', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true},
+    })
+    expect(wrapper.classes()).toContain('show')
+    await wrapper.setProps({modelValue: false})
+    expect(wrapper.classes()).not.toContain('show')
+
+    wrapper.unmount()
+  })
+
+  it('has class alert-dismissible when prop dismissible', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    expect(wrapper.classes()).toContain('alert-dismissible')
+    await wrapper.setProps({dismissible: false})
+    expect(wrapper.classes()).not.toContain('alert-dismissible')
+
+    wrapper.unmount()
+  })
+
+  it('has class fade when prop modelValue', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true},
+    })
+    expect(wrapper.classes()).toContain('fade')
+    await wrapper.setProps({modelValue: false})
+    expect(wrapper.classes()).not.toContain('fade')
+
+    wrapper.unmount()
+  })
+
+  it('component exists when modelValue true', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true},
+    })
+    const $div = wrapper.find('div')
+    expect($div.exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('component does not exist when modelValue false', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: false},
+    })
+    const $div = wrapper.find('div')
+    expect($div.exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('component exists when show true', () => {
+    const wrapper = mount(BAlert, {
+      props: {show: true},
+    })
+    const $div = wrapper.find('div')
+    expect($div.exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('component does not exist when show false', () => {
+    const wrapper = mount(BAlert, {
+      props: {show: false},
+    })
+    const $div = wrapper.find('div')
+    expect($div.exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true},
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('has button child if prop dismissible', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.find('button')
+    expect($button.exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('does not have button child if prop dismissible false', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: false},
+    })
+    const $button = wrapper.find('button')
+    expect($button.exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('button child has static attribute type button', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    expect($button.attributes('type')).toBe('button')
+
+    wrapper.unmount()
+  })
+
+  it('button child has static class btn-close', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    expect($button.classes()).toContain('btn-close')
+
+    wrapper.unmount()
+  })
+
+  it('button child has static attribute data-bs-dismiss alert', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    expect($button.attributes('data-bs-dismiss')).toBe('alert')
+
+    wrapper.unmount()
+  })
+
+  it('button child has aria-label Close by default', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    expect($button.attributes('aria-label')).toBe('Close')
+
+    wrapper.unmount()
+  })
+
+  it('button child has aria-label prop dismissLabel', () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true, dismissLabel: 'foobar'},
+    })
+    const $button = wrapper.get('button')
+    expect($button.attributes('aria-label')).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('button child on click emits update:modelValue', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    await $button.trigger('click')
+    expect(wrapper.emitted()).toHaveProperty('update:modelValue')
+
+    wrapper.unmount()
+  })
+
+  it('button child on click emits dismissed', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    await $button.trigger('click')
+    expect(wrapper.emitted()).toHaveProperty('dismissed')
+
+    wrapper.unmount()
+  })
+
+  it('button child on click emits update:modelValue and gives value false if prop modelValue boolean', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: true, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    await $button.trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    const [event] = wrapper.emitted('update:modelValue') ?? []
+    expect(event).toEqual([false])
+
+    wrapper.unmount()
+  })
+
+  it('button child on click emits update:modelValue and gives value 0 if prop modelValue number', async () => {
+    const wrapper = mount(BAlert, {
+      props: {modelValue: 1000, dismissible: true},
+    })
+    const $button = wrapper.get('button')
+    await $button.trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    const [event] = wrapper.emitted('update:modelValue') ?? []
+    expect(event).toEqual([0])
+
+    wrapper.unmount()
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/col.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/col.spec.ts
@@ -1,0 +1,23 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BCol from './BCol.vue'
+
+describe('col', () => {
+  it('tag is default div', () => {
+    const wrapper = mount(BCol)
+    expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
+  })
+
+  it('tag is prop tag', () => {
+    const wrapper = mount(BCol, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+
+    wrapper.unmount()
+  })
+
+  // TODO
+})

--- a/packages/bootstrap-vue-3/src/components/col.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/col.spec.ts
@@ -19,5 +19,75 @@ describe('col', () => {
     wrapper.unmount()
   })
 
-  // TODO
+  it('has class col-{type} when prop cols', async () => {
+    const wrapper = mount(BCol, {
+      props: {cols: '6'},
+    })
+    expect(wrapper.classes()).toContain('col-6')
+    await wrapper.setProps({cols: null})
+    expect(wrapper.classes()).not.toContain('col-6')
+
+    wrapper.unmount()
+  })
+
+  it('has class offset-{type} when prop offset', async () => {
+    const wrapper = mount(BCol, {
+      props: {offset: '6'},
+    })
+    expect(wrapper.classes()).toContain('offset-6')
+    await wrapper.setProps({offset: null})
+    expect(wrapper.classes()).not.toContain('offset-6')
+
+    wrapper.unmount()
+  })
+
+  it('has class order-{type} when prop order', async () => {
+    const wrapper = mount(BCol, {
+      props: {order: '6'},
+    })
+    expect(wrapper.classes()).toContain('order-6')
+    await wrapper.setProps({order: null})
+    expect(wrapper.classes()).not.toContain('order-6')
+
+    wrapper.unmount()
+  })
+
+  it('has class align-self-{type} when prop order', async () => {
+    const wrapper = mount(BCol, {
+      props: {alignSelf: 'baseline'},
+    })
+    expect(wrapper.classes()).toContain('align-self-baseline')
+    await wrapper.setProps({alignSelf: null})
+    expect(wrapper.classes()).not.toContain('align-self-baseline')
+
+    wrapper.unmount()
+  })
+
+  it('has class col when prop col', async () => {
+    const wrapper = mount(BCol, {
+      props: {col: true, cols: 'auto'},
+    })
+    expect(wrapper.classes()).toContain('col')
+
+    wrapper.unmount()
+  })
+
+  // TODO this component almost always seems like it has col class
+  it.skip('does not have class col when prop col false and prop cols Truthy', async () => {
+    const wrapper = mount(BCol, {
+      props: {col: false, cols: 'auto'},
+    })
+    expect(wrapper.classes()).not.toContain('col')
+
+    wrapper.unmount()
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BCol, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
 })

--- a/packages/bootstrap-vue-3/src/components/collapse.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/collapse.spec.ts
@@ -1,0 +1,83 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BCollapse from './BCollapse.vue'
+
+describe('collapse', () => {
+  it('has static class collapse', () => {
+    const wrapper = mount(BCollapse)
+    expect(wrapper.classes()).toContain('collapse')
+
+    wrapper.unmount()
+  })
+
+  it('has default tag div', () => {
+    const wrapper = mount(BCollapse)
+    expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
+  })
+
+  it('is tag when prop tag', () => {
+    const wrapper = mount(BCollapse, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+
+    wrapper.unmount()
+  })
+
+  it('has default id', () => {
+    const wrapper = mount(BCollapse)
+    expect(wrapper.attributes('id')).toBeDefined()
+
+    wrapper.unmount()
+  })
+
+  it('has id as prop id', () => {
+    const wrapper = mount(BCollapse, {
+      props: {id: 'foobar'},
+    })
+    expect(wrapper.attributes('id')).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('has data-bs-parent when prop accordion', () => {
+    const wrapper = mount(BCollapse, {
+      props: {accordion: 'abc'},
+    })
+    expect(wrapper.attributes('data-bs-parent')).toBe('abc')
+
+    wrapper.unmount()
+  })
+
+  it('has data-bs-parent null when accordion undefined', () => {
+    const wrapper = mount(BCollapse)
+    expect(wrapper.attributes('data-bs-parent')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+
+  it('has attribute is-nav when prop is nav', async () => {
+    const wrapper = mount(BCollapse, {
+      props: {isNav: true},
+    })
+    expect(wrapper.attributes('is-nav')).toBe('true')
+    await wrapper.setProps({isNav: false})
+    expect(wrapper.attributes('is-nav')).toBe('false')
+
+    wrapper.unmount()
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BCollapse, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  // TODO :visible prop on default slot does not seem to have any affect on slot being visible
+  // Perhaps it was supposed to be v-if/v-show?
+})

--- a/packages/bootstrap-vue-3/src/components/container.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/container.spec.ts
@@ -1,0 +1,12 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BContainer from './BContainer.vue'
+
+describe('container', () => {
+  it('renders default slot', () => {
+    const wrapper = mount(BContainer, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/img.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/img.spec.ts
@@ -1,0 +1,172 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BImg from './BImg.vue'
+
+describe('img', () => {
+  it('has class img-thumbnail if prop thumbnail', async () => {
+    const wrapper = mount(BImg, {
+      props: {thumbnail: true},
+    })
+    expect(wrapper.classes()).toContain('img-thumbnail')
+    await wrapper.setProps({thumbnail: false})
+    expect(wrapper.classes()).not.toContain('img-thumbnail')
+
+    wrapper.unmount()
+  })
+
+  it('has class img-fluid if prop fluid', async () => {
+    const wrapper = mount(BImg, {
+      props: {fluid: true},
+    })
+    expect(wrapper.classes()).toContain('img-fluid')
+    await wrapper.setProps({fluid: false})
+    expect(wrapper.classes()).not.toContain('img-fluid')
+
+    wrapper.unmount()
+  })
+
+  it('has class img-fluid if prop fluidGrow', async () => {
+    const wrapper = mount(BImg, {
+      props: {fluidGrow: true},
+    })
+    expect(wrapper.classes()).toContain('img-fluid')
+    await wrapper.setProps({fluidGrow: false})
+    expect(wrapper.classes()).not.toContain('img-fluid')
+
+    wrapper.unmount()
+  })
+
+  it('has class w-100 if prop fluidGrow', async () => {
+    const wrapper = mount(BImg, {
+      props: {fluidGrow: true},
+    })
+    expect(wrapper.classes()).toContain('w-100')
+    await wrapper.setProps({fluidGrow: false})
+    expect(wrapper.classes()).not.toContain('w-100')
+
+    wrapper.unmount()
+  })
+
+  it('has class rounded if prop rounded true', async () => {
+    const wrapper = mount(BImg, {
+      props: {rounded: true},
+    })
+    expect(wrapper.classes()).toContain('rounded')
+    await wrapper.setProps({rounded: false})
+    expect(wrapper.classes()).not.toContain('rounded')
+
+    wrapper.unmount()
+  })
+
+  it('has class rounded if prop rounded empty string', async () => {
+    const wrapper = mount(BImg, {
+      props: {rounded: ''},
+    })
+    expect(wrapper.classes()).toContain('rounded')
+    await wrapper.setProps({rounded: false})
+    expect(wrapper.classes()).not.toContain('rounded')
+
+    wrapper.unmount()
+  })
+
+  it('has class rounded-{type} if prop rounded string', async () => {
+    const wrapper = mount(BImg, {
+      props: {rounded: 'abc'},
+    })
+    expect(wrapper.classes()).toContain('rounded-abc')
+    await wrapper.setProps({rounded: false})
+    expect(wrapper.classes()).not.toContain('rounded-abc')
+
+    wrapper.unmount()
+  })
+
+  it('has class d-block if prop block', async () => {
+    const wrapper = mount(BImg, {
+      props: {block: true},
+    })
+    expect(wrapper.classes()).toContain('d-block')
+    await wrapper.setProps({block: false})
+    expect(wrapper.classes()).not.toContain('d-block')
+
+    wrapper.unmount()
+  })
+
+  it('has class d-block if prop centerBoolean', async () => {
+    const wrapper = mount(BImg, {
+      props: {center: true},
+    })
+    expect(wrapper.classes()).toContain('d-block')
+    await wrapper.setProps({center: false})
+    expect(wrapper.classes()).not.toContain('d-block')
+
+    wrapper.unmount()
+  })
+
+  it('has class float-start if prop left', async () => {
+    const wrapper = mount(BImg, {
+      props: {left: true},
+    })
+    expect(wrapper.classes()).toContain('float-start')
+    await wrapper.setProps({left: false})
+    expect(wrapper.classes()).not.toContain('float-start')
+
+    wrapper.unmount()
+  })
+
+  it('has class float-end if prop right', async () => {
+    const wrapper = mount(BImg, {
+      props: {right: true},
+    })
+    expect(wrapper.classes()).toContain('float-end')
+    await wrapper.setProps({right: false})
+    expect(wrapper.classes()).not.toContain('float-end')
+
+    wrapper.unmount()
+  })
+
+  it('has class mx-auto if prop center', async () => {
+    const wrapper = mount(BImg, {
+      props: {center: true},
+    })
+    expect(wrapper.classes()).toContain('mx-auto')
+    await wrapper.setProps({center: false})
+    expect(wrapper.classes()).not.toContain('mx-auto')
+
+    wrapper.unmount()
+  })
+
+  it('has class float-start takes priority over prop right/center', async () => {
+    const wrapper = mount(BImg, {
+      props: {left: true, right: true, center: true},
+    })
+    expect(wrapper.classes()).toContain('float-start')
+    await wrapper.setProps({left: false})
+    expect(wrapper.classes()).toContain('float-end')
+
+    wrapper.unmount()
+  })
+
+  it('has class float-end takes priority over prop center', async () => {
+    const wrapper = mount(BImg, {
+      props: {right: true, center: true},
+    })
+    expect(wrapper.classes()).toContain('float-end')
+    await wrapper.setProps({right: false})
+    expect(wrapper.classes()).toContain('mx-auto')
+
+    wrapper.unmount()
+  })
+
+  it('does not have any alignment classes when all props are false', () => {
+    const wrapper = mount(BImg, {
+      props: {right: false, center: false, left: false},
+    })
+    expect(wrapper.classes()).not.toContain('float-start')
+    expect(wrapper.classes()).not.toContain('float-end')
+    expect(wrapper.classes()).not.toContain('mx-auto')
+
+    wrapper.unmount()
+  })
+
+  // TODO requires testing of attributes existing on img
+})

--- a/packages/bootstrap-vue-3/src/components/modal.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/modal.spec.ts
@@ -1,0 +1,14 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BModal from './BModal.vue'
+
+describe.skip('modal', () => {
+  // Having issues getting the 'body' from the VDOM
+
+  it('has static class modal', () => {
+    const wrapper = mount(BModal)
+    expect(wrapper.classes()).toContain('modal')
+
+    wrapper.unmount()
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
@@ -6,15 +6,157 @@ describe('offcanvas', () => {
   it('has static class offcanvas', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.classes()).toContain('offcanvas')
+
+    wrapper.unmount()
   })
 
   it('has tabindex -1', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.attributes('tabindex')).toBe('-1')
+
+    wrapper.unmount()
   })
 
   it('has aria-labelledby offcanvasLabel', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.attributes('aria-labelledby')).toBe('offcanvasLabel')
+
+    wrapper.unmount()
+  })
+
+  it('has offcanvas-{type} when prop placement', () => {
+    const wrapper = mount(BOffcanvas)
+    expect(wrapper.classes()).toContain('offcanvas-start')
+
+    wrapper.unmount()
+  })
+
+  it('has offcanvas-{type} when prop placement not default', () => {
+    const wrapper = mount(BOffcanvas, {
+      props: {placement: 'abc'},
+    })
+    expect(wrapper.classes()).toContain('offcanvas-abc')
+
+    wrapper.unmount()
+  })
+
+  it('has data-bs-backdrop', async () => {
+    const wrapper = mount(BOffcanvas)
+    expect(wrapper.attributes('data-bs-backdrop')).toBe('true')
+    await wrapper.setProps({backdrop: false})
+    expect(wrapper.attributes('data-bs-backdrop')).toBe('false')
+
+    wrapper.unmount()
+  })
+
+  it('has data-bs-scroll', async () => {
+    const wrapper = mount(BOffcanvas)
+    expect(wrapper.attributes('data-bs-scroll')).toBe('false')
+    await wrapper.setProps({bodyScrolling: true})
+    expect(wrapper.attributes('data-bs-scroll')).toBe('true')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has static class offcanvas-header', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    expect($div.classes()).toContain('offcanvas-header')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child h5 with static class offcanvas-title', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    const $h5 = $div.find('h5')
+    expect($h5.classes()).toContain('offcanvas-title')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child h5 has id offcanvasLabel', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    const $h5 = $div.find('h5')
+    expect($h5.attributes('id')).toContain('offcanvasLabel')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child h5 that has slot title', () => {
+    const wrapper = mount(BOffcanvas, {
+      slots: {title: 'foobar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    const $h5 = $div.find('h5')
+    expect($h5.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child h5 that has prop title', () => {
+    const wrapper = mount(BOffcanvas, {
+      props: {title: 'foobar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    const $h5 = $div.find('h5')
+    expect($h5.text()).toBe('foobar')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child button has static type button', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    const $button = $div.find('button')
+    expect($button.attributes('type')).toBe('button')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child button has static class btn-close', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    const $button = $div.find('button')
+    expect($button.classes()).toContain('btn-close')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child button has aria-label close', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    const $button = $div.find('button')
+    expect($button.attributes('aria-label')).toBe('Close')
+
+    wrapper.unmount()
+  })
+
+  it('first child div has child button has static class text-reset', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, $div] = wrapper.findAll('div')
+    const $button = $div.find('button')
+    expect($button.classes()).toContain('text-reset')
+
+    wrapper.unmount()
+  })
+
+  it('second child div has static class offcanvas-body', () => {
+    const wrapper = mount(BOffcanvas)
+    const [, , $div] = wrapper.findAll('div')
+    expect($div.classes()).toContain('offcanvas-body')
+
+    wrapper.unmount()
+  })
+
+  it('second child div renders default slot', () => {
+    const wrapper = mount(BOffcanvas, {
+      slots: {default: 'foobar'},
+    })
+    const [, , $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
@@ -69,7 +69,7 @@ describe('offcanvas', () => {
   it('first child div has child h5 with static class offcanvas-title', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
-    const $h5 = $div.find('h5')
+    const $h5 = $div.get('h5')
     expect($h5.classes()).toContain('offcanvas-title')
 
     wrapper.unmount()
@@ -78,7 +78,7 @@ describe('offcanvas', () => {
   it('first child div has child h5 has id offcanvasLabel', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
-    const $h5 = $div.find('h5')
+    const $h5 = $div.get('h5')
     expect($h5.attributes('id')).toContain('offcanvasLabel')
 
     wrapper.unmount()
@@ -89,7 +89,7 @@ describe('offcanvas', () => {
       slots: {title: 'foobar'},
     })
     const [, $div] = wrapper.findAll('div')
-    const $h5 = $div.find('h5')
+    const $h5 = $div.get('h5')
     expect($h5.text()).toBe('foobar')
 
     wrapper.unmount()
@@ -100,7 +100,7 @@ describe('offcanvas', () => {
       props: {title: 'foobar'},
     })
     const [, $div] = wrapper.findAll('div')
-    const $h5 = $div.find('h5')
+    const $h5 = $div.get('h5')
     expect($h5.text()).toBe('foobar')
 
     wrapper.unmount()
@@ -109,7 +109,7 @@ describe('offcanvas', () => {
   it('first child div has child button has static type button', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
-    const $button = $div.find('button')
+    const $button = $div.get('button')
     expect($button.attributes('type')).toBe('button')
 
     wrapper.unmount()
@@ -118,7 +118,7 @@ describe('offcanvas', () => {
   it('first child div has child button has static class btn-close', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
-    const $button = $div.find('button')
+    const $button = $div.get('button')
     expect($button.classes()).toContain('btn-close')
 
     wrapper.unmount()
@@ -127,7 +127,7 @@ describe('offcanvas', () => {
   it('first child div has child button has aria-label close', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
-    const $button = $div.find('button')
+    const $button = $div.get('button')
     expect($button.attributes('aria-label')).toBe('Close')
 
     wrapper.unmount()
@@ -136,7 +136,7 @@ describe('offcanvas', () => {
   it('first child div has child button has static class text-reset', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
-    const $button = $div.find('button')
+    const $button = $div.get('button')
     expect($button.classes()).toContain('text-reset')
 
     wrapper.unmount()

--- a/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
@@ -1,0 +1,20 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BOffcanvas from './BOffcanvas.vue'
+
+describe('offcanvas', () => {
+  it('has static class offcanvas', () => {
+    const wrapper = mount(BOffcanvas)
+    expect(wrapper.classes()).toContain('offcanvas')
+  })
+
+  it('has tabindex -1', () => {
+    const wrapper = mount(BOffcanvas)
+    expect(wrapper.attributes('tabindex')).toBe('-1')
+  })
+
+  it('has aria-labelledby offcanvasLabel', () => {
+    const wrapper = mount(BOffcanvas)
+    expect(wrapper.attributes('aria-labelledby')).toBe('offcanvasLabel')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/popover.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/popover.spec.ts
@@ -6,32 +6,44 @@ describe('popover', () => {
   it('has static class popover', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.classes()).toContain('popover')
+
+    wrapper.unmount()
   })
 
   it('has static class b-popover', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.classes()).toContain('b-popover')
+
+    wrapper.unmount()
   })
 
   // There doesn't seem to be any way to get ref? It is not an attribute nor prop...
   it.skip('has attribute ref element', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.attributes('ref')).toBe('element')
+
+    wrapper.unmount()
   })
 
   it('has role tooltip', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.attributes('role')).toBe('tooltip')
+
+    wrapper.unmount()
   })
 
   it('has tabindex -1', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.attributes('tabindex')).toBe('-1')
+
+    wrapper.unmount()
   })
 
   it('is tag div', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
   })
 
   it('has prop id', async () => {
@@ -41,6 +53,8 @@ describe('popover', () => {
     expect(wrapper.attributes('id')).toBe('abc')
     await wrapper.setProps({id: undefined})
     expect(wrapper.attributes('id')).toBeUndefined()
+
+    wrapper.unmount()
   })
 
   it('first child contains slot title', () => {
@@ -49,6 +63,8 @@ describe('popover', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('first child contains prop title', () => {
@@ -57,6 +73,8 @@ describe('popover', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('first child contains slot title if both slot and prop exists', () => {
@@ -66,6 +84,8 @@ describe('popover', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('slotbar')
+
+    wrapper.unmount()
   })
 
   it('second child contains slot default', () => {
@@ -74,6 +94,8 @@ describe('popover', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('second child contains prop content', () => {
@@ -82,6 +104,8 @@ describe('popover', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('second child contains slot default if both slot and prop exists', () => {
@@ -91,6 +115,8 @@ describe('popover', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('slotbar')
+
+    wrapper.unmount()
   })
 
   it('contains b-popover-{type} if prop variant', async () => {
@@ -100,6 +126,8 @@ describe('popover', () => {
     expect(wrapper.classes()).toContain('b-popover-primary')
     await wrapper.setProps({variant: undefined})
     expect(wrapper.classes()).not.toContain('b-popover-primary')
+
+    wrapper.unmount()
   })
 
   // Functionally, this component does more, but this only tests the component

--- a/packages/bootstrap-vue-3/src/components/popover.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/popover.spec.ts
@@ -1,0 +1,109 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BPopover from './BPopover.vue'
+
+describe('popover', () => {
+  it('has static class popover', () => {
+    const wrapper = mount(BPopover)
+    expect(wrapper.classes()).toContain('popover')
+  })
+
+  it('has static class b-popover', () => {
+    const wrapper = mount(BPopover)
+    expect(wrapper.classes()).toContain('b-popover')
+  })
+
+  // There doesn't seem to be any way to get ref? It is not an attribute nor prop...
+  it.skip('has attribute ref element', () => {
+    const wrapper = mount(BPopover)
+    expect(wrapper.attributes('ref')).toBe('element')
+  })
+
+  it('has role tooltip', () => {
+    const wrapper = mount(BPopover)
+    expect(wrapper.attributes('role')).toBe('tooltip')
+  })
+
+  it('has tabindex -1', () => {
+    const wrapper = mount(BPopover)
+    expect(wrapper.attributes('tabindex')).toBe('-1')
+  })
+
+  it('is tag div', () => {
+    const wrapper = mount(BPopover)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('has prop id', async () => {
+    const wrapper = mount(BPopover, {
+      props: {id: 'abc'},
+    })
+    expect(wrapper.attributes('id')).toBe('abc')
+    await wrapper.setProps({id: undefined})
+    expect(wrapper.attributes('id')).toBeUndefined()
+  })
+
+  it('first child contains slot title', () => {
+    const wrapper = mount(BPopover, {
+      slots: {title: 'foobar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('foobar')
+  })
+
+  it('first child contains prop title', () => {
+    const wrapper = mount(BPopover, {
+      props: {title: 'foobar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('foobar')
+  })
+
+  it('first child contains slot title if both slot and prop exists', () => {
+    const wrapper = mount(BPopover, {
+      props: {title: 'propbar'},
+      slots: {title: 'slotbar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('slotbar')
+  })
+
+  it('second child contains slot default', () => {
+    const wrapper = mount(BPopover, {
+      slots: {default: 'foobar'},
+    })
+    const [, , $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('foobar')
+  })
+
+  it('second child contains prop content', () => {
+    const wrapper = mount(BPopover, {
+      props: {content: 'foobar'},
+    })
+    const [, , $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('foobar')
+  })
+
+  it('second child contains slot default if both slot and prop exists', () => {
+    const wrapper = mount(BPopover, {
+      props: {content: 'propbar'},
+      slots: {default: 'slotbar'},
+    })
+    const [, , $div] = wrapper.findAll('div')
+    expect($div.text()).toBe('slotbar')
+  })
+
+  it('contains b-popover-{type} if prop variant', async () => {
+    const wrapper = mount(BPopover, {
+      props: {variant: 'primary'},
+    })
+    expect(wrapper.classes()).toContain('b-popover-primary')
+    await wrapper.setProps({variant: undefined})
+    expect(wrapper.classes()).not.toContain('b-popover-primary')
+  })
+
+  // Functionally, this component does more, but this only tests the component
+  // Behaviorally, the component does emit, which should be tested,
+  // But as I am writting this, I am unsure of how to invoke the events from popover,
+  // and pass them into a test
+})

--- a/packages/bootstrap-vue-3/src/components/row.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/row.spec.ts
@@ -1,0 +1,66 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BRow from './BRow.vue'
+
+describe('row', () => {
+  it('has static class row', () => {
+    const wrapper = mount(BRow)
+    expect(wrapper.classes()).toContain('row')
+  })
+
+  it('tag is div by default', () => {
+    const wrapper = mount(BRow)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('tag is prop tag', () => {
+    const wrapper = mount(BRow, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('has class gx-{type} when prop gutterX', () => {
+    const wrapper = mount(BRow, {
+      props: {gutterX: '120'},
+    })
+    expect(wrapper.classes()).toContain('gx-120')
+  })
+
+  it('has class gx-{type} when prop gutterY', () => {
+    const wrapper = mount(BRow, {
+      props: {gutterY: '120'},
+    })
+    expect(wrapper.classes()).toContain('gy-120')
+  })
+
+  it('has class align-items-{type} when prop alignV', async () => {
+    const wrapper = mount(BRow, {
+      props: {alignV: 'baseline'},
+    })
+    expect(wrapper.classes()).toContain('align-items-baseline')
+    await wrapper.setProps({alignV: undefined})
+    expect(wrapper.classes()).not.toContain('align-items-baseline')
+  })
+
+  it('has class justify-content-{type} when prop alignH', async () => {
+    const wrapper = mount(BRow, {
+      props: {alignH: 'between'},
+    })
+    expect(wrapper.classes()).toContain('justify-content-between')
+    await wrapper.setProps({alignH: undefined})
+    expect(wrapper.classes()).not.toContain('justify-content-between')
+  })
+
+  it('has class align-content-{type} when prop alignContent', async () => {
+    const wrapper = mount(BRow, {
+      props: {alignContent: 'between'},
+    })
+    expect(wrapper.classes()).toContain('align-content-between')
+    await wrapper.setProps({alignContent: undefined})
+    expect(wrapper.classes()).not.toContain('align-content-between')
+  })
+
+  // Did not test has rowColClasses existing or getClasses existing
+  // Is that up to a unit test? Or a component test? Or Both?
+})

--- a/packages/bootstrap-vue-3/src/components/row.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/row.spec.ts
@@ -6,11 +6,15 @@ describe('row', () => {
   it('has static class row', () => {
     const wrapper = mount(BRow)
     expect(wrapper.classes()).toContain('row')
+
+    wrapper.unmount()
   })
 
   it('tag is div by default', () => {
     const wrapper = mount(BRow)
     expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
   })
 
   it('tag is prop tag', () => {
@@ -18,6 +22,8 @@ describe('row', () => {
       props: {tag: 'span'},
     })
     expect(wrapper.element.tagName).toBe('SPAN')
+
+    wrapper.unmount()
   })
 
   it('has class gx-{type} when prop gutterX', () => {
@@ -25,6 +31,8 @@ describe('row', () => {
       props: {gutterX: '120'},
     })
     expect(wrapper.classes()).toContain('gx-120')
+
+    wrapper.unmount()
   })
 
   it('has class gx-{type} when prop gutterY', () => {
@@ -32,6 +40,8 @@ describe('row', () => {
       props: {gutterY: '120'},
     })
     expect(wrapper.classes()).toContain('gy-120')
+
+    wrapper.unmount()
   })
 
   it('has class align-items-{type} when prop alignV', async () => {
@@ -41,6 +51,8 @@ describe('row', () => {
     expect(wrapper.classes()).toContain('align-items-baseline')
     await wrapper.setProps({alignV: undefined})
     expect(wrapper.classes()).not.toContain('align-items-baseline')
+
+    wrapper.unmount()
   })
 
   it('has class justify-content-{type} when prop alignH', async () => {
@@ -50,6 +62,8 @@ describe('row', () => {
     expect(wrapper.classes()).toContain('justify-content-between')
     await wrapper.setProps({alignH: undefined})
     expect(wrapper.classes()).not.toContain('justify-content-between')
+
+    wrapper.unmount()
   })
 
   it('has class align-content-{type} when prop alignContent', async () => {
@@ -59,6 +73,8 @@ describe('row', () => {
     expect(wrapper.classes()).toContain('align-content-between')
     await wrapper.setProps({alignContent: undefined})
     expect(wrapper.classes()).not.toContain('align-content-between')
+
+    wrapper.unmount()
   })
 
   // Did not test has rowColClasses existing or getClasses existing

--- a/packages/bootstrap-vue-3/src/components/spinner.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/spinner.spec.ts
@@ -185,7 +185,7 @@ describe('spinner', () => {
       props: {tag: 'div'},
       slots: {label: 'foobar'},
     })
-    const $span = wrapper.find('span')
+    const $span = wrapper.get('span')
     expect($span.text()).toBe('foobar')
 
     wrapper.unmount()
@@ -195,7 +195,7 @@ describe('spinner', () => {
     const wrapper = mount(BSpinner, {
       props: {tag: 'div', label: 'foobar'},
     })
-    const $span = wrapper.find('span')
+    const $span = wrapper.get('span')
     expect($span.text()).toBe('foobar')
 
     wrapper.unmount()
@@ -206,7 +206,7 @@ describe('spinner', () => {
       props: {tag: 'div', label: 'propbar'},
       slots: {label: 'labelbar'},
     })
-    const $span = wrapper.find('span')
+    const $span = wrapper.get('span')
     expect($span.text()).toBe('labelbar')
 
     wrapper.unmount()
@@ -216,7 +216,7 @@ describe('spinner', () => {
     const wrapper = mount(BSpinner, {
       props: {label: 'foobar', tag: 'div'},
     })
-    const $span = wrapper.find('span')
+    const $span = wrapper.get('span')
     expect($span.classes()).toContain('visually-hidden')
 
     wrapper.unmount()

--- a/packages/bootstrap-vue-3/src/components/spinner.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/spinner.spec.ts
@@ -1,0 +1,180 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+import BSpinner from './BSpinner.vue'
+
+describe('spinner', () => {
+  it('tag is span by default', () => {
+    const wrapper = mount(BSpinner)
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('tag is tag prop', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div'},
+    })
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('has class spinner-border when prop type is border', async () => {
+    const wrapper = mount(BSpinner, {
+      props: {type: 'border'},
+    })
+    expect(wrapper.classes()).toContain('spinner-border')
+    await wrapper.setProps({type: 'grow'})
+    expect(wrapper.classes()).not.toContain('spinner-border')
+  })
+
+  it('has class spinner-border-sm when both prop type border and prop small', async () => {
+    const wrapper = mount(BSpinner, {
+      props: {type: 'border', small: true},
+    })
+    expect(wrapper.classes()).toContain('spinner-border-sm')
+    await wrapper.setProps({type: 'grow'})
+    expect(wrapper.classes()).not.toContain('spinner-border-sm')
+    // TODO bspinner has both spinner-border and spinner-border-sm , is this intentional?
+  })
+
+  it('has class spinner-grow when prop type is grow', async () => {
+    const wrapper = mount(BSpinner, {
+      props: {type: 'grow'},
+    })
+    expect(wrapper.classes()).toContain('spinner-grow')
+    await wrapper.setProps({type: 'border'})
+    expect(wrapper.classes()).not.toContain('spinner-grow')
+  })
+
+  it('has class spinner-grow-sm when prop type is grow and prop small', async () => {
+    const wrapper = mount(BSpinner, {
+      props: {type: 'grow', small: true},
+    })
+    expect(wrapper.classes()).toContain('spinner-grow-sm')
+    await wrapper.setProps({type: 'border'})
+    expect(wrapper.classes()).not.toContain('spinner-grow-sm')
+  })
+
+  it('has class spinner-grow when prop type is grow', async () => {
+    const wrapper = mount(BSpinner, {
+      props: {type: 'grow'},
+    })
+    expect(wrapper.classes()).toContain('spinner-grow')
+    await wrapper.setProps({type: 'border'})
+    expect(wrapper.classes()).not.toContain('spinner-grow')
+  })
+
+  it('has class text-{type} when prop variant', async () => {
+    const wrapper = mount(BSpinner, {
+      props: {variant: 'primary'},
+    })
+    expect(wrapper.classes()).toContain('text-primary')
+    await wrapper.setProps({variant: 'secondary'})
+    expect(wrapper.classes()).toContain('text-secondary')
+    expect(wrapper.classes()).not.toContain('text-primary')
+  })
+
+  it('does not have role when prop role, but has no label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {role: 'foobar'},
+    })
+    expect(wrapper.attributes('role')).toBeUndefined()
+  })
+
+  it('has role when prop role but also has prop label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {role: 'foobar', label: 'someLabel'},
+    })
+    expect(wrapper.attributes('role')).toBe('foobar')
+  })
+
+  it('has role when prop role but also has slot label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {role: 'foobar'},
+      slots: {label: 'someLabel'},
+    })
+    expect(wrapper.attributes('role')).toBe('foobar')
+  })
+
+  it('has role status by default when label exists', () => {
+    const wrapper = mount(BSpinner, {
+      slots: {label: 'foobar'},
+    })
+    expect(wrapper.attributes('role')).toBe('status')
+  })
+
+  it('has aria-hidden undefined when prop label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {label: 'foobar'},
+    })
+    expect(wrapper.attributes('aria-hidden')).toBeUndefined()
+  })
+
+  it('has aria-hidden undefined when slot label', () => {
+    const wrapper = mount(BSpinner, {
+      slots: {label: 'foobar'},
+    })
+    expect(wrapper.attributes('aria-hidden')).toBeUndefined()
+  })
+
+  it('has aria-hidden true when no label', () => {
+    const wrapper = mount(BSpinner)
+    expect(wrapper.attributes('aria-hidden')).toBe('true')
+  })
+
+  it('does not have span child if no label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(false)
+  })
+
+  it('has span child if prop label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div', label: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(true)
+  })
+
+  it('has span child if prop label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div'},
+      slots: {label: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(true)
+  })
+
+  it('span child has text for slot label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div'},
+      slots: {label: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.text()).toBe('foobar')
+  })
+
+  it('span child has text for prop label', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div', label: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.text()).toBe('foobar')
+  })
+
+  it('prioritizes slot label over prop label if both exist', () => {
+    const wrapper = mount(BSpinner, {
+      props: {tag: 'div', label: 'propbar'},
+      slots: {label: 'labelbar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.text()).toBe('labelbar')
+  })
+
+  it('span child when has label has static class visually-hidden', () => {
+    const wrapper = mount(BSpinner, {
+      props: {label: 'foobar', tag: 'div'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.classes()).toContain('visually-hidden')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/spinner.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/spinner.spec.ts
@@ -6,6 +6,8 @@ describe('spinner', () => {
   it('tag is span by default', () => {
     const wrapper = mount(BSpinner)
     expect(wrapper.element.tagName).toBe('SPAN')
+
+    wrapper.unmount()
   })
 
   it('tag is tag prop', () => {
@@ -13,6 +15,8 @@ describe('spinner', () => {
       props: {tag: 'div'},
     })
     expect(wrapper.element.tagName).toBe('DIV')
+
+    wrapper.unmount()
   })
 
   it('has class spinner-border when prop type is border', async () => {
@@ -22,6 +26,8 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-border')
     await wrapper.setProps({type: 'grow'})
     expect(wrapper.classes()).not.toContain('spinner-border')
+
+    wrapper.unmount()
   })
 
   it('has class spinner-border-sm when both prop type border and prop small', async () => {
@@ -31,6 +37,8 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-border-sm')
     await wrapper.setProps({type: 'grow'})
     expect(wrapper.classes()).not.toContain('spinner-border-sm')
+
+    wrapper.unmount()
     // TODO bspinner has both spinner-border and spinner-border-sm , is this intentional?
   })
 
@@ -41,6 +49,8 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-grow')
     await wrapper.setProps({type: 'border'})
     expect(wrapper.classes()).not.toContain('spinner-grow')
+
+    wrapper.unmount()
   })
 
   it('has class spinner-grow-sm when prop type is grow and prop small', async () => {
@@ -50,6 +60,8 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-grow-sm')
     await wrapper.setProps({type: 'border'})
     expect(wrapper.classes()).not.toContain('spinner-grow-sm')
+
+    wrapper.unmount()
   })
 
   it('has class spinner-grow when prop type is grow', async () => {
@@ -59,6 +71,8 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-grow')
     await wrapper.setProps({type: 'border'})
     expect(wrapper.classes()).not.toContain('spinner-grow')
+
+    wrapper.unmount()
   })
 
   it('has class text-{type} when prop variant', async () => {
@@ -69,6 +83,8 @@ describe('spinner', () => {
     await wrapper.setProps({variant: 'secondary'})
     expect(wrapper.classes()).toContain('text-secondary')
     expect(wrapper.classes()).not.toContain('text-primary')
+
+    wrapper.unmount()
   })
 
   it('does not have role when prop role, but has no label', () => {
@@ -76,6 +92,8 @@ describe('spinner', () => {
       props: {role: 'foobar'},
     })
     expect(wrapper.attributes('role')).toBeUndefined()
+
+    wrapper.unmount()
   })
 
   it('has role when prop role but also has prop label', () => {
@@ -83,6 +101,8 @@ describe('spinner', () => {
       props: {role: 'foobar', label: 'someLabel'},
     })
     expect(wrapper.attributes('role')).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('has role when prop role but also has slot label', () => {
@@ -91,6 +111,8 @@ describe('spinner', () => {
       slots: {label: 'someLabel'},
     })
     expect(wrapper.attributes('role')).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('has role status by default when label exists', () => {
@@ -98,6 +120,8 @@ describe('spinner', () => {
       slots: {label: 'foobar'},
     })
     expect(wrapper.attributes('role')).toBe('status')
+
+    wrapper.unmount()
   })
 
   it('has aria-hidden undefined when prop label', () => {
@@ -105,6 +129,8 @@ describe('spinner', () => {
       props: {label: 'foobar'},
     })
     expect(wrapper.attributes('aria-hidden')).toBeUndefined()
+
+    wrapper.unmount()
   })
 
   it('has aria-hidden undefined when slot label', () => {
@@ -112,11 +138,15 @@ describe('spinner', () => {
       slots: {label: 'foobar'},
     })
     expect(wrapper.attributes('aria-hidden')).toBeUndefined()
+
+    wrapper.unmount()
   })
 
   it('has aria-hidden true when no label', () => {
     const wrapper = mount(BSpinner)
     expect(wrapper.attributes('aria-hidden')).toBe('true')
+
+    wrapper.unmount()
   })
 
   it('does not have span child if no label', () => {
@@ -125,6 +155,8 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(false)
+
+    wrapper.unmount()
   })
 
   it('has span child if prop label', () => {
@@ -133,6 +165,8 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(true)
+
+    wrapper.unmount()
   })
 
   it('has span child if prop label', () => {
@@ -142,6 +176,8 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(true)
+
+    wrapper.unmount()
   })
 
   it('span child has text for slot label', () => {
@@ -151,6 +187,8 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('span child has text for prop label', () => {
@@ -159,6 +197,8 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.text()).toBe('foobar')
+
+    wrapper.unmount()
   })
 
   it('prioritizes slot label over prop label if both exist', () => {
@@ -168,6 +208,8 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.text()).toBe('labelbar')
+
+    wrapper.unmount()
   })
 
   it('span child when has label has static class visually-hidden', () => {
@@ -176,5 +218,7 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.classes()).toContain('visually-hidden')
+
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
These tests may not include all coverage of various files and some are not fully finished. Read todos.

Actual changes of vue files include 

fix: BCol classes persisting after prop change
refactor: BImg computed classes contained business logic. 
refactor: explicit render checks in dynamic classes (ie `'someClass': !!prop.someProp` => `'someClass': prop.someProp !== undefined`.. Depending on the case  

Some other tests were refactored to use .get() instead of .find(). Based on the docs from vue-test-utils. .get() should be preferred and .find() should be used to test the existence of a component. As .get() will throw an error at it's spot if the component does not exist... For example
```ts
const $comp = wrapper.find('div')
expect($comp.classes()) // <- will throw error here about calling on empty wrapper
// vs
const $comp = wrapper.get('div') // <- better: will throw here about comp doesn't exist
```
Just for better error messages.