### PR TITLE
BTable Sorting

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -21,7 +21,7 @@
             </button>
           </div>
           <div class="modal-body" :class="computedBodyClasses">
-            <Suspense v-if="!lazyBoolean || (lazyBoolean && modelValueBoolean == true)">
+            <Suspense v-if="!lazyBoolean || (lazyBoolean && modelValueBoolean === true)">
               <!-- <slot /> -->
               <ModalContentComponent></ModalContentComponent>
             </Suspense>
@@ -258,13 +258,11 @@ useEventListener(element, 'shown.bs.modal', (e) => emit('shown', e))
 useEventListener(element, 'hidden.bs.modal', (e) => emit('hidden', e))
 
 const show = () => {
-  // if (modelValueBoolean.value == true) return;
   emit('update:modelValue', true)
   getInstance().show()
 }
 
 const hide = () => {
-  // if (modelValueBoolean.value == false) return;
   emit('update:modelValue', false)
   getInstance().hide()
 }

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -8,12 +8,7 @@
             v-for="field in computedFields"
             :key="field.key"
             scope="col"
-            :class="[
-              field.class,
-              field.thClass,
-              field.variant ? `table-${field.variant}` : '',
-              {'b-table-sortable-column': isSortable && field.sortable},
-            ]"
+            :class="getFieldColumnClasses(field)"
             :title="field.headerTitle"
             :abbr="field.headerAbbr"
             :style="field.thStyle"
@@ -22,11 +17,11 @@
           >
             <div class="d-flex flex-nowrap align-items-center gap-1">
               <span
-                v-if="isSortable && field.sortable && field.key == sortBy"
+                v-if="isSortable && field.sortable && field.key === sortBy"
                 class="text-muted small"
               >
-                <span v-show="sortDesc == true">▼</span>
-                <span v-show="sortDesc == false">▲</span>
+                <span v-show="sortDesc === true">▼</span>
+                <span v-show="sortDesc === false">▲</span>
               </span>
               <div>
                 <slot
@@ -58,10 +53,7 @@
       </thead>
       <tbody>
         <!-- eslint-disable-next-line vue/require-v-for-key -->
-        <tr
-          v-for="tr in computedItems"
-          :class="[tr._rowVariant ? `table-${tr._rowVariant}` : null]"
-        >
+        <tr v-for="tr in computedItems" :class="tr._rowVariant ? `table-${tr._rowVariant}` : null">
           <td
             v-for="(field, index) in computedFields"
             :key="field.key"
@@ -119,7 +111,14 @@
 // import type {Breakpoint} from '../../types'
 import {computed, toRef} from 'vue'
 import {useBooleanish} from '../../composables'
-import type {Booleanish, ColorVariant, TableField, TableItem, VerticalAlign} from '../../types'
+import type {
+  Booleanish,
+  ColorVariant,
+  TableField,
+  TableFieldObject,
+  TableItem,
+  VerticalAlign,
+} from '../../types'
 import BTableContainer from './BTableContainer.vue'
 import useItemHelper from './itemHelper'
 
@@ -221,4 +220,11 @@ const columnClicked = (field: TableField<Record<string, unknown>>) => {
     emits('sorted', props.sortBy, props.sortDesc)
   }
 }
+
+const getFieldColumnClasses = (field: TableFieldObject) => [
+  field.class,
+  field.thClass,
+  field.variant ? `table-${field.variant}` : '',
+  {'b-table-sortable-column': isSortable.value && field.sortable},
+]
 </script>

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="responsive" :class="responsiveClasses">
+  <BTableContainer :responsive="responsive" :responsive-classes="responsiveClasses">
     <table :class="classes">
       <thead>
         <slot v-if="$slots['thead-top']" name="thead-top" />
@@ -8,18 +8,35 @@
             v-for="field in computedFields"
             :key="field.key"
             scope="col"
-            :class="[field.class, field.thClass, field.variant ? `table-${field.variant}` : '']"
+            :class="[
+              field.class,
+              field.thClass,
+              field.variant ? `table-${field.variant}` : '',
+              {'b-table-sortable-column': isSortable && field.sortable},
+            ]"
             :title="field.headerTitle"
             :abbr="field.headerAbbr"
             :style="field.thStyle"
             v-bind="field.thAttr"
+            @click="columnClicked(field)"
           >
-            <slot
-              v-if="$slots['head(' + field.key + ')']"
-              :name="'head(' + field.key + ')'"
-              :label="field.label"
-            />
-            <template v-else>{{ field.label }}</template>
+            <div class="d-flex flex-nowrap align-items-center gap-1">
+              <span
+                v-if="isSortable && field.sortable && field.key == sortBy"
+                class="text-muted small"
+              >
+                <span v-show="sortDesc == true">▼</span>
+                <span v-show="sortDesc == false">▲</span>
+              </span>
+              <div>
+                <slot
+                  v-if="$slots['head(' + field.key + ')']"
+                  :name="'head(' + field.key + ')'"
+                  :label="field.label"
+                />
+                <template v-else>{{ field.label }}</template>
+              </div>
+            </div>
           </th>
         </tr>
         <tr v-if="$slots['thead-sub']">
@@ -41,7 +58,10 @@
       </thead>
       <tbody>
         <!-- eslint-disable-next-line vue/require-v-for-key -->
-        <tr v-for="tr in items" :class="[tr._rowVariant ? `table-${tr._rowVariant}` : null]">
+        <tr
+          v-for="tr in computedItems"
+          :class="[tr._rowVariant ? `table-${tr._rowVariant}` : null]"
+        >
           <td
             v-for="(field, index) in computedFields"
             :key="field.key"
@@ -92,106 +112,15 @@
         }}
       </caption>
     </table>
-  </div>
-  <table v-else :class="classes">
-    <thead>
-      <slot v-if="$slots['thead-top']" name="thead-top" />
-      <tr>
-        <th
-          v-for="field in computedFields"
-          :key="field.key"
-          scope="col"
-          :class="[field.class, field.thClass, field.variant ? `table-${field.variant}` : '']"
-          :title="field.headerTitle"
-          :abbr="field.headerAbbr"
-          :style="field.thStyle"
-          v-bind="field.thAttr"
-        >
-          <slot
-            v-if="$slots['head(' + field.key + ')']"
-            :name="'head(' + field.key + ')'"
-            :label="field.label"
-          />
-          <template v-else>{{ field.label }}</template>
-        </th>
-      </tr>
-      <tr v-if="$slots['thead-sub']">
-        <td
-          v-for="field in computedFields"
-          :key="field.key"
-          scope="col"
-          :class="[field.class, field.thClass, field.variant ? `table-${field.variant}` : '']"
-        >
-          <slot
-            v-if="$slots['thead-sub']"
-            name="thead-sub"
-            :items="computedFields"
-            v-bind="field"
-          />
-          <template v-else>{{ field.label }}</template>
-        </td>
-      </tr>
-    </thead>
-    <tbody>
-      <!-- eslint-disable-next-line vue/require-v-for-key -->
-      <tr v-for="tr in items" :class="[tr._rowVariant ? `table-${tr._rowVariant}` : null]">
-        <td
-          v-for="(field, index) in computedFields"
-          :key="field.key"
-          v-bind="field.tdAttr"
-          :class="[
-            field.class,
-            field.tdClass,
-            field.variant ? `table-${field.variant}` : '',
-            tr?._cellVariants && tr?._cellVariants[field.key]
-              ? `table-${tr?._cellVariants[field.key]}`
-              : '',
-          ]"
-        >
-          <slot
-            v-if="$slots['cell(' + field.key + ')']"
-            :name="'cell(' + field.key + ')'"
-            :value="tr[field.key]"
-            :index="index"
-            :item="tr"
-            :items="items"
-          />
-          <template v-else>{{ tr[field.key] }}</template>
-        </td>
-      </tr>
-    </tbody>
-    <tfoot v-if="footCloneBoolean">
-      <tr>
-        <th
-          v-for="field in computedFields"
-          :key="field.key"
-          v-bind="field.thAttr"
-          scope="col"
-          :class="[field.class, field.thClass, field.variant ? `table-${field.variant}` : '']"
-          :title="field.headerTitle"
-          :abbr="field.headerAbbr"
-          :style="field.thStyle"
-        >
-          {{ field.label }}
-        </th>
-      </tr>
-    </tfoot>
-    <caption v-if="$slots['table-caption']">
-      <slot name="table-caption" />
-    </caption>
-    <caption v-else-if="caption">
-      {{
-        caption
-      }}
-    </caption>
-  </table>
+  </BTableContainer>
 </template>
 
 <script setup lang="ts">
 // import type {Breakpoint} from '../../types'
 import {computed, toRef} from 'vue'
-import type {Booleanish, ColorVariant, TableField, TableItem, VerticalAlign} from '../../types'
 import {useBooleanish} from '../../composables'
+import type {Booleanish, ColorVariant, TableField, TableItem, VerticalAlign} from '../../types'
+import BTableContainer from './BTableContainer.vue'
 import useItemHelper from './itemHelper'
 
 interface BTableProps {
@@ -210,6 +139,9 @@ interface BTableProps {
   small?: Booleanish
   striped?: Booleanish
   variant?: ColorVariant
+  sortBy?: string
+  sortDesc?: boolean
+  sortInternal?: boolean
 }
 
 const props = withDefaults(defineProps<BTableProps>(), {
@@ -224,7 +156,10 @@ const props = withDefaults(defineProps<BTableProps>(), {
   responsive: false,
   small: false,
   striped: false,
+  sortInternal: true,
 })
+
+const emits = defineEmits(['update:sortBy', 'update:sortDesc', 'sorted'])
 
 const captionTopBoolean = useBooleanish(toRef(props, 'captionTop'))
 const borderlessBoolean = useBooleanish(toRef(props, 'borderless'))
@@ -253,6 +188,11 @@ const classes = computed(() => [
 
 const itemHelper = useItemHelper()
 const computedFields = computed(() => itemHelper.normaliseFields(props.fields, props.items))
+const computedItems = computed(() =>
+  props.sortInternal
+    ? itemHelper.sortItems(props.fields, props.items, {key: props.sortBy, desc: props.sortDesc})
+    : props.items
+)
 
 const responsiveClasses = computed(() => [
   {
@@ -260,4 +200,25 @@ const responsiveClasses = computed(() => [
     [`table-responsive-${props.responsive}`]: typeof props.responsive === 'string',
   },
 ])
+
+const isSortable = computed(
+  () =>
+    props.fields.filter((field) => (typeof field === 'string' ? false : field.sortable)).length > 0
+)
+const columnClicked = (field: TableField<Record<string, unknown>>) => {
+  //!! make sure to enable this flag after implementing the table.busy feature.
+  // if (props.busy) return;
+
+  const fieldKey = typeof field === 'string' ? field : field.key
+  const fieldSortable = typeof field === 'string' ? false : field.sortable
+  if (isSortable.value === true && fieldSortable === true) {
+    if (fieldKey === props.sortBy) {
+      emits('update:sortDesc', !props.sortDesc)
+    } else {
+      emits('update:sortBy', typeof field === 'string' ? field : field.key)
+      emits('update:sortDesc', false)
+    }
+    emits('sorted', props.sortBy, props.sortDesc)
+  }
+}
 </script>

--- a/packages/bootstrap-vue-3/src/components/BTable/BTableContainer.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTableContainer.vue
@@ -1,0 +1,22 @@
+<template>
+  <div v-if="responsive" :class="responsiveClasses">
+    <slot></slot>
+  </div>
+  <template v-else>
+    <slot></slot>
+  </template>
+</template>
+
+<script lang="ts" setup>
+interface BTableContainerProps {
+  responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
+  responsiveClasses: any
+}
+
+const props = withDefaults(defineProps<BTableContainerProps>(), {
+  responsive: false,
+  responsiveClasses: [],
+})
+</script>
+
+<style scoped></style>

--- a/packages/bootstrap-vue-3/src/components/BTable/BTableContainer.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTableContainer.vue
@@ -10,13 +10,10 @@
 <script lang="ts" setup>
 interface BTableContainerProps {
   responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
-  responsiveClasses: any
+  responsiveClasses?: string[] | Record<string, any>
 }
 
 const props = withDefaults(defineProps<BTableContainerProps>(), {
   responsive: false,
-  responsiveClasses: [],
 })
 </script>
-
-<style scoped></style>

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -89,9 +89,6 @@
 }
 
 .table th {
-  &.b-table-sortable-btn {
-  }
-
   &.b-table-sortable-column {
     cursor: pointer;
   }

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -80,3 +80,19 @@
   color: #212529;
   background-color: #fff;
 }
+
+.table.b-table > tbody > tr > .table-b-table-default,
+.table.b-table > tfoot > tr > .table-b-table-default,
+.table.b-table > thead > tr > .table-b-table-default {
+  color: #212529;
+  background-color: #fff;
+}
+
+.table th {
+  &.b-table-sortable-btn {
+  }
+
+  &.b-table-sortable-column {
+    cursor: pointer;
+  }
+}

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -24,8 +24,30 @@ const useItemHelper = () => {
     return fields
   }
 
+  const sortItems = (
+    fields: TableField[],
+    items: TableItem<Record<string, any>>[],
+    sort?: {key?: string; desc?: boolean}
+  ) => {
+    console.log(7777777)
+    if (!sort || !sort.key) return items
+    const sortKey = sort.key
+    return items.sort((a, b) =>
+      a[sortKey] > b[sortKey]
+        ? sort.desc
+          ? -1
+          : 1
+        : b[sortKey] > a[sortKey]
+        ? sort.desc
+          ? 1
+          : -1
+        : 0
+    )
+  }
+
   return {
     normaliseFields,
+    sortItems,
   }
 }
 


### PR DESCRIPTION
supported props from vue-bootstrap:
- sort-by
- sort-desc

new props: 
-sort-internal{boolean} = a boolean to determine if you want the table to sort the given rows or not, it can be disabled when using an external API request for sorting your table

working example:
```vue
<template>
  <b-container>
    <div>
      <b-table
        :items="items"
        :fields="fields"
        v-model:sort-by="sortBy"
        v-model:sort-desc="sortDesc"
        :sort-internal="true"
      ></b-table>

      <div>
        Sorting By: <b>{{ sortBy }}</b>, Sort Direction:
        <b>{{ sortDesc ? 'Descending' : 'Ascending' }}</b>
      </div>
    </div>
  </b-container>
</template>

<script  lang="ts">
import { defineComponent } from "vue";

export default defineComponent({
  data() {
    return {
      sortBy: 'age',
      sortDesc: false,
      fields: [
        { key: 'last_name', label: 'last_name', sortable: true },
        { key: 'first_name', label: 'first_name', sortable: true },
        { key: 'age', label: 'age', sortable: true },
        { key: 'isActive', label: 'isActive', sortable: false }
      ],
      items: [
        { isActive: true, age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
        { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
        { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
        { isActive: true, age: 38, first_name: 'Jami', last_name: 'Carney' }
      ]
    }
  }
});
</script>
```

**DRY!**
I have also wrapped the table element inside a BTableContainer to handle the div.responsive logic, this will make the component have only one element to modify.