### PR TITLE
test: replace wrapper.unmount with afterEach

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "turbo run test",
     "test:lint": "turbo run test:lint",
     "test:unit": "turbo run test:unit",
+    "test:coverage": "turbo run test:coverage",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install && turbo run build"

--- a/packages/bootstrap-vue-3/package.json
+++ b/packages/bootstrap-vue-3/package.json
@@ -30,7 +30,8 @@
     "format": "prettier . --write",
     "test": "pnpm run test:lint && pnpm run test:unit",
     "test:lint": "pnpm run lint",
-    "test:unit": "vitest"
+    "test:unit": "vitest",
+    "test:coverage": "vitest --coverage"
   },
   "peerDependencies": {
     "@popperjs/core": "^2.11.6",
@@ -41,6 +42,7 @@
     "@popperjs/core": "^2.11.6",
     "@types/bootstrap": "^5.2.2",
     "@vitejs/plugin-vue": "^3.0.0",
+    "@vitest/coverage-c8": "^0.22.1",
     "@vue/runtime-core": "^3.2.37",
     "@vue/shared": "^3.2.37",
     "@vue/test-utils": "^2.0.2",

--- a/packages/bootstrap-vue-3/src/components/BAccordion/accordion-item.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAccordion/accordion-item.spec.ts
@@ -1,37 +1,31 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BAccordionItem from './BAccordionItem.vue'
 import BCollapse from '../BCollapse.vue'
 
 describe('accordion-item', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class accordion-item', () => {
     const wrapper = mount(BAccordionItem)
     expect(wrapper.classes()).toContain('accordion-item')
-
-    wrapper.unmount()
   })
 
   it('root is div', () => {
     const wrapper = mount(BAccordionItem)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('contains b-collapse', () => {
     const wrapper = mount(BAccordionItem)
     const $bcollapse = wrapper.findComponent(BCollapse)
     expect($bcollapse.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('b-collapse contains static class accordion-collapse', () => {
     const wrapper = mount(BAccordionItem)
     const $bcollapse = wrapper.findComponent(BCollapse)
     expect($bcollapse.classes()).toContain('accordion-collapse')
-
-    wrapper.unmount()
   })
 
   it('b-collapse has child div', () => {
@@ -39,8 +33,6 @@ describe('accordion-item', () => {
     const $bcollapse = wrapper.findComponent(BCollapse)
     const [, $div] = $bcollapse.findAll('div')
     expect($div.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('b-collapse child div contains static class accordion-body', () => {
@@ -48,8 +40,6 @@ describe('accordion-item', () => {
     const $bcollapse = wrapper.findComponent(BCollapse)
     const [, $div] = $bcollapse.findAll('div')
     expect($div.classes()).toContain('accordion-body')
-
-    wrapper.unmount()
   })
 
   it('b-collapse child div contains default slot', () => {
@@ -59,16 +49,12 @@ describe('accordion-item', () => {
     const $bcollapse = wrapper.findComponent(BCollapse)
     const [, $div] = $bcollapse.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('b-collapse has id attr has default id', () => {
     const wrapper = mount(BAccordionItem)
     const $bcollapse = wrapper.findComponent(BCollapse)
     expect($bcollapse.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('b-collapse has id attr has prop id', () => {
@@ -77,8 +63,6 @@ describe('accordion-item', () => {
     })
     const $bcollapse = wrapper.findComponent(BCollapse)
     expect($bcollapse.attributes('id')).toBe('spam&eggs')
-
-    wrapper.unmount()
   })
 
   it('b-collapse has prop visible', async () => {
@@ -89,8 +73,6 @@ describe('accordion-item', () => {
     expect($bcollapse.props('visible')).toBe(true)
     await wrapper.setProps({visible: false})
     expect($bcollapse.props('visible')).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('b-collapse has aria-labelledby with prop id', () => {
@@ -99,24 +81,18 @@ describe('accordion-item', () => {
     })
     const $bcollapse = wrapper.findComponent(BCollapse)
     expect($bcollapse.attributes('aria-labelledby')).toBe('headingfoobar')
-
-    wrapper.unmount()
   })
 
   it('h2 child has static class accordion-header', () => {
     const wrapper = mount(BAccordionItem)
     const $h2 = wrapper.get('h2')
     expect($h2.classes()).toContain('accordion-header')
-
-    wrapper.unmount()
   })
 
   it('h2 child has id attr has default id', () => {
     const wrapper = mount(BAccordionItem)
     const $h2 = wrapper.get('h2')
     expect($h2.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('h2 child has id attr has prop id', () => {
@@ -125,8 +101,6 @@ describe('accordion-item', () => {
     })
     const $h2 = wrapper.get('h2')
     expect($h2.attributes('id')).toBe('foobarheading')
-
-    wrapper.unmount()
   })
 
   it('h2 child has button child', () => {
@@ -134,8 +108,6 @@ describe('accordion-item', () => {
     const $h2 = wrapper.get('h2')
     const $button = $h2.find('button')
     expect($button.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('h2 child button child has static class accordion-button', () => {
@@ -143,8 +115,6 @@ describe('accordion-item', () => {
     const $h2 = wrapper.get('h2')
     const $button = $h2.get('button')
     expect($button.classes()).toContain('accordion-button')
-
-    wrapper.unmount()
   })
 
   it('h2 child button child has type attribute button', () => {
@@ -152,8 +122,6 @@ describe('accordion-item', () => {
     const $h2 = wrapper.get('h2')
     const $button = $h2.get('button')
     expect($button.attributes('type')).toBe('button')
-
-    wrapper.unmount()
   })
 
   it('h2 child button child has aria-expanded false by default', () => {
@@ -161,8 +129,6 @@ describe('accordion-item', () => {
     const $h2 = wrapper.get('h2')
     const $button = $h2.get('button')
     expect($button.attributes('aria-expanded')).toBe('false')
-
-    wrapper.unmount()
   })
 
   it('h2 child button child has aria-expanded true when visible true', () => {
@@ -172,8 +138,6 @@ describe('accordion-item', () => {
     const $h2 = wrapper.get('h2')
     const $button = $h2.get('button')
     expect($button.attributes('aria-expanded')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('h2 child button child has aria-controls as id', () => {
@@ -183,8 +147,6 @@ describe('accordion-item', () => {
     const $h2 = wrapper.get('h2')
     const $button = $h2.get('button')
     expect($button.attributes('aria-controls')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('h2 child button child class collapsed when visible false', async () => {
@@ -196,7 +158,5 @@ describe('accordion-item', () => {
     expect($button.classes()).toContain('collapsed')
     await wrapper.setProps({visible: true})
     expect($button.classes()).not.toContain('collapsed')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BAccordion/accordion.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAccordion/accordion.spec.ts
@@ -1,20 +1,18 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BAccordion from './BAccordion.vue'
 
 describe('accordion', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class accordion', () => {
     const wrapper = mount(BAccordion)
     expect(wrapper.classes()).toContain('accordion')
-
-    wrapper.unmount()
   })
 
   it('has computed id by default', () => {
     const wrapper = mount(BAccordion)
     expect(wrapper.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has id when prop id is set', () => {
@@ -22,8 +20,6 @@ describe('accordion', () => {
       props: {id: 'abc'},
     })
     expect(wrapper.attributes('id')).toBe('abc')
-
-    wrapper.unmount()
   })
 
   it('has class accordion-flush when flush is true', async () => {
@@ -33,8 +29,6 @@ describe('accordion', () => {
     expect(wrapper.classes()).toContain('accordion-flush')
     await wrapper.setProps({flush: false})
     expect(wrapper.classes()).not.toContain('accordion-flush')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -42,7 +36,5 @@ describe('accordion', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BAvatar/avatar-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/avatar-group.spec.ts
@@ -1,27 +1,23 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BAvatarGroup from './BAvatarGroup.vue'
 
 describe('avatar-group', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class b-avatar-group', () => {
     const wrapper = mount(BAvatarGroup)
     expect(wrapper.classes()).toContain('b-avatar-group')
-
-    wrapper.unmount()
   })
 
   it('has role group attribute', () => {
     const wrapper = mount(BAvatarGroup)
     expect(wrapper.attributes('role')).toBe('group')
-
-    wrapper.unmount()
   })
 
   it('tag is div by default', () => {
     const wrapper = mount(BAvatarGroup)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('tag changes with prop tag', () => {
@@ -29,8 +25,6 @@ describe('avatar-group', () => {
       props: {tag: 'span'},
     })
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('has second child div', () => {
@@ -43,8 +37,6 @@ describe('avatar-group', () => {
     const wrapper = mount(BAvatarGroup)
     const [, $div] = wrapper.findAll('div')
     expect($div.classes()).toContain('b-avatar-group-inner')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -53,8 +45,6 @@ describe('avatar-group', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it.skip('div child has style attribute when size prop', () => {
@@ -64,7 +54,5 @@ describe('avatar-group', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.html()).toBe('false')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BAvatar/avatar.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/avatar.spec.ts
@@ -1,13 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BAvatar from './BAvatar.vue'
 
 describe('avatar', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static b-avatar class', () => {
     const wrapper = mount(BAvatar)
     expect(wrapper.classes()).toContain('b-avatar')
-
-    wrapper.unmount()
   })
 
   it('tag is default button when prop button is true', () => {
@@ -15,8 +15,6 @@ describe('avatar', () => {
       props: {button: true},
     })
     expect(wrapper.element.tagName).toBe('BUTTON')
-
-    wrapper.unmount()
   })
 
   it('tag is prop buttonType when prop button is true', () => {
@@ -24,15 +22,11 @@ describe('avatar', () => {
       props: {button: true, buttonType: 'div'},
     })
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('tag is default span', () => {
     const wrapper = mount(BAvatar)
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   // TODO not done

--- a/packages/bootstrap-vue-3/src/components/BBadge/badge.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BBadge/badge.spec.ts
@@ -1,21 +1,19 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BBadge from './BBadge.vue'
 import BLink from '../BLink/BLink.vue'
 
 describe('badge', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class badge', () => {
     const wrapper = mount(BBadge)
     expect(wrapper.classes()).toContain('badge')
-
-    wrapper.unmount()
   })
 
   it('tag is span by default', () => {
     const wrapper = mount(BBadge)
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('contains BLink if to prop', () => {
@@ -24,8 +22,6 @@ describe('badge', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('contains BLink if href prop', () => {
@@ -34,16 +30,12 @@ describe('badge', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('does not contain BLink by default', () => {
     const wrapper = mount(BBadge)
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('is still blink even if prop tag exists, but is also link', () => {
@@ -53,8 +45,6 @@ describe('badge', () => {
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
     expect(wrapper.element.tagName).toBe('A')
-
-    wrapper.unmount()
   })
 
   it('is prop tag when is not link', () => {
@@ -62,8 +52,6 @@ describe('badge', () => {
       props: {tag: 'span'},
     })
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('contains class bg-{type} when prop varaint', async () => {
@@ -74,8 +62,6 @@ describe('badge', () => {
     await wrapper.setProps({variant: 'secondary'})
     expect(wrapper.classes()).toContain('bg-secondary')
     expect(wrapper.classes()).not.toContain('bg-primary')
-
-    wrapper.unmount()
   })
 
   it('contains class active when prop active', async () => {
@@ -85,8 +71,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('active')
     await wrapper.setProps({active: false})
     expect(wrapper.classes()).not.toContain('active')
-
-    wrapper.unmount()
   })
 
   it('contains class disabled when prop disabled', async () => {
@@ -96,8 +80,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('disabled')
     await wrapper.setProps({disabled: false})
     expect(wrapper.classes()).not.toContain('disabled')
-
-    wrapper.unmount()
   })
 
   it('contains class text-dark when prop variant is warning|info|light', async () => {
@@ -113,8 +95,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('text-dark')
     await wrapper.setProps({variant: 'primary'})
     expect(wrapper.classes()).not.toContain('text-dark')
-
-    wrapper.unmount()
   })
 
   it('contains class rounded-pill when prop pill', async () => {
@@ -124,8 +104,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('rounded-pill')
     await wrapper.setProps({pill: false})
     expect(wrapper.classes()).not.toContain('rounded-pill')
-
-    wrapper.unmount()
   })
 
   it('contains class text-decoration-none when prop to', async () => {
@@ -135,8 +113,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('text-decoration-none')
     await wrapper.setProps({to: undefined})
     expect(wrapper.classes()).not.toContain('text-decoration-none')
-
-    wrapper.unmount()
   })
 
   it('contains class text-decoration-none when prop href', async () => {
@@ -146,8 +122,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('text-decoration-none')
     await wrapper.setProps({href: undefined})
     expect(wrapper.classes()).not.toContain('text-decoration-none')
-
-    wrapper.unmount()
   })
 
   it('contains p-2 border border-light rounded-circle when prop dotIndicator', async () => {
@@ -163,8 +137,6 @@ describe('badge', () => {
     expect(wrapper.classes()).not.toContain('border')
     expect(wrapper.classes()).not.toContain('border-light')
     expect(wrapper.classes()).not.toContain('rounded-circle')
-
-    wrapper.unmount()
   })
 
   it('contains position-absolute top-0 start-100 translate-middle when prop dotIndicator', async () => {
@@ -180,8 +152,6 @@ describe('badge', () => {
     expect(wrapper.classes()).not.toContain('top-0')
     expect(wrapper.classes()).not.toContain('start-100')
     expect(wrapper.classes()).not.toContain('translate-middle')
-
-    wrapper.unmount()
   })
 
   it('contains position-absolute top-0 start-100 translate-middle when prop textIndicator', async () => {
@@ -197,7 +167,5 @@ describe('badge', () => {
     expect(wrapper.classes()).not.toContain('top-0')
     expect(wrapper.classes()).not.toContain('start-100')
     expect(wrapper.classes()).not.toContain('translate-middle')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrum.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrum.spec.ts
@@ -1,18 +1,18 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BBreadcrumb from './BBreadcrumb.vue'
 import BBreadcrumbItem from './BBreadcrumbItem.vue'
 import type {BreadcrumbItem} from '../../types'
 import {BREADCRUMB_SYMBOL} from '../../composables/useBreadcrumb'
 
 describe('breadcrumb', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains aria-label breadcrumb', () => {
     const wrapper = mount(BBreadcrumb, {
       global: {provide: {[BREADCRUMB_SYMBOL as unknown as symbol]: {}}},
     })
     expect(wrapper.attributes('aria-label')).toBe('breadcrumb')
-
-    wrapper.unmount()
   })
 
   it('tag is nav', () => {
@@ -20,8 +20,6 @@ describe('breadcrumb', () => {
       global: {provide: {[BREADCRUMB_SYMBOL as unknown as symbol]: {}}},
     })
     expect(wrapper.element.tagName).toBe('NAV')
-
-    wrapper.unmount()
   })
 
   it('child tag is ol', () => {
@@ -32,8 +30,6 @@ describe('breadcrumb', () => {
     // Rather, only that it is deeply nested inside the component
     const $ol = wrapper.find('ol')
     expect($ol.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('ol child has static class breadcrumb', () => {
@@ -44,8 +40,6 @@ describe('breadcrumb', () => {
     // Rather, only that it is deeply nested inside the component
     const $ol = wrapper.get('ol')
     expect($ol.classes()).toContain('breadcrumb')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -54,8 +48,6 @@ describe('breadcrumb', () => {
       global: {provide: {[BREADCRUMB_SYMBOL as unknown as symbol]: {}}},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('renders prepend slot', () => {
@@ -64,8 +56,6 @@ describe('breadcrumb', () => {
       global: {provide: {[BREADCRUMB_SYMBOL as unknown as symbol]: {}}},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('renders append slot', () => {
@@ -74,8 +64,6 @@ describe('breadcrumb', () => {
       global: {provide: {[BREADCRUMB_SYMBOL as unknown as symbol]: {}}},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('renders all slots in correct order', () => {
@@ -84,8 +72,6 @@ describe('breadcrumb', () => {
       global: {provide: {[BREADCRUMB_SYMBOL as unknown as symbol]: {}}},
     })
     expect(wrapper.text()).toBe('prependdefaultappend')
-
-    wrapper.unmount()
   })
 
   it('has breadcrumbitem', () => {
@@ -95,8 +81,6 @@ describe('breadcrumb', () => {
     })
     const $bbreadcrumbitem = wrapper.findComponent(BBreadcrumbItem)
     expect($bbreadcrumbitem.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('renders bbreadcrumbitem before default slot and after prepend slot', () => {
@@ -106,8 +90,6 @@ describe('breadcrumb', () => {
       slots: {default: 'default', prepend: 'prepend'},
     })
     expect(wrapper.text()).toBe('prependfoodefault')
-
-    wrapper.unmount()
   })
 
   it('bbreadcrumbitem contains items as props', () => {
@@ -126,7 +108,5 @@ describe('breadcrumb', () => {
     expect($bbreadcrumbitem.props('disabled')).toBe(true)
     expect($bbreadcrumbitem.props('href')).toBe('href')
     expect($bbreadcrumbitem.props('to')).toBe('to')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrumb-item.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BBreadcrumb/breadcrumb-item.spec.ts
@@ -1,14 +1,14 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BBreadcrumbItem from './BBreadcrumbItem.vue'
 import BLink from '../BLink/BLink.vue'
 
 describe('breadcrumb-item', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class breadcrumb-item', () => {
     const wrapper = mount(BBreadcrumbItem)
     expect(wrapper.classes()).toContain('breadcrumb-item')
-
-    wrapper.unmount()
   })
 
   it('has class active when prop active', async () => {
@@ -18,8 +18,6 @@ describe('breadcrumb-item', () => {
     expect(wrapper.classes()).toContain('active')
     await wrapper.setProps({active: false})
     expect(wrapper.classes()).not.toContain('active')
-
-    wrapper.unmount()
   })
 
   it('contains a span child when prop active', () => {
@@ -28,16 +26,12 @@ describe('breadcrumb-item', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('contains a blink child by default', () => {
     const wrapper = mount(BBreadcrumbItem)
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child contains attr aria-current when prop active', async () => {
@@ -49,8 +43,6 @@ describe('breadcrumb-item', () => {
     await wrapper.setProps({active: false})
     const $blink = wrapper.getComponent(BLink)
     expect($blink.attributes('aria-current')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('emits click event', async () => {
@@ -58,8 +50,6 @@ describe('breadcrumb-item', () => {
     const $blink = wrapper.getComponent(BLink)
     await $blink.trigger('click')
     expect($blink.emitted()).toHaveProperty('click')
-
-    wrapper.unmount()
   })
 
   it('does not emit click event when prop disabled', async () => {
@@ -69,8 +59,6 @@ describe('breadcrumb-item', () => {
     const $blink = wrapper.getComponent(BLink)
     await $blink.trigger('click')
     expect(wrapper.emitted('click')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('emits a MouseEvent when clicked', async () => {
@@ -79,8 +67,6 @@ describe('breadcrumb-item', () => {
     await $blink.trigger('click')
     const $emitted = $blink.emitted('click') ?? []
     expect($emitted[0][0] instanceof MouseEvent).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('renders default slot in child when child is span', () => {
@@ -90,7 +76,5 @@ describe('breadcrumb-item', () => {
     })
     const $span = wrapper.get('span')
     expect($span.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BButton/button-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BButton/button-group.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BButtonGroup from './BButtonGroup.vue'
 
 describe('button-group', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is div by default', () => {
     const wrapper = mount(BButtonGroup)
     expect(wrapper.element.tagName).toBe('DIV')

--- a/packages/bootstrap-vue-3/src/components/BButton/button-toolbar.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BButton/button-toolbar.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BButtonToolbar from './BButtonToolbar.vue'
 
 describe('button-toolbar', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is div', () => {
     const wrapper = mount(BButtonToolbar)
     expect(wrapper.element.tagName).toBe('DIV')

--- a/packages/bootstrap-vue-3/src/components/BButton/button.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BButton/button.spec.ts
@@ -1,8 +1,11 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BButton from './BButton.vue'
+import BLink from '../BLink/BLink.vue'
 
 describe('button', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class btn', () => {
     const wrapper = mount(BButton)
     expect(wrapper.classes()).toContain('btn')
@@ -13,5 +16,449 @@ describe('button', () => {
     expect(wrapper.element.tagName).toBe('BUTTON')
   })
 
-  // TODO
+  it('is blink if prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+  })
+
+  it('is tag a if prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc'},
+    })
+    expect(wrapper.element.tagName).toBe('A')
+  })
+
+  it('is tag a if prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {tag: 'div'},
+    })
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('is blink if prop to and prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', href: '/abc'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+  })
+
+  it('is blink if prop to and prop href and prop tag', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', href: '/abc', tag: 'div'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+  })
+
+  it('is tag a if prop href and prop tag', () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc', tag: 'div'},
+    })
+    expect(wrapper.element.tagName).toBe('A')
+  })
+
+  it('is blink if prop to and prop tag', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', tag: 'div'},
+    })
+    const $blink = wrapper.findComponent(BLink)
+    expect($blink.exists()).toBe(true)
+  })
+
+  it('has class btn-{type} when prop variant', async () => {
+    const wrapper = mount(BButton, {
+      props: {variant: 'primary'},
+    })
+    expect(wrapper.classes()).toContain('btn-primary')
+    await wrapper.setProps({variant: undefined})
+    expect(wrapper.classes()).not.toContain('btn-primary')
+  })
+
+  it('has class btn-{type} when prop size', async () => {
+    const wrapper = mount(BButton, {
+      props: {size: 'sm'},
+    })
+    expect(wrapper.classes()).toContain('btn-sm')
+    await wrapper.setProps({size: undefined})
+    expect(wrapper.classes()).not.toContain('btn-sm')
+  })
+
+  it('has class active when prop active', async () => {
+    const wrapper = mount(BButton, {
+      props: {active: true},
+    })
+    expect(wrapper.classes()).toContain('active')
+    await wrapper.setProps({active: false})
+    expect(wrapper.classes()).not.toContain('active')
+  })
+
+  it('has class active when prop pressed', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true},
+    })
+    expect(wrapper.classes()).toContain('active')
+    await wrapper.setProps({pressed: false})
+    expect(wrapper.classes()).not.toContain('active')
+  })
+
+  it('has class rounded-pill when prop pill', async () => {
+    const wrapper = mount(BButton, {
+      props: {pill: true},
+    })
+    expect(wrapper.classes()).toContain('rounded-pill')
+    await wrapper.setProps({pill: false})
+    expect(wrapper.classes()).not.toContain('rounded-pill')
+  })
+
+  it('has class rounded-0 when prop squared', async () => {
+    const wrapper = mount(BButton, {
+      props: {squared: true},
+    })
+    expect(wrapper.classes()).toContain('rounded-0')
+    await wrapper.setProps({squared: false})
+    expect(wrapper.classes()).not.toContain('rounded-0')
+  })
+
+  it('has class disabled when prop disabled', async () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true},
+    })
+    expect(wrapper.classes()).toContain('disabled')
+    await wrapper.setProps({disabled: false})
+    expect(wrapper.classes()).not.toContain('disabled')
+  })
+
+  it('has aria-disabled if prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc', disabled: true},
+    })
+    expect(wrapper.attributes('aria-disabled')).toBeUndefined()
+  })
+
+  it('has aria-disabled if prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', disabled: true},
+    })
+    expect(wrapper.attributes('aria-disabled')).toBe('true')
+  })
+
+  it('has aria-disabled if prop disabled and prop tag is button', () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true},
+    })
+    expect(wrapper.attributes('aria-disabled')).toBeUndefined()
+  })
+
+  it('has attr aria-pressed when prop pressed', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true},
+    })
+    expect(wrapper.attributes('aria-pressed')).toBe('true')
+    await wrapper.setProps({pressed: false})
+    expect(wrapper.attributes('aria-pressed')).toBeUndefined()
+  })
+
+  it('has attr autocomplete when prop pressed', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true},
+    })
+    expect(wrapper.attributes('autocomplete')).toBe('off')
+    await wrapper.setProps({pressed: false})
+    expect(wrapper.attributes('autocomplete')).toBeUndefined()
+  })
+
+  it('has attr disabled when is button and prop disabled', async () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true},
+    })
+    expect(wrapper.attributes('disabled')).toBe('')
+    await wrapper.setProps({disabled: false})
+    expect(wrapper.attributes('disabled')).toBeUndefined()
+  })
+
+  it('does not have attr disabled when prop disabled but has prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true, href: '/abc'},
+    })
+    expect(wrapper.attributes('disabled')).toBeUndefined()
+  })
+
+  it('does not have attr disabled when prop disabled but has prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true, to: '/abc'},
+    })
+    expect(wrapper.attributes('disabled')).toBeUndefined()
+  })
+
+  it('does not have attr disabled when prop disabled but does not have tag button', () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true, tag: 'div'},
+    })
+    expect(wrapper.attributes('disabled')).toBeUndefined()
+  })
+
+  it('has attr href when prop href', async () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc'},
+    })
+    expect(wrapper.attributes('href')).toBe('/abc')
+    await wrapper.setProps({href: undefined})
+    expect(wrapper.attributes('href')).toBeUndefined()
+  })
+
+  it('has attr rel when prop rel and prop to', async () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', rel: 'foobar'},
+    })
+    expect(wrapper.attributes('rel')).toBe('foobar')
+    await wrapper.setProps({to: undefined})
+    expect(wrapper.attributes('rel')).toBeUndefined()
+  })
+
+  it('has attr rel when prop rel and prop href', async () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc', rel: 'foobar'},
+    })
+    expect(wrapper.attributes('rel')).toBe('foobar')
+    await wrapper.setProps({href: undefined})
+    expect(wrapper.attributes('rel')).toBeUndefined()
+  })
+
+  it('has attr rel when prop rel when not href or to', () => {
+    const wrapper = mount(BButton, {
+      props: {rel: 'foobar'},
+    })
+    expect(wrapper.attributes('rel')).toBeUndefined()
+  })
+
+  it('has attr role as button when non standard tag', () => {
+    const wrapper = mount(BButton, {
+      props: {tag: 'div'},
+    })
+    expect(wrapper.attributes('role')).toBe('button')
+  })
+
+  it('has attr role as button when prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc'},
+    })
+    expect(wrapper.attributes('role')).toBe('button')
+  })
+
+  it('has attr role as button when prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc'},
+    })
+    expect(wrapper.attributes('role')).toBe('button')
+  })
+
+  it('has attr role as button by default', () => {
+    const wrapper = mount(BButton)
+    expect(wrapper.attributes('role')).toBeUndefined()
+  })
+
+  it('has prop target when prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc'},
+    })
+    expect(wrapper.attributes('target')).toBe('_self')
+  })
+
+  it('has prop target when prop href', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc'},
+    })
+    expect(wrapper.attributes('target')).toBe('_self')
+  })
+
+  it('has prop target when prop to and prop target', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', target: '_blank'},
+    })
+    expect(wrapper.attributes('target')).toBe('_blank')
+  })
+
+  it('has prop target when prop href and prop target', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', target: '_blank'},
+    })
+    expect(wrapper.attributes('target')).toBe('_blank')
+  })
+
+  it('does not have attr target when not link', () => {
+    const wrapper = mount(BButton, {
+      props: {target: '_blank'},
+    })
+    expect(wrapper.attributes('target')).toBeUndefined()
+  })
+
+  it('has attr type when when prop type', async () => {
+    const wrapper = mount(BButton)
+    expect(wrapper.attributes('type')).toBe('button')
+    await wrapper.setProps({type: 'submit'})
+    expect(wrapper.attributes('type')).toBe('submit')
+    await wrapper.setProps({type: 'reset'})
+    expect(wrapper.attributes('type')).toBe('reset')
+  })
+
+  it('does not have attr type prop type and prop tag', async () => {
+    const wrapper = mount(BButton, {
+      props: {type: 'submit', tag: 'div'},
+    })
+    expect(wrapper.attributes('type')).toBeUndefined()
+  })
+
+  it('does not have attr type prop type and prop to', async () => {
+    const wrapper = mount(BButton, {
+      props: {type: 'submit', to: '/abc'},
+    })
+    expect(wrapper.attributes('type')).toBeUndefined()
+  })
+
+  it('does not have attr type prop type and prop href', async () => {
+    const wrapper = mount(BButton, {
+      props: {type: 'submit', href: '/abc'},
+    })
+    expect(wrapper.attributes('type')).toBeUndefined()
+  })
+
+  it('has attr to when prop to', async () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc'},
+    })
+    expect(wrapper.attributes('to')).toBe('/abc')
+  })
+
+  it('has attr to when prop href and prop to', async () => {
+    const wrapper = mount(BButton, {
+      props: {href: '/abc', to: '/def'},
+    })
+    expect(wrapper.attributes('to')).toBe('/def')
+  })
+
+  it('has attr to when prop to and prop tag', async () => {
+    const wrapper = mount(BButton, {
+      props: {tag: 'div', to: '/def'},
+    })
+    expect(wrapper.attributes('to')).toBe('/def')
+  })
+
+  it('has attr to when prop to and prop tag', async () => {
+    const wrapper = mount(BButton)
+    expect(wrapper.attributes('to')).toBeUndefined()
+  })
+
+  it('has attr append when prop to and prop append', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', append: true},
+    })
+    const $blink = wrapper.getComponent(BLink)
+    expect($blink.props('append')).toBe(true)
+  })
+
+  it('has activeClass when prop activeClass and prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', activeClass: 'foobar'},
+    })
+    const $blink = wrapper.getComponent(BLink)
+    expect($blink.props('activeClass')).toBe('foobar')
+  })
+
+  it('has nested prop event when prop event and prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', event: 'foobar'},
+    })
+    const $blink = wrapper.getComponent(BLink)
+    expect($blink.props('event')).toBe('foobar')
+  })
+
+  it('has nested prop exactActiveClass when prop exactActiveClass and prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', exactActiveClass: 'foobar'},
+    })
+    const $blink = wrapper.getComponent(BLink)
+    expect($blink.props('exactActiveClass')).toBe('foobar')
+  })
+
+  it('has nested prop routerComponentName when prop routerComponentName and prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', routerComponentName: 'foobar'},
+    })
+    const $blink = wrapper.getComponent(BLink)
+    expect($blink.props('routerComponentName')).toBe('foobar')
+  })
+
+  it('has nested prop routerTag when prop routerTag and prop to', () => {
+    const wrapper = mount(BButton, {
+      props: {to: '/abc', routerTag: 'foobar'},
+    })
+    const $blink = wrapper.getComponent(BLink)
+    expect($blink.props('routerTag')).toBe('foobar')
+  })
+
+  it('emits click when clicked', async () => {
+    const wrapper = mount(BButton)
+    await wrapper.trigger('click')
+    expect(wrapper.emitted()).toHaveProperty('click')
+  })
+
+  it('click emit value is MouseEvent', async () => {
+    const wrapper = mount(BButton)
+    await wrapper.trigger('click')
+    const $emitted = wrapper.emitted('click') ?? []
+    expect($emitted[0][0] instanceof MouseEvent).toBe(true)
+  })
+
+  it('click does not emit event when disabled', async () => {
+    const wrapper = mount(BButton, {
+      props: {disabled: true},
+    })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('click')).toBeUndefined()
+  })
+
+  it('emits update:pressed when prop pressed', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true},
+    })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted()).toHaveProperty('update:pressed')
+  })
+
+  it('emit update:pressed value is opposite of prop pressed', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true},
+    })
+    await wrapper.trigger('click')
+    const $emitted = wrapper.emitted('update:pressed') ?? []
+    expect($emitted[0][0]).toBe(false)
+  })
+
+  it('does not emit update:pressed when prop pressed and prop disabled', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true, disabled: true},
+    })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('update:pressed')).toBeUndefined()
+  })
+
+  it('emits both click and update:pressed when prop pressed and clicked', async () => {
+    const wrapper = mount(BButton, {
+      props: {pressed: true},
+    })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted()).toHaveProperty('click')
+    expect(wrapper.emitted()).toHaveProperty('update:pressed')
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BButton, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
 })

--- a/packages/bootstrap-vue-3/src/components/BButton/close-button.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BButton/close-button.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BCloseButton from './BCloseButton.vue'
 
 describe('close-button', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class btn-close', () => {
     const wrapper = mount(BCloseButton)
     expect(wrapper.classes()).toContain('btn-close')

--- a/packages/bootstrap-vue-3/src/components/BFormCheckbox/form-checkbox-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BFormCheckbox/form-checkbox-group.spec.ts
@@ -1,6 +1,6 @@
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 import {nextTick} from 'vue'
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {createContainer} from '../../../tests/utils'
 import BFormCheckboxGroup from './BFormCheckboxGroup.vue'
 import BFormCheckbox from './BFormCheckbox.vue'
@@ -8,6 +8,7 @@ import BFormCheckbox from './BFormCheckbox.vue'
 const global = {components: {BFormCheckbox}}
 
 describe('form-checkbox-group', () => {
+  enableAutoUnmount(afterEach)
   // --- Structure, class and attributes tests ---
 
   it('default has structure <div></div>', () => {
@@ -18,8 +19,6 @@ describe('form-checkbox-group', () => {
 
     const $children = wrapper.element.children
     expect($children.length).toEqual(0)
-
-    wrapper.unmount()
   })
 
   it('default has no classes on wrapper other than focus ring', () => {
@@ -27,8 +26,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
     expect(wrapper.classes().length).toEqual(1)
-
-    wrapper.unmount()
   })
 
   it('default has auto ID set', async () => {
@@ -41,8 +38,6 @@ describe('form-checkbox-group', () => {
 
     // Auto ID not generated until after mount
     expect(wrapper.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('default has tabindex set to -1', () => {
@@ -50,24 +45,18 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('tabindex')).toBeDefined()
     expect(wrapper.attributes('tabindex')).toBe('-1')
-
-    wrapper.unmount()
   })
 
   it('default does not have aria-required set', () => {
     const wrapper = mount(BFormCheckboxGroup, {global})
 
     expect(wrapper.attributes('aria-required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default does not have aria-invalid set', () => {
     const wrapper = mount(BFormCheckboxGroup, {global})
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default has attribute role=group', () => {
@@ -75,8 +64,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('role')).toBeDefined()
     expect(wrapper.attributes('role')).toBe('group')
-
-    wrapper.unmount()
   })
 
   it('default has user provided ID', () => {
@@ -90,8 +77,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toBe('test')
-
-    wrapper.unmount()
   })
 
   it('default has class was-validated when validated=true', () => {
@@ -105,8 +90,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.classes()).toBeDefined()
     expect(wrapper.classes()).toContain('was-validated')
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when state=false', () => {
@@ -120,8 +103,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('default does not have attribute aria-invalid when state=true', () => {
@@ -134,8 +115,6 @@ describe('form-checkbox-group', () => {
     })
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default does not have attribute aria-invalid when state=undefined', () => {
@@ -148,8 +127,6 @@ describe('form-checkbox-group', () => {
     })
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=true', () => {
@@ -163,8 +140,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid="true"', () => {
@@ -178,8 +153,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=""', () => {
@@ -193,8 +166,6 @@ describe('form-checkbox-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   // --- Button mode structure ---
@@ -212,8 +183,6 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode has classes button-group-vertical and button-group-toggle when stacked=true', () => {
@@ -230,8 +199,6 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode has size class when size prop set', () => {
@@ -249,8 +216,6 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('btn-group-lg')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode has size class when size prop set and stacked', () => {
@@ -269,8 +234,6 @@ describe('form-checkbox-group', () => {
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('btn-group-lg')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode button variant works', async () => {
@@ -299,8 +262,6 @@ describe('form-checkbox-group', () => {
     expect($btns[0].classes()).toContain('btn-primary')
     expect($btns[1].classes()).toContain('btn-primary')
     expect($btns[2].classes()).toContain('btn-danger')
-
-    wrapper.unmount()
   })
 
   // --- Functionality testing ---
@@ -318,8 +279,6 @@ describe('form-checkbox-group', () => {
     // expect(wrapper.vm.isRadioGroup).toEqual(false)
     expect(wrapper.vm.modelValue).toEqual([])
     expect(wrapper.findAll('input[type=checkbox]').length).toBe(3)
-
-    wrapper.unmount()
   })
 
   it('has checkboxes via options array which respect disabled', () => {
@@ -340,8 +299,6 @@ describe('form-checkbox-group', () => {
     expect($inputs[0].attributes('disabled')).toBeUndefined()
     expect($inputs[1].attributes('disabled')).toBeUndefined()
     expect($inputs[2].attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('emits change event when checkbox clicked', async () => {
@@ -394,8 +351,6 @@ describe('form-checkbox-group', () => {
     expect($changed[3][0]).toEqual(['two', 'three'])
     expect($emitted.length).toBe(4)
     expect($emitted[3][0]).toEqual(['two', 'three'])
-
-    wrapper.unmount()
   })
 
   it('modelValue organizes based on options', async () => {
@@ -456,8 +411,6 @@ describe('form-checkbox-group', () => {
     expect(($inputs[0].element as HTMLInputElement).checked).toBe(true)
     expect(($inputs[1].element as HTMLInputElement).checked).toBe(false)
     expect(($inputs[2].element as HTMLInputElement).checked).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child checkboxes have is-valid classes when group state set to valid', () => {
@@ -479,8 +432,6 @@ describe('form-checkbox-group', () => {
     $inputs.forEach(($input) => {
       expect($input.classes()).toContain('is-valid')
     })
-
-    wrapper.unmount()
   })
 
   it('child checkboxes have is-invalid classes when group state set to invalid', () => {
@@ -501,8 +452,6 @@ describe('form-checkbox-group', () => {
     $inputs.forEach(($input) => {
       expect($input.classes()).toContain('is-invalid')
     })
-
-    wrapper.unmount()
   })
 
   it('child checkboxes have disabled attribute when group disabled', () => {
@@ -523,8 +472,6 @@ describe('form-checkbox-group', () => {
     $inputs.forEach(($input) => {
       expect($input.attributes('disabled')).toBeDefined()
     })
-
-    wrapper.unmount()
   })
 
   it('child checkboxes have required attribute when group required', () => {
@@ -547,8 +494,6 @@ describe('form-checkbox-group', () => {
       expect($input.attributes('required')).toBeDefined()
       expect($input.attributes('aria-required')).toBe('true')
     })
-
-    wrapper.unmount()
   })
 
   it('child checkboxes have class form-check-inline when stacked=false', () => {
@@ -568,8 +513,6 @@ describe('form-checkbox-group', () => {
     $inputs.forEach(($input) => {
       expect($input.classes()).toContain('form-check-inline')
     })
-
-    wrapper.unmount()
   })
 
   it('child checkboxes do not have class custom-control-inline when stacked=true', () => {
@@ -589,7 +532,5 @@ describe('form-checkbox-group', () => {
     $inputs.forEach(($input) => {
       expect($input.classes()).not.toContain('form-check-inline')
     })
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormCheckbox/form-checkbox.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormCheckbox/form-checkbox.spec.js
@@ -1,10 +1,11 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, beforeEach, describe, expect, it, vitest} from 'vitest'
 import {nextTick} from 'vue'
 import {createContainer, waitRAF} from '../../../tests/utils'
 import BFormCheckbox from './BFormCheckbox.vue'
 
 describe('form-checkbox', () => {
+  enableAutoUnmount(afterEach)
   // --- Custom checkbox structure, class and attributes tests ---
 
   it('default has structure <div><input><label></label></div>', () => {
@@ -25,8 +26,6 @@ describe('form-checkbox', () => {
     expect($children.length).toEqual(2)
     expect($children[0].tagName).toEqual('INPUT')
     expect($children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('default has wrapper class form-check and custom-checkbox', () => {
@@ -42,8 +41,6 @@ describe('form-checkbox', () => {
 
     expect(wrapper.classes().length).toEqual(1)
     expect(wrapper.classes()).toContain('form-check')
-
-    wrapper.unmount()
   })
 
   it('default has input type checkbox', () => {
@@ -60,8 +57,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('type')).toBeDefined()
     expect($input.attributes('type')).toEqual('checkbox')
-
-    wrapper.unmount()
   })
 
   it('default does not have aria-label attribute on input', () => {
@@ -75,8 +70,6 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.get('input').attributes('aria-label')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has aria-label attribute on input when aria-label provided', () => {
@@ -91,8 +84,6 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.get('input').attributes('aria-label')).toBe('bar')
-
-    wrapper.unmount()
   })
 
   it('default has input class form-check-input', () => {
@@ -109,8 +100,6 @@ describe('form-checkbox', () => {
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('form-check-input')
     expect($input.classes()).not.toContain('position-static')
-
-    wrapper.unmount()
   })
 
   it('default has label class form-check-label', () => {
@@ -126,8 +115,6 @@ describe('form-checkbox', () => {
     const $label = wrapper.get('label')
     expect($label.classes().length).toEqual(1)
     expect($label.classes()).toContain('form-check-label')
-
-    wrapper.unmount()
   })
 
   it('has default slot content in label', () => {
@@ -142,8 +129,6 @@ describe('form-checkbox', () => {
 
     const $label = wrapper.get('label')
     expect($label.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 
   it('has default has label when slot content not set', () => {
@@ -155,8 +140,6 @@ describe('form-checkbox', () => {
 
     const $label = wrapper.get('label')
     expect($label.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('default has no disabled attribute on input', () => {
@@ -171,8 +154,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has disabled attribute on input when prop disabled set', () => {
@@ -188,8 +169,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('default has no required attribute on input', () => {
@@ -204,8 +183,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not have required attribute on input when prop required set and name prop not provided', () => {
@@ -221,8 +198,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has required attribute on input when prop required and name set', () => {
@@ -239,8 +214,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('required')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('default has no name attribute on input', () => {
@@ -255,8 +228,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('name')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has name attribute on input when name prop set', () => {
@@ -273,8 +244,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('name')).toBeDefined()
     expect($input.attributes('name')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('default has no form attribute on input', () => {
@@ -289,8 +258,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('form')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has form attribute on input when form prop set', () => {
@@ -307,8 +274,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('form')).toBeDefined()
     expect($input.attributes('form')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('has custom attributes transferred to input element', () => {
@@ -322,8 +287,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('foo')).toBeDefined()
     expect($input.attributes('foo')).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('default has class form-check-inline when prop inline=true', () => {
@@ -340,8 +303,6 @@ describe('form-checkbox', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('form-check')
     expect(wrapper.classes()).toContain('form-check-inline')
-
-    wrapper.unmount()
   })
 
   it('default has no input validation classes by default', () => {
@@ -358,8 +319,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('default has no input validation classes when state=undefined', () => {
@@ -377,8 +336,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('default has input validation class is-valid when state=true', () => {
@@ -396,8 +353,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('default has input validation class is-invalid when state=false', () => {
@@ -415,8 +370,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('has id attribute on input when id prop set', () => {
@@ -433,8 +386,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
     expect($input.attributes('id')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('default has id attribute on input', () => {
@@ -449,8 +400,6 @@ describe('form-checkbox', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has for attribute on label when id prop set', () => {
@@ -467,8 +416,6 @@ describe('form-checkbox', () => {
     const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($label.attributes('for')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('default has for attribute on label equal to id property of input', () => {
@@ -487,8 +434,6 @@ describe('form-checkbox', () => {
     const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($input.attributes('id')).toEqual($label.attributes('for'))
-
-    wrapper.unmount()
   })
 
   it('default has unique id attribute on input', () => {
@@ -515,8 +460,6 @@ describe('form-checkbox', () => {
     expect($input.attributes('id')).toBeDefined()
     expect($input2.attributes('id')).toBeDefined()
     expect($input.attributes('id')).not.toEqual($input2.attributes('id'))
-
-    wrapper.unmount()
   })
   // --- plain styling ---
 
@@ -539,8 +482,6 @@ describe('form-checkbox', () => {
     expect($children.length).toEqual(2)
     expect($children[0].tagName).toEqual('INPUT')
     expect($children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('plain has no wrapper class form-check', () => {
@@ -557,8 +498,6 @@ describe('form-checkbox', () => {
 
     expect(wrapper.classes().length).toEqual(0)
     expect(wrapper.classes()).not.toContain('form-check')
-
-    wrapper.unmount()
   })
 
   it('plain has input type checkbox', () => {
@@ -576,8 +515,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('type')).toBeDefined()
     expect($input.attributes('type')).toEqual('checkbox')
-
-    wrapper.unmount()
   })
 
   it('plain has no input class form-check-input', () => {
@@ -594,8 +531,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(0)
     expect($input.classes()).not.toContain('form-check-input')
-
-    wrapper.unmount()
   })
 
   it('plain has no label class form-check-label', () => {
@@ -612,8 +547,6 @@ describe('form-checkbox', () => {
     const $label = wrapper.get('label')
     expect($label.classes()).not.toContain('form-check-label')
     expect($label.classes().length).toEqual(0)
-
-    wrapper.unmount()
   })
 
   it('plain has default slot content in label', () => {
@@ -629,8 +562,6 @@ describe('form-checkbox', () => {
 
     const $label = wrapper.get('label')
     expect($label.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 
   it('plain does not have class position-static when label provided', () => {
@@ -645,8 +576,6 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.get('input').classes()).not.toContain('position-static')
-
-    wrapper.unmount()
   })
 
   it('plain has no label when no default slot content', () => {
@@ -657,8 +586,6 @@ describe('form-checkbox', () => {
       },
     })
     expect(wrapper.find('label').exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('plain has class form-check-inline when prop inline=true', () => {
@@ -674,8 +601,6 @@ describe('form-checkbox', () => {
     })
 
     expect(wrapper.classes()).toContain('form-check-inline')
-
-    wrapper.unmount()
   })
 
   it('plain has no input validation classes by default', () => {
@@ -693,8 +618,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('plain has no input validation classes when state=undefined', () => {
@@ -713,8 +636,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('plain has input validation class is-valid when state=true', () => {
@@ -733,8 +654,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).not.toContain('is-invalid')
     expect($input.classes()).toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('plain has input validation class is-invalid when state=false', () => {
@@ -753,8 +672,6 @@ describe('form-checkbox', () => {
     expect($input).toBeDefined()
     expect($input.classes()).toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   // --- Switch styling - stand alone ---
@@ -778,8 +695,6 @@ describe('form-checkbox', () => {
     expect($children.length).toEqual(2)
     expect($children[0].tagName).toEqual('INPUT')
     expect($children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('switch has wrapper classes form-check and form-switch', () => {
@@ -797,8 +712,6 @@ describe('form-checkbox', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('form-check')
     expect(wrapper.classes()).toContain('form-switch')
-
-    wrapper.unmount()
   })
 
   it('switch has input type checkbox', () => {
@@ -816,8 +729,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('type')).toBeDefined()
     expect($input.attributes('type')).toEqual('checkbox')
-
-    wrapper.unmount()
   })
 
   it('switch has input class form-check-input', () => {
@@ -834,8 +745,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('form-check-input')
-
-    wrapper.unmount()
   })
 
   it('switch has label class form-check-label', () => {
@@ -852,8 +761,6 @@ describe('form-checkbox', () => {
     const $label = wrapper.get('label')
     expect($label.classes().length).toEqual(1)
     expect($label.classes()).toContain('form-check-label')
-
-    wrapper.unmount()
   })
 
   // --- Button styling - stand-alone mode ---
@@ -877,8 +784,6 @@ describe('form-checkbox', () => {
     expect($children.length).toEqual(2)
     expect($children[0].tagName).toEqual('INPUT')
     expect($children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has wrapper classes btn-check', () => {
@@ -896,8 +801,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('btn-check')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label classes btn and btn-secondary when unchecked', () => {
@@ -919,8 +822,6 @@ describe('form-checkbox', () => {
     expect($label.classes()).not.toContain('focus')
     expect($label.classes()).toContain('btn')
     expect($label.classes()).toContain('btn-secondary')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label classes btn, btn-secondary and active when checked by default', () => {
@@ -942,8 +843,6 @@ describe('form-checkbox', () => {
     expect($label.classes()).toContain('btn')
     expect($label.classes()).toContain('btn-secondary')
     expect($label.classes()).toContain('active')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label class active when clicked (checked)', async () => {
@@ -977,8 +876,6 @@ describe('form-checkbox', () => {
     expect($label.classes()).toContain('active')
     expect($label.classes()).toContain('btn')
     expect($label.classes()).toContain('btn-secondary')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label class focus when input focused', async () => {
@@ -1012,8 +909,6 @@ describe('form-checkbox', () => {
     await $input.trigger('blur')
     expect($label.classes().length).toEqual(2)
     expect($label.classes()).not.toContain('focus')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label btn-primary when prop btn-variant set to primary', () => {
@@ -1037,8 +932,6 @@ describe('form-checkbox', () => {
     expect($label.classes()).not.toContain('btn-secondary')
     expect($label.classes()).toContain('btn')
     expect($label.classes()).toContain('btn-primary')
-
-    wrapper.unmount()
   })
 
   it('plain has no effect on stand-alone button', () => {
@@ -1057,8 +950,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('btn-check')
-
-    wrapper.unmount()
   })
 
   // --- Indeterminate testing ---
@@ -1076,8 +967,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.indeterminate).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('has input indeterminate set by when indeterminate=true', () => {
@@ -1094,8 +983,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.indeterminate).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('has input indeterminate set by when indeterminate set to true after mount', async () => {
@@ -1118,8 +1005,6 @@ describe('form-checkbox', () => {
 
     await wrapper.setProps({indeterminate: false})
     expect($input.element.indeterminate).toBe(false)
-
-    wrapper.unmount()
   })
 
   // --- Functionality testing ---
@@ -1141,8 +1026,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('default has internal modelValue=true when prop modelValue=true', () => {
@@ -1162,8 +1045,6 @@ describe('form-checkbox', () => {
     const $input = wrapper.get('input')
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('default has internal modelValue null', () => {
@@ -1179,8 +1060,6 @@ describe('form-checkbox', () => {
 
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.modelValue).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default has internal modelValue set to checked prop', () => {
@@ -1198,8 +1077,6 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toEqual('foo')
-
-    wrapper.unmount()
   })
 
   it('default has internal modelValue set to value when checked=value', () => {
@@ -1217,8 +1094,6 @@ describe('form-checkbox', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('emits a change event when clicked', async () => {
@@ -1252,8 +1127,6 @@ describe('form-checkbox', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual('foo')
-
-    wrapper.unmount()
   })
 
   it('emits a change event when label clicked', async () => {
@@ -1287,8 +1160,6 @@ describe('form-checkbox', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual('foo')
-
-    wrapper.unmount()
   })
 
   it('does not emit a change event when clicked if disabled', async () => {
@@ -1316,8 +1187,6 @@ describe('form-checkbox', () => {
 
     await $input.trigger('click')
     expect(wrapper.emitted('change')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not emit a change event when label clicked if disabled', async () => {
@@ -1345,8 +1214,6 @@ describe('form-checkbox', () => {
 
     await $label.trigger('click')
     expect(wrapper.emitted('change')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('works when v-model bound to an array', async () => {
@@ -1426,8 +1293,6 @@ describe('form-checkbox', () => {
 
     expect($input).toBeDefined()
     expect($input.element.checked).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('should react to model changes when bound to an array', async () => {
@@ -1462,8 +1327,6 @@ describe('form-checkbox', () => {
     expect(wrapper.vm.modelValue.length).toBe(2)
     expect(wrapper.vm.modelValue[0]).toEqual('bar')
     expect(wrapper.vm.modelValue[1]).toEqual('foo')
-
-    wrapper.unmount()
   })
 
   it('works when value is an object', async () => {
@@ -1500,8 +1363,6 @@ describe('form-checkbox', () => {
     expect(Array.isArray(wrapper.vm.modelValue)).toBe(true)
     expect(wrapper.vm.modelValue.length).toBe(1)
     expect(wrapper.vm.modelValue[0]).toEqual('foo')
-
-    wrapper.unmount()
   })
   // These tests are wrapped in a new describe to limit the scope
   // of the `getBoundingClientRect()` mock
@@ -1546,8 +1407,6 @@ describe('form-checkbox', () => {
       expect($input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).toBe($input.element)
-
-      wrapper.unmount()
     })
 
     it('does not auto focus when false', async () => {
@@ -1570,8 +1429,6 @@ describe('form-checkbox', () => {
       expect($input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).not.toBe($input.element)
-
-      wrapper.unmount()
     })
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormInput/form-input.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormInput/form-input.spec.js
@@ -1,17 +1,17 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, beforeEach, describe, expect, it, vitest} from 'vitest'
 import {nextTick} from 'vue'
 import {createContainer, waitRAF} from '../../../tests/utils'
 import BFormInput from './BFormInput.vue'
 
 describe('form-input', () => {
+  enableAutoUnmount(afterEach)
+
   it('has class form-control', () => {
     const wrapper = mount(BFormInput)
 
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control')
-
-    wrapper.unmount()
   })
 
   it('has class form-control-lg when size=lg and plane=false', () => {
@@ -23,8 +23,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-lg')
-
-    wrapper.unmount()
   })
 
   it('has class form-control-sm when size=lg and plain=false', () => {
@@ -36,8 +34,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-sm')
-
-    wrapper.unmount()
   })
 
   it('does not have class form-control-plaintext when plaintext not set', () => {
@@ -46,8 +42,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.classes()).not.toContain('form-control-plaintext')
     expect($input.attributes('readonly')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has class form-control-plaintext when plaintext=true', () => {
@@ -59,8 +53,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-plaintext')
-
-    wrapper.unmount()
   })
 
   it('has attribute read-only when plaintext=true', () => {
@@ -73,8 +65,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-control-plaintext')
     expect($input.attributes('readonly')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has class custom-range instead of form-control when type=range', () => {
@@ -87,8 +77,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('form-range')
     expect($input.classes()).not.toContain('form-control')
-
-    wrapper.unmount()
   })
 
   it('does not have class form-control-plaintext when type=range and plaintext=true', () => {
@@ -103,8 +91,6 @@ describe('form-input', () => {
     expect($input.classes()).toContain('form-range')
     expect($input.classes()).not.toContain('form-control')
     expect($input.classes()).not.toContain('form-control-plaintext')
-
-    wrapper.unmount()
   })
 
   it('does not have class form-control-plaintext when type=color and plaintext=true', () => {
@@ -119,8 +105,6 @@ describe('form-input', () => {
     expect($input.classes()).not.toContain('custom-range')
     expect($input.classes()).not.toContain('form-control-plaintext')
     expect($input.classes()).toContain('form-control')
-
-    wrapper.unmount()
   })
 
   it('has user supplied id', () => {
@@ -132,8 +116,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('id')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has safeId after mount when no id provided', async () => {
@@ -146,8 +128,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has form attribute when form prop set', () => {
@@ -159,8 +139,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('form')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('does not have list attribute when list prop not set', () => {
@@ -168,8 +146,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('list')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has list attribute when list prop set', () => {
@@ -181,8 +157,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('list')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('does not have list attribute when list prop set and type=password', () => {
@@ -195,8 +169,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('list')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('renders text input by default', () => {
@@ -204,8 +176,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('type')).toBe('text')
-
-    wrapper.unmount()
   })
 
   it('renders number input when type set to number', () => {
@@ -217,8 +187,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('type')).toBe('number')
-
-    wrapper.unmount()
   })
 
   it('renders text input when type not supported', () => {
@@ -239,8 +207,6 @@ describe('form-input', () => {
     expect($input.attributes('type')).toBe('text')
 
     expect(warnHandler).toHaveBeenCalled()
-
-    wrapper.unmount()
   })
 
   it('does not have is-valid or is-invalid classes when state is default', () => {
@@ -249,8 +215,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.classes()).not.toContain('is-valid')
     expect($input.classes()).not.toContain('is-invalid')
-
-    wrapper.unmount()
   })
 
   it('has class is-valid when state=true', () => {
@@ -263,8 +227,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('is-valid')
     expect($input.classes()).not.toContain('is-invalid')
-
-    wrapper.unmount()
   })
 
   it('has class is-invalid when state=false', () => {
@@ -277,16 +239,12 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.classes()).toContain('is-invalid')
     expect($input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('does not have aria-invalid attribute by default', () => {
     const wrapper = mount(BFormInput)
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not have aria-invalid attribute when state is true', () => {
@@ -297,8 +255,6 @@ describe('form-input', () => {
     })
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when state=false', () => {
@@ -310,8 +266,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when aria-invalid="true"', () => {
@@ -323,8 +277,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when aria-invalid=true', () => {
@@ -336,8 +288,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when aria-invalid="spelling"', () => {
@@ -349,8 +299,6 @@ describe('form-input', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('aria-invalid')).toBe('spelling')
-
-    wrapper.unmount()
   })
 
   it('is disabled when disabled=true', () => {
@@ -363,8 +311,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeDefined()
     expect($input.element.disabled).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('is not disabled when disabled=false', () => {
@@ -377,8 +323,6 @@ describe('form-input', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('disabled')).toBeUndefined()
     expect($input.element.disabled).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('emits an input event', async () => {
@@ -391,8 +335,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input')[0].length).toEqual(1)
     expect(wrapper.emitted('input')[0][0]).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('emits a native focus event', async () => {
@@ -408,8 +350,6 @@ describe('form-input', () => {
 
     expect(wrapper.emitted()).toMatchObject({})
     expect(spy).toHaveBeenCalled()
-
-    wrapper.unmount()
   })
 
   it('emits a blur event with native event as only arg', async () => {
@@ -426,8 +366,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('blur')[0].length).toEqual(1)
     expect(wrapper.emitted('blur')[0][0] instanceof Event).toBe(true)
     expect(wrapper.emitted('blur')[0][0].type).toEqual('blur')
-
-    wrapper.unmount()
   })
 
   it('applies formatter on input when not lazy', async () => {
@@ -451,8 +389,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toEqual(1)
     expect(wrapper.emitted('input')[0][0]).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter on input when lazy', async () => {
@@ -481,8 +417,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('input').length).toEqual(1)
     expect(wrapper.emitted('input')[0][0]).toEqual('TEST')
     expect(wrapper.emitted('change')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('applies formatter on blur when lazy', async () => {
@@ -521,8 +455,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeDefined()
     expect(wrapper.emitted('blur').length).toEqual(1)
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter when value supplied on mount and not lazy', () => {
@@ -541,8 +473,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter when value prop updated and not lazy', async () => {
@@ -564,8 +494,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter when value prop updated and lazy', async () => {
@@ -588,8 +516,6 @@ describe('form-input', () => {
     expect(wrapper.emitted('input')).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not update value when non-lazy formatter returns false', async () => {
@@ -618,8 +544,6 @@ describe('form-input', () => {
     expect(wrapper.vm.modelValue).toBe('abc')
     // Value in input should remain the same as entered
     expect($input.element.value).toEqual('TEST')
-
-    wrapper.unmount()
   })
 
   /* TODO: implement noWheel
@@ -647,7 +571,7 @@ describe('form-input', () => {
     // `:no-wheel="true"` will fire a blur event on the input when wheel fired
     expect(spy).toHaveBeenCalled()
 
-    wrapper.unmount()
+    
   })
 
 
@@ -677,7 +601,7 @@ describe('form-input', () => {
     // `:no-wheel="false"` will not fire a blur event on the input when wheel fired
     expect(spy).not.toHaveBeenCalled()
 
-    wrapper.unmount()
+    
   })
 
 
@@ -719,7 +643,7 @@ describe('form-input', () => {
     expect(document.activeElement).not.toBe(wrapper.element)
     expect(spy).toHaveBeenCalled()
 
-    wrapper.unmount()
+    
   })
   */
 
@@ -765,8 +689,6 @@ describe('form-input', () => {
     // Updating the `v-model` to new numeric value
     await wrapper.setProps({modelValue: 45.6})
     expect($input.element.value).toBe('45.6')
-
-    wrapper.unmount()
   })
 
   it('"lazy" modifier prop works', async () => {
@@ -819,8 +741,6 @@ describe('form-input', () => {
     // `v-model` update event should have emitted
     expect(wrapper.emitted('update:modelValue').length).toEqual(2)
     expect(wrapper.emitted('update:modelValue')[1][0]).toBe('abcd')
-
-    wrapper.unmount()
   })
 
   /* TODO: implement debounce
@@ -921,7 +841,7 @@ describe('form-input', () => {
     // `input` event should not have emitted new event
     expect(wrapper.emitted('input').length).toBe(6)
 
-    wrapper.unmount()
+    
   })
   */
 
@@ -962,8 +882,6 @@ describe('form-input', () => {
       expect($input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).toBe($input.element)
-
-      wrapper.unmount()
     })
 
     it('does not autofocus when false', async () => {
@@ -982,8 +900,6 @@ describe('form-input', () => {
       expect($input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).not.toBe($input.element)
-
-      wrapper.unmount()
     })
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormRadio/form-radio-group.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormRadio/form-radio-group.spec.js
@@ -1,5 +1,5 @@
-import {describe, expect, it} from 'vitest'
-import {mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {createContainer} from '../../../tests/utils'
 import {nextTick} from 'vue'
 import BFormRadioGroup from './BFormRadioGroup.vue'
@@ -8,6 +8,7 @@ import BFormRadio from './BFormRadio.vue'
 const global = {components: {BFormRadio}}
 
 describe('form-radio-group', () => {
+  enableAutoUnmount(afterEach)
   // --- Structure, class and attributes tests ---
 
   it('default has structure <div></div>', () => {
@@ -16,8 +17,6 @@ describe('form-radio-group', () => {
     expect(wrapper).toBeDefined()
     expect(wrapper.element.tagName).toBe('DIV')
     expect(wrapper.element.children.length).toEqual(0)
-
-    wrapper.unmount()
   })
 
   it('default has no classes on wrapper other than focus ring', () => {
@@ -25,8 +24,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.classes().length).toEqual(1)
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('default has auto ID set', async () => {
@@ -38,8 +35,6 @@ describe('form-radio-group', () => {
     await nextTick()
 
     expect(wrapper.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('default has tabindex set to -1', () => {
@@ -47,24 +42,18 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('tabindex')).toBeDefined()
     expect(wrapper.attributes('tabindex')).toBe('-1')
-
-    wrapper.unmount()
   })
 
   it('default does not have aria-required set', () => {
     const wrapper = mount(BFormRadioGroup, {global})
 
     expect(wrapper.attributes('aria-required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default does not have aria-invalid set', () => {
     const wrapper = mount(BFormRadioGroup, {global})
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default has attribute role=radiogroup', () => {
@@ -72,8 +61,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('role')).toBeDefined()
     expect(wrapper.attributes('role')).toBe('radiogroup')
-
-    wrapper.unmount()
   })
 
   it('default has user provided ID', () => {
@@ -87,8 +74,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toBe('test')
-
-    wrapper.unmount()
   })
 
   it('default has class was-validated when validated=true', () => {
@@ -102,8 +87,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.classes()).toBeDefined()
     expect(wrapper.classes()).toContain('was-validated')
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when state=false', () => {
@@ -117,8 +100,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('default does not have attribute aria-invalid when state=true', () => {
@@ -131,8 +112,6 @@ describe('form-radio-group', () => {
     })
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default does not have attribute aria-invalid when state=undefined', () => {
@@ -145,8 +124,6 @@ describe('form-radio-group', () => {
     })
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=true', () => {
@@ -160,8 +137,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid="true"', () => {
@@ -175,8 +150,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('default has attribute aria-invalid=true when aria-invalid=""', () => {
@@ -190,8 +163,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.attributes('aria-invalid')).toBeDefined()
     expect(wrapper.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   // --- Button mode structure ---
@@ -209,8 +180,6 @@ describe('form-radio-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode has classes button-group-vertical and button-group-toggle when stacked=true', () => {
@@ -227,8 +196,6 @@ describe('form-radio-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode has size class when size prop set', () => {
@@ -246,8 +213,6 @@ describe('form-radio-group', () => {
     expect(wrapper.classes()).toContain('btn-group')
     expect(wrapper.classes()).toContain('btn-group-lg')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode has size class when size prop set and stacked', () => {
@@ -266,8 +231,6 @@ describe('form-radio-group', () => {
     expect(wrapper.classes()).toContain('btn-group-vertical')
     expect(wrapper.classes()).toContain('btn-group-lg')
     expect(wrapper.classes()).toContain('bv-no-focus-ring')
-
-    wrapper.unmount()
   })
 
   it('button mode button variant works', async () => {
@@ -297,8 +260,6 @@ describe('form-radio-group', () => {
     expect($buttons[0].classes()).toContain('btn-primary')
     expect($buttons[1].classes()).toContain('btn-primary')
     expect($buttons[2].classes()).toContain('btn-danger')
-
-    wrapper.unmount()
   })
 
   // --- Functionality testing ---
@@ -315,8 +276,6 @@ describe('form-radio-group', () => {
 
     expect(wrapper.vm.modelValue).toEqual('')
     expect(wrapper.findAll('input[type=radio]').length).toBe(3)
-
-    wrapper.unmount()
   })
 
   it('has radios via options array which respect disabled', () => {
@@ -337,8 +296,6 @@ describe('form-radio-group', () => {
     expect($radios[0].attributes('disabled')).toBeUndefined()
     expect($radios[1].attributes('disabled')).toBeUndefined()
     expect($radios[2].attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has radios with attribute required when prop required set', async () => {
@@ -365,8 +322,6 @@ describe('form-radio-group', () => {
       expect($radio.attributes('required')).toBeDefined()
       expect($radio.attributes('aria-required')).toBe('true')
     })
-
-    wrapper.unmount()
   })
 
   it('emits change event when radio clicked', async () => {
@@ -410,8 +365,6 @@ describe('form-radio-group', () => {
     expect(wrapper.emitted('change')[2][0]).toEqual('one')
     expect(wrapper.emitted('update:modelValue').length).toBe(3)
     expect(wrapper.emitted('update:modelValue')[2][0]).toEqual('one')
-
-    wrapper.unmount()
   })
 
   it('radios reflect group checked v-model', async () => {
@@ -445,7 +398,5 @@ describe('form-radio-group', () => {
     expect($radios[0].element.checked).toBe(false)
     expect($radios[1].element.checked).toBe(false)
     expect($radios[2].element.checked).toBe(true)
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormRadio/form-radio.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormRadio/form-radio.spec.js
@@ -1,4 +1,4 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, beforeEach, describe, expect, it, vitest} from 'vitest'
 import {createContainer, waitRAF} from '../../../tests/utils'
 import {nextTick} from 'vue'
@@ -6,6 +6,7 @@ import BFormRadio from './BFormRadio.vue'
 
 describe('form-radio', () => {
   /* Custom radio structure, class and attributes tests */
+  enableAutoUnmount(afterEach)
 
   it('default has structure <div><input><label></label></div>', () => {
     const wrapper = mount(BFormRadio, {
@@ -23,8 +24,6 @@ describe('form-radio', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('default has wrapper class form-check', () => {
@@ -39,8 +38,6 @@ describe('form-radio', () => {
     })
     expect(wrapper.classes().length).toEqual(1)
     expect(wrapper.classes()).toContain('form-check')
-
-    wrapper.unmount()
   })
 
   it('default has input type radio', () => {
@@ -56,8 +53,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('radio')
-
-    wrapper.unmount()
   })
 
   it('default has input class form-check-input', () => {
@@ -73,8 +68,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-input')
-
-    wrapper.unmount()
   })
 
   it('default has label class form-check-label', () => {
@@ -90,8 +83,6 @@ describe('form-radio', () => {
     const input = wrapper.get('label')
     expect(input.classes().length).toEqual(1)
     expect(input.classes()).toContain('form-check-label')
-
-    wrapper.unmount()
   })
 
   it('has default slot content in label', () => {
@@ -106,8 +97,6 @@ describe('form-radio', () => {
     })
     const label = wrapper.get('label')
     expect(label.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 
   it('default has no disabled attribute on input', () => {
@@ -122,8 +111,6 @@ describe('form-radio', () => {
     })
     const input = wrapper.get('input')
     expect(input.attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has disabled attribute on input when prop disabled set', () => {
@@ -139,8 +126,6 @@ describe('form-radio', () => {
     })
     const input = wrapper.get('input')
     expect(input.attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('default has no required attribute on input', () => {
@@ -155,8 +140,6 @@ describe('form-radio', () => {
     })
     const input = wrapper.get('input')
     expect(input.attributes('required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not have required attribute on input when prop required set and name prop not provided', () => {
@@ -173,8 +156,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('required')).toBeUndefined()
     expect(input.attributes('aria-required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has required attribute on input when prop required and name set', () => {
@@ -192,8 +173,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('required')).toBeDefined()
     expect(input.attributes('aria-required')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('default has no name attribute on input', () => {
@@ -208,8 +187,6 @@ describe('form-radio', () => {
     })
     const input = wrapper.get('input')
     expect(input.attributes('name')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has name attribute on input when name prop set', () => {
@@ -226,8 +203,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('name')).toBeDefined()
     expect(input.attributes('name')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('default has no form attribute on input', () => {
@@ -242,8 +217,6 @@ describe('form-radio', () => {
     })
     const input = wrapper.get('input')
     expect(input.attributes('form')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has form attribute on input when form prop set', () => {
@@ -260,8 +233,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('form')).toBeDefined()
     expect(input.attributes('form')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('has custom attributes transferred to input element', () => {
@@ -274,8 +245,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('foo')).toBeDefined()
     expect(input.attributes('foo')).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('default has class form-check-inline when prop inline=true', () => {
@@ -292,8 +261,6 @@ describe('form-radio', () => {
     expect(wrapper.classes().length).toEqual(2)
     expect(wrapper.classes()).toContain('form-check')
     expect(wrapper.classes()).toContain('form-check-inline')
-
-    wrapper.unmount()
   })
 
   it('default has no input validation classes by default', () => {
@@ -310,8 +277,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('default has no input validation classes when state=undefined', () => {
@@ -329,8 +294,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('default has input validation class is-valid when state=true', () => {
@@ -348,8 +311,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('default has input validation class is-invalid when state=false', () => {
@@ -367,8 +328,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('has id attribute on input when id prop set', () => {
@@ -385,8 +344,6 @@ describe('form-radio', () => {
     const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
     expect($input.attributes('id')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('default has id attribute on input', () => {
@@ -401,8 +358,6 @@ describe('form-radio', () => {
 
     const $input = wrapper.get('input')
     expect($input.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has for attribute on label when id prop set', () => {
@@ -419,8 +374,6 @@ describe('form-radio', () => {
     const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($label.attributes('for')).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('default has for attribute on label equal to id property of input', () => {
@@ -439,8 +392,6 @@ describe('form-radio', () => {
     const $label = wrapper.get('label')
     expect($label.attributes('for')).toBeDefined()
     expect($input.attributes('id')).toEqual($label.attributes('for'))
-
-    wrapper.unmount()
   })
 
   it('default has unique id attribute on input', () => {
@@ -467,8 +418,6 @@ describe('form-radio', () => {
     expect($input.attributes('id')).toBeDefined()
     expect($input2.attributes('id')).toBeDefined()
     expect($input.attributes('id')).not.toEqual($input2.attributes('id'))
-
-    wrapper.unmount()
   })
   // --- Plain styling ---
 
@@ -489,8 +438,6 @@ describe('form-radio', () => {
     expect(children.length).toEqual(2)
     expect(children[0].tagName).toEqual('INPUT')
     expect(children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('plain has no wrapper class form-check', () => {
@@ -506,8 +453,6 @@ describe('form-radio', () => {
     })
     expect(wrapper.classes().length).toEqual(0)
     expect(wrapper.classes()).not.toContain('form-check')
-
-    wrapper.unmount()
   })
 
   it('plain has input type radio', () => {
@@ -524,8 +469,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.attributes('type')).toBeDefined()
     expect(input.attributes('type')).toEqual('radio')
-
-    wrapper.unmount()
   })
 
   it('plain has no input class form-check-input', () => {
@@ -542,8 +485,6 @@ describe('form-radio', () => {
     const input = wrapper.get('input')
     expect(input.classes()).not.toContain('form-check-input')
     expect(input.classes().length).toEqual(0)
-
-    wrapper.unmount()
   })
 
   it('plain has no label class form-check-label', () => {
@@ -560,8 +501,6 @@ describe('form-radio', () => {
     const input = wrapper.get('label')
     expect(input.classes()).not.toContain('form-check-label')
     expect(input.classes().length).toEqual(0)
-
-    wrapper.unmount()
   })
 
   it('plain has default slot content in label', () => {
@@ -577,8 +516,6 @@ describe('form-radio', () => {
     })
     const label = wrapper.get('label')
     expect(label.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 
   it('plain has no input validation classes by default', () => {
@@ -596,8 +533,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('plain has no input validation classes when state=undefined', () => {
@@ -616,8 +551,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('plain has input validation class is-valid when state=true', () => {
@@ -636,8 +569,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).not.toContain('is-invalid')
     expect(input.classes()).toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('plain has input validation class is-invalid when state=false', () => {
@@ -656,8 +587,6 @@ describe('form-radio', () => {
     expect(input).toBeDefined()
     expect(input.classes()).toContain('is-invalid')
     expect(input.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   // --- Button styling - stand-alone mode ---
@@ -680,8 +609,6 @@ describe('form-radio', () => {
     expect($children.length).toEqual(2)
     expect($children[0].tagName).toEqual('INPUT')
     expect($children[1].tagName).toEqual('LABEL')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has wrapper classes btn-check', () => {
@@ -698,8 +625,6 @@ describe('form-radio', () => {
     const $input = wrapper.get('input')
     expect($input.classes().length).toEqual(1)
     expect($input.classes()).toContain('btn-check')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label classes btn and btn-secondary when unchecked', () => {
@@ -720,8 +645,6 @@ describe('form-radio', () => {
     expect(label.classes()).not.toContain('focus')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label classes btn and btn-size when size property set', () => {
@@ -744,8 +667,6 @@ describe('form-radio', () => {
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
     expect(label.classes()).toContain('btn-lg')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label classes btn, btn-secondary and active when checked by default', () => {
@@ -766,8 +687,6 @@ describe('form-radio', () => {
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
     expect(label.classes()).toContain('active')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label class active when clicked (checked)', async () => {
@@ -800,8 +719,6 @@ describe('form-radio', () => {
     expect(label.classes()).toContain('active')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-secondary')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label class focus when input focused', async () => {
@@ -835,8 +752,6 @@ describe('form-radio', () => {
     await input.trigger('blur')
     expect(label.classes().length).toEqual(2)
     expect(label.classes()).not.toContain('focus')
-
-    wrapper.unmount()
   })
 
   it('stand-alone button has label btn-primary when prop btn-variant set to primary', () => {
@@ -859,8 +774,6 @@ describe('form-radio', () => {
     expect(label.classes()).not.toContain('btn-secondary')
     expect(label.classes()).toContain('btn')
     expect(label.classes()).toContain('btn-primary')
-
-    wrapper.unmount()
   })
 
   // --- Functionality testing ---
@@ -878,8 +791,6 @@ describe('form-radio', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toBe('')
-
-    wrapper.unmount()
   })
 
   it('default has internal modelValue set to value when checked=value', () => {
@@ -895,8 +806,6 @@ describe('form-radio', () => {
     expect(wrapper.vm).toBeDefined()
     expect(wrapper.vm.modelValue).toBeDefined()
     expect(wrapper.vm.modelValue).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('default has internal modelValue set to value when checked changed to value', async () => {
@@ -921,8 +830,6 @@ describe('form-radio', () => {
     // const last = wrapper.emitted('input').length - 1
     // expect(wrapper.emitted('input')[last]).toBeDefined()
     // expect(wrapper.emitted('input')[last][0]).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('emits a change event when clicked', async () => {
@@ -949,8 +856,6 @@ describe('form-radio', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('emits a change event when label clicked', async () => {
@@ -985,8 +890,6 @@ describe('form-radio', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(1)
     expect(wrapper.emitted('change')[0][0]).toEqual('bar')
-
-    wrapper.unmount()
   })
 
   it('does not emit a change event when clicked if disabled', async () => {
@@ -1012,8 +915,6 @@ describe('form-radio', () => {
 
     await $input.trigger('click')
     expect(wrapper.emitted('change')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not emit a change event when label clicked if disabled', async () => {
@@ -1038,8 +939,6 @@ describe('form-radio', () => {
 
     await $label.trigger('click')
     expect(wrapper.emitted('change')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('works when v-model bound to an array', async () => {
@@ -1102,8 +1001,6 @@ describe('form-radio', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('change').length).toBe(2)
     expect(wrapper.emitted('change')[1][0]).toEqual(['bar'])
-
-    wrapper.unmount()
   })
 
   it('works when value is an object', async () => {
@@ -1130,8 +1027,6 @@ describe('form-radio', () => {
 
     await input.trigger('click')
     expect(wrapper.vm.modelValue).toEqual({bar: 1, baz: 2})
-
-    wrapper.unmount()
   })
 
   // These tests are wrapped in a new describe to limit the scope of the getBCR Mock
@@ -1175,8 +1070,6 @@ describe('form-radio', () => {
       expect(input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).toBe(input.element)
-
-      wrapper.unmount()
     })
 
     it('does not autofocus by default', async () => {
@@ -1197,8 +1090,6 @@ describe('form-radio', () => {
       expect(input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).not.toBe(input.element)
-
-      wrapper.unmount()
     })
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormSelect/form-select-option-group.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormSelect/form-select-option-group.spec.js
@@ -1,9 +1,11 @@
-import {mount} from '@vue/test-utils'
-import {afterAll, describe, expect, it, vitest} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterAll, afterEach, describe, expect, it, vitest} from 'vitest'
 import {h} from 'vue'
 import BFormSelectOptionGroup from './BFormSelectOptionGroup.vue'
 
 describe('form-select-option-group', () => {
+  enableAutoUnmount(afterEach)
+
   afterAll(() => {
     console.warn.mockClear()
   })
@@ -18,8 +20,6 @@ describe('form-select-option-group', () => {
     expect(wrapper.element.tagName).toBe('OPTGROUP')
     expect(wrapper.attributes('label')).toEqual('foo')
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('has option elements from simple options array', () => {
@@ -41,8 +41,6 @@ describe('form-select-option-group', () => {
     $options.forEach(($option) => {
       expect($option.attributes('disabled')).toBeUndefined()
     })
-
-    wrapper.unmount()
   })
 
   it('has option elements from options array of objects', () => {
@@ -71,8 +69,6 @@ describe('form-select-option-group', () => {
     expect($options[0].attributes('disabled')).toBeUndefined()
     expect($options[1].attributes('disabled')).toBeDefined()
     expect($options[2].attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has option elements from options legacy object format', () => {
@@ -96,8 +92,6 @@ describe('form-select-option-group', () => {
     expect(spyWarn).toHaveBeenLastCalledWith(
       '[BootstrapVue warn]: BFormSelectOptionGroup - Setting prop "options" to an object is deprecated. Use the array format instead.'
     )
-
-    wrapper.unmount()
   })
 
   it('has option elements from default slot', () => {
@@ -125,7 +119,5 @@ describe('form-select-option-group', () => {
     expect($options[0].attributes('value')).toBe('1')
     expect($options[1].attributes('value')).toBe('2')
     expect($options[2].attributes('value')).toBe('3')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormSelect/form-select-option.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormSelect/form-select-option.spec.js
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import BFormSelectOption from './BFormSelectOption.vue'
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 
 describe('form-select-option', () => {
+  enableAutoUnmount(afterEach)
+
   it('has expected default structure', () => {
     const wrapper = mount(BFormSelectOption, {
       props: {
@@ -13,8 +15,6 @@ describe('form-select-option', () => {
     expect(wrapper.element.tagName).toBe('OPTION')
     expect(wrapper.attributes('value')).toEqual('foo')
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('renders default slot content', () => {
@@ -30,8 +30,6 @@ describe('form-select-option', () => {
     expect(wrapper.element.tagName).toBe('OPTION')
     expect(wrapper.attributes('value')).toEqual('foo')
     expect(wrapper.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 
   it('renders HTML as default slot content', () => {
@@ -49,8 +47,6 @@ describe('form-select-option', () => {
 
     const $bold = wrapper.get('b')
     expect($bold.text()).toEqual('Bold')
-
-    wrapper.unmount()
   })
 
   it('has disabled attribute applied when disabled=true', () => {
@@ -65,7 +61,5 @@ describe('form-select-option', () => {
     expect(wrapper.attributes('value')).toEqual('foo')
     expect(wrapper.attributes('disabled')).toBeDefined()
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormSelect/form-select.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormSelect/form-select.spec.js
@@ -1,10 +1,12 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {createContainer, waitRAF} from '../../../tests/utils'
 import {h, nextTick} from 'vue'
 import BFormSelect from './BFormSelect.vue'
 import {afterAll, afterEach, beforeEach, describe, expect, it, vitest} from 'vitest'
 
 describe('form-select', () => {
+  enableAutoUnmount(afterEach)
+
   afterAll(() => {
     console.warn.mockClear()
   })
@@ -13,8 +15,6 @@ describe('form-select', () => {
     const wrapper = mount(BFormSelect)
 
     expect(wrapper.element.tagName).toBe('SELECT')
-
-    wrapper.unmount()
   })
 
   it('has class form-select', () => {
@@ -22,23 +22,17 @@ describe('form-select', () => {
 
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(1)
-
-    wrapper.unmount()
   })
 
   it('does not have attr multiple by default', () => {
     const wrapper = mount(BFormSelect)
 
     expect(wrapper.attributes('multiple')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not have attr required by default', () => {
     const wrapper = mount(BFormSelect)
     expect(wrapper.attributes('required')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has attr required when required=true', () => {
@@ -49,16 +43,12 @@ describe('form-select', () => {
     })
 
     expect(wrapper.attributes('required')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('does not have attr form by default', () => {
     const wrapper = mount(BFormSelect)
 
     expect(wrapper.attributes('form')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has attr form when form is set', () => {
@@ -70,8 +60,6 @@ describe('form-select', () => {
 
     expect(wrapper.attributes('form')).toBeDefined()
     expect(wrapper.attributes('form')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has attr multiple when multiple=true', () => {
@@ -83,8 +71,6 @@ describe('form-select', () => {
     })
 
     expect(wrapper.attributes('multiple')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has attr size when select-size is set', () => {
@@ -97,8 +83,6 @@ describe('form-select', () => {
     expect(wrapper.attributes('size')).toBeDefined()
     expect(wrapper.attributes('size')).toBe('4')
     expect(wrapper.attributes('multiple')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has auto ID attr by default', async () => {
@@ -107,8 +91,6 @@ describe('form-select', () => {
     await nextTick()
 
     expect(wrapper.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has user supplied ID attr when id is set', () => {
@@ -120,16 +102,12 @@ describe('form-select', () => {
 
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('does not have attr size by default', () => {
     const wrapper = mount(BFormSelect)
 
     expect(wrapper.attributes('size')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does have attr size when plain=true', () => {
@@ -141,8 +119,6 @@ describe('form-select', () => {
 
     expect(wrapper.attributes('size')).toBeDefined()
     expect(wrapper.attributes('size')).toBe('0')
-
-    wrapper.unmount()
   })
 
   it('has class form-select-sm when size=sm and plain=false', () => {
@@ -155,8 +131,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-select-sm')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has class form-select-lg when size=lg and plain=false', () => {
@@ -169,8 +143,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-select-lg')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has class form-select-foo when size=foo and plain=false', () => {
@@ -183,8 +155,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-select-foo')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has class is-invalid and attr aria-invalid="true" when state=false', () => {
@@ -198,8 +168,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('is-invalid')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has class is-valid when state=true', () => {
@@ -213,8 +181,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('is-valid')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has attr aria-invalid="true" when aria-invalid="true"', () => {
@@ -227,8 +193,6 @@ describe('form-select', () => {
     expect(wrapper.attributes('aria-invalid')).toBe('true')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(1)
-
-    wrapper.unmount()
   })
 
   it('has attr aria-invalid="true" when aria-invalid=true', () => {
@@ -241,8 +205,6 @@ describe('form-select', () => {
     expect(wrapper.attributes('aria-invalid')).toBe('true')
     expect(wrapper.classes()).toContain('form-select')
     expect(wrapper.classes().length).toBe(1)
-
-    wrapper.unmount()
   })
 
   it('has class form-control when plain=true', () => {
@@ -255,8 +217,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-control')
     expect(wrapper.classes().length).toBe(1)
     expect(wrapper.element.tagName).toBe('SELECT')
-
-    wrapper.unmount()
   })
 
   it('has class form-control-lg when size=lg and plain=true', () => {
@@ -270,8 +230,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-control-lg')
     expect(wrapper.classes()).toContain('form-control')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has class form-control-sm when size=sm and plain=true', () => {
@@ -285,8 +243,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-control-sm')
     expect(wrapper.classes()).toContain('form-control')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has class form-control-foo when size=foo and plain=true', () => {
@@ -300,8 +256,6 @@ describe('form-select', () => {
     expect(wrapper.classes()).toContain('form-control-foo')
     expect(wrapper.classes()).toContain('form-control')
     expect(wrapper.classes().length).toBe(2)
-
-    wrapper.unmount()
   })
 
   it('has option elements from simple options array', () => {
@@ -319,8 +273,6 @@ describe('form-select', () => {
     $options.forEach(($option) => {
       expect($option.attributes('disabled')).toBeUndefined()
     })
-
-    wrapper.unmount()
   })
 
   it('has option elements from options array of objects', () => {
@@ -345,8 +297,6 @@ describe('form-select', () => {
     expect($options[0].attributes('disabled')).toBeUndefined()
     expect($options[1].attributes('disabled')).toBeDefined()
     expect($options[2].attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has option elements from options array of objects with custom field names', () => {
@@ -381,8 +331,6 @@ describe('form-select', () => {
     expect($options[0].attributes('disabled')).toBeUndefined()
     expect($options[1].attributes('disabled')).toBeUndefined()
     expect($options[2].attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has option group elements with options from options array of objects', () => {
@@ -428,8 +376,6 @@ describe('form-select', () => {
     expect($options[1].attributes('disabled')).toBeUndefined()
     expect($options[2].attributes('disabled')).toBeUndefined()
     expect($options[3].attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has option group and option elements from options array of objects', () => {
@@ -468,8 +414,6 @@ describe('form-select', () => {
     expect($options[1].attributes('disabled')).toBeUndefined()
     expect($options[2].attributes('disabled')).toBeUndefined()
     expect($options[3].attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has option elements from options legacy object format', () => {
@@ -492,8 +436,6 @@ describe('form-select', () => {
     expect(spyWarn).toHaveBeenLastCalledWith(
       '[BootstrapVue warn]: BFormSelect - Setting prop "options" to an object is deprecated. Use the array format instead.'
     )
-
-    wrapper.unmount()
   })
 
   it('has option elements from default slot', () => {
@@ -515,8 +457,6 @@ describe('form-select', () => {
     expect($options[0].attributes('value')).toBe('1')
     expect($options[1].attributes('value')).toBe('2')
     expect($options[2].attributes('value')).toBe('3')
-
-    wrapper.unmount()
   })
 
   it('displays option text when value not set', () => {
@@ -529,8 +469,6 @@ describe('form-select', () => {
     const $options = wrapper.findAll('option')
     expect($options.length).toBe(1)
     expect($options[0].text()).toBe('one')
-
-    wrapper.unmount()
   })
 
   it('updates v-model when option selected in single mode', async () => {
@@ -554,8 +492,6 @@ describe('form-select', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('update:modelValue')[0][0]).toBe('three')
     expect(wrapper.emitted('change')[0][0]).toBe('three')
-
-    wrapper.unmount()
   })
 
   it('updating v-model (value) when selects correct option', async () => {
@@ -577,8 +513,6 @@ describe('form-select', () => {
     // Select 3rd option
     await wrapper.setProps({modelValue: {three: 3}})
     expect($options[2].element.selected).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('updates v-model when option selected in single mode with complex values', async () => {
@@ -606,8 +540,6 @@ describe('form-select', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('update:modelValue')[0][0]).toEqual({c: 3})
     expect(wrapper.emitted('change')[0][0]).toEqual({c: 3})
-
-    wrapper.unmount()
   })
 
   it('updates v-model when option selected in multiple mode', async () => {
@@ -634,8 +566,6 @@ describe('form-select', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('update:modelValue')[0][0]).toEqual(['two', 'three'])
     expect(wrapper.emitted('change')[0][0]).toEqual(['two', 'three'])
-
-    wrapper.unmount()
   })
 
   it('updates v-model when option selected in multiple mode with complex values', async () => {
@@ -666,8 +596,6 @@ describe('form-select', () => {
     expect(wrapper.emitted('change')).toBeDefined()
     expect(wrapper.emitted('update:modelValue')[0][0]).toEqual([{b: 2}, {c: 3}])
     expect(wrapper.emitted('change')[0][0]).toEqual([{b: 2}, {c: 3}])
-
-    wrapper.unmount()
   })
 
   // These tests are wrapped in a new describe to limit the scope of the getBCR Mock
@@ -709,8 +637,6 @@ describe('form-select', () => {
       expect(input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).toBe(input.element)
-
-      wrapper.unmount()
     })
 
     it('does not autofocus when false', async () => {
@@ -730,8 +656,6 @@ describe('form-select', () => {
       expect(input.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).not.toBe(input.element)
-
-      wrapper.unmount()
     })
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormTags/form-tag.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BFormTags/form-tag.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import BFormTag from './BFormTag.vue'
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 
 describe('form-tag', () => {
+  enableAutoUnmount(afterEach)
+
   it('has expected structure', () => {
     const wrapper = mount(BFormTag, {
       props: {
@@ -20,8 +22,6 @@ describe('form-tag', () => {
     expect($button.exists()).toBe(true)
     expect($button.classes()).toContain('b-form-tag-remove')
     expect($button.attributes('aria-label')).toBe('Remove tag')
-
-    wrapper.unmount()
   })
 
   it('renders custom root element', () => {
@@ -39,8 +39,6 @@ describe('form-tag', () => {
     expect(wrapper.text()).toContain('foobar')
 
     expect(wrapper.find('button').exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -59,8 +57,6 @@ describe('form-tag', () => {
     expect(wrapper.text()).not.toContain('foo')
 
     expect(wrapper.find('button').exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('has pill styles when `pill` prop set', () => {
@@ -79,8 +75,6 @@ describe('form-tag', () => {
     expect(wrapper.text()).toContain('foo')
 
     expect(wrapper.find('button').exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('has custom variant when `variant` prop set', () => {
@@ -99,8 +93,6 @@ describe('form-tag', () => {
     expect(wrapper.text()).toContain('foo')
 
     expect(wrapper.find('button').exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('emits "remove" event when button clicked', async () => {
@@ -122,8 +114,6 @@ describe('form-tag', () => {
     await $button.trigger('click')
     expect(wrapper.emitted('remove')).toBeDefined()
     expect(wrapper.emitted('remove')?.length).toBe(1)
-
-    wrapper.unmount()
   })
 
   it('does not have remove button when `disabled` prop is set', () => {
@@ -140,8 +130,6 @@ describe('form-tag', () => {
     expect(wrapper.text()).toContain('foobar')
 
     expect(wrapper.find('button').exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('does not have remove button when `no-remove` prop is set', () => {
@@ -157,7 +145,5 @@ describe('form-tag', () => {
     expect(wrapper.text()).toContain('foobar')
 
     expect(wrapper.find('button').exists()).toBe(false)
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BFormTextarea/form-textarea.spec.js
+++ b/packages/bootstrap-vue-3/src/components/BFormTextarea/form-textarea.spec.js
@@ -1,17 +1,17 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {createContainer, waitRAF} from '../../../tests/utils'
 import {nextTick} from 'vue'
 import BFormTextarea from './BFormTextarea.vue'
 import {afterEach, beforeEach, describe, expect, it, vitest} from 'vitest'
 
 describe('form-textarea', () => {
+  enableAutoUnmount(afterEach)
+
   it('has class form-control', () => {
     const wrapper = mount(BFormTextarea)
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control')
-
-    wrapper.unmount()
   })
 
   it('has class form-control-lg when size=lg and plane=false', () => {
@@ -23,8 +23,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-lg')
-
-    wrapper.unmount()
   })
 
   it('has class form-control-sm when size=lg and plain=false', () => {
@@ -36,8 +34,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-sm')
-
-    wrapper.unmount()
   })
 
   it('does not have class form-control-plaintext when plaintext not set', () => {
@@ -46,8 +42,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).not.toContain('form-control-plaintext')
     expect($textarea.attributes('readonly')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has class form-control-plaintext when plaintext=true', () => {
@@ -59,8 +53,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-plaintext')
-
-    wrapper.unmount()
   })
 
   it('has attribute read-only when plaintext=true', () => {
@@ -73,8 +65,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('form-control-plaintext')
     expect($textarea.attributes('readonly')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has user supplied id', () => {
@@ -86,8 +76,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('id')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has safeId after mount when no id provided', async () => {
@@ -100,8 +88,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has form attribute when form prop set', () => {
@@ -113,8 +99,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('form')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('does not have is-valid or is-invalid classes when state is default', () => {
@@ -123,8 +107,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).not.toContain('is-valid')
     expect($textarea.classes()).not.toContain('is-invalid')
-
-    wrapper.unmount()
   })
 
   it('has class is-valid when state=true', () => {
@@ -137,8 +119,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('is-valid')
     expect($textarea.classes()).not.toContain('is-invalid')
-
-    wrapper.unmount()
   })
 
   it('has class is-invalid when state=false', () => {
@@ -151,16 +131,12 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.classes()).toContain('is-invalid')
     expect($textarea.classes()).not.toContain('is-valid')
-
-    wrapper.unmount()
   })
 
   it('does not have aria-invalid attribute by default', () => {
     const wrapper = mount(BFormTextarea)
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not have aria-invalid attribute when state is true', () => {
@@ -171,8 +147,6 @@ describe('form-textarea', () => {
     })
 
     expect(wrapper.attributes('aria-invalid')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when state=false', () => {
@@ -184,8 +158,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when aria-invalid="true"', () => {
@@ -197,8 +169,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when aria-invalid=true', () => {
@@ -210,8 +180,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('has aria-invalid attribute when aria-invalid="spelling"', () => {
@@ -223,8 +191,6 @@ describe('form-textarea', () => {
 
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('aria-invalid')).toBe('spelling')
-
-    wrapper.unmount()
   })
 
   it('has user supplied rows', () => {
@@ -237,8 +203,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('rows')).toBeDefined()
     expect($textarea.element.rows).toBe(8)
-
-    wrapper.unmount()
   })
 
   it('is disabled when disabled=true', () => {
@@ -251,8 +215,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('disabled')).toBeDefined()
     expect($textarea.element.disabled).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('is not disabled when disabled=false', () => {
@@ -265,8 +227,6 @@ describe('form-textarea', () => {
     const $textarea = wrapper.get('textarea')
     expect($textarea.attributes('disabled')).toBeUndefined()
     expect($textarea.element.disabled).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('emits an input event', async () => {
@@ -279,8 +239,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input')[0].length).toEqual(1)
     expect(wrapper.emitted('input')[0][0]).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('emits a native focus event', async () => {
@@ -296,8 +254,6 @@ describe('form-textarea', () => {
 
     expect(wrapper.emitted()).toMatchObject({})
     expect(spy).toHaveBeenCalled()
-
-    wrapper.unmount()
   })
 
   it('emits a blur event with native event as only arg', async () => {
@@ -314,8 +270,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('blur')[0].length).toEqual(1)
     expect(wrapper.emitted('blur')[0][0] instanceof Event).toBe(true)
     expect(wrapper.emitted('blur')[0][0].type).toEqual('blur')
-
-    wrapper.unmount()
   })
 
   it('applies formatter on textarea when not lazy', async () => {
@@ -339,8 +293,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('input')).toBeDefined()
     expect(wrapper.emitted('input').length).toEqual(1)
     expect(wrapper.emitted('input')[0][0]).toEqual('test')
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter on textarea when lazy', async () => {
@@ -369,8 +321,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('input').length).toEqual(1)
     expect(wrapper.emitted('input')[0][0]).toEqual('TEST')
     expect(wrapper.emitted('change')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('applies formatter on blur when lazy', async () => {
@@ -409,8 +359,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeDefined()
     expect(wrapper.emitted('blur').length).toEqual(1)
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter when value supplied on mount and not lazy', () => {
@@ -429,8 +377,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('input')).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter when value prop updated and not lazy', async () => {
@@ -452,8 +398,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('input')).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not apply formatter when value prop updated and lazy', async () => {
@@ -476,8 +420,6 @@ describe('form-textarea', () => {
     expect(wrapper.emitted('input')).toBeUndefined()
     expect(wrapper.emitted('change')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('does not update value when non-lazy formatter returns false', async () => {
@@ -506,8 +448,6 @@ describe('form-textarea', () => {
     expect(wrapper.vm.modelValue).toBe('abc')
     // Value in input should remain the same as entered
     expect($textarea.element.value).toEqual('TEST')
-
-    wrapper.unmount()
   })
 
   /* TODO: implement noWheel
@@ -535,7 +475,7 @@ describe('form-textarea', () => {
     // `:no-wheel="true"` will fire a blur event on the input when wheel fired
     expect(spy).toHaveBeenCalled()
 
-    wrapper.unmount()
+    
   })
 
 
@@ -565,7 +505,7 @@ describe('form-textarea', () => {
     // `:no-wheel="false"` will not fire a blur event on the input when wheel fired
     expect(spy).not.toHaveBeenCalled()
 
-    wrapper.unmount()
+    
   })
 
 
@@ -607,7 +547,7 @@ describe('form-textarea', () => {
     expect(document.activeElement).not.toBe(wrapper.element)
     expect(spy).toHaveBeenCalled()
 
-    wrapper.unmount()
+    
   })
   */
 
@@ -661,8 +601,6 @@ describe('form-textarea', () => {
     // `v-model` update event should have emitted
     expect(wrapper.emitted('update:modelValue').length).toEqual(2)
     expect(wrapper.emitted('update:modelValue')[1][0]).toBe('abcd')
-
-    wrapper.unmount()
   })
 
   /* TODO: implement debounce
@@ -763,7 +701,7 @@ describe('form-textarea', () => {
     // `input` event should not have emitted new event
     expect(wrapper.emitted('input').length).toBe(6)
 
-    wrapper.unmount()
+    
   })
   */
 
@@ -782,8 +720,6 @@ describe('form-textarea', () => {
     expect(document.activeElement).toBe($textarea.element)
     wrapper.vm.blur()
     expect(document.activeElement).not.toBe($textarea.element)
-
-    wrapper.unmount()
   })
 
   // These tests are wrapped in a new describe to limit the scope of the getBCR Mock
@@ -823,8 +759,6 @@ describe('form-textarea', () => {
       expect($textarea.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).toBe($textarea.element)
-
-      wrapper.unmount()
     })
 
     it('does not autofocus when false', async () => {
@@ -843,8 +777,6 @@ describe('form-textarea', () => {
       expect($textarea.exists()).toBe(true)
       expect(document).toBeDefined()
       expect(document.activeElement).not.toBe($textarea.element)
-
-      wrapper.unmount()
     })
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BLink/link.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BLink/link.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import BLink from './BLink.vue'
-import {describe, expect, it, vitest} from 'vitest'
+import {afterEach, describe, expect, it, vitest} from 'vitest'
 
 describe('link', () => {
+  enableAutoUnmount(afterEach)
+
   it('has expected default structure', () => {
     const wrapper = mount(BLink)
 
@@ -13,8 +15,6 @@ describe('link', () => {
     expect(wrapper.attributes('aria-disabled')).toBeUndefined()
     expect(wrapper.classes().length).toBe(0)
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('renders content from default slot', () => {
@@ -31,8 +31,6 @@ describe('link', () => {
     expect(wrapper.attributes('aria-disabled')).toBeUndefined()
     expect(wrapper.classes().length).toBe(0)
     expect(wrapper.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 
   it('sets attribute href to user supplied value', () => {
@@ -49,8 +47,6 @@ describe('link', () => {
     expect(wrapper.attributes('aria-disabled')).toBeUndefined()
     expect(wrapper.classes().length).toBe(0)
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('sets attribute href when user supplied href is hash target', () => {
@@ -67,8 +63,6 @@ describe('link', () => {
     expect(wrapper.attributes('aria-disabled')).toBeUndefined()
     expect(wrapper.classes().length).toBe(0)
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('should set href to string `to` prop', () => {
@@ -85,8 +79,6 @@ describe('link', () => {
     expect(wrapper.attributes('aria-disabled')).toBeUndefined()
     expect(wrapper.classes().length).toBe(0)
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('should set href to path from `to` prop', () => {
@@ -103,8 +95,6 @@ describe('link', () => {
     expect(wrapper.attributes('aria-disabled')).toBeUndefined()
     expect(wrapper.classes().length).toBe(0)
     expect(wrapper.text()).toEqual('')
-
-    wrapper.unmount()
   })
 
   it('should default rel to `noopener` when target==="_blank"', () => {
@@ -120,8 +110,6 @@ describe('link', () => {
     expect(wrapper.attributes('target')).toEqual('_blank')
     expect(wrapper.attributes('rel')).toEqual('noopener')
     expect(wrapper.classes().length).toBe(0)
-
-    wrapper.unmount()
   })
 
   it('should render the given rel to when target==="_blank"', () => {
@@ -138,8 +126,6 @@ describe('link', () => {
     expect(wrapper.attributes('target')).toEqual('_blank')
     expect(wrapper.attributes('rel')).toEqual('alternate')
     expect(wrapper.classes().length).toBe(0)
-
-    wrapper.unmount()
   })
 
   it('should add "active" class when prop active=true', () => {
@@ -152,8 +138,6 @@ describe('link', () => {
     expect(wrapper.element.tagName).toBe('A')
     expect(wrapper.classes()).toContain('active')
     expect(wrapper.classes().length).toBe(1)
-
-    wrapper.unmount()
   })
 
   it('should add aria-disabled="true" when disabled', () => {
@@ -165,8 +149,6 @@ describe('link', () => {
 
     expect(wrapper.attributes('aria-disabled')).toBeDefined()
     expect(wrapper.attributes('aria-disabled')).toEqual('true')
-
-    wrapper.unmount()
   })
 
   it("should add '.disabled' class when prop disabled=true", () => {
@@ -177,8 +159,6 @@ describe('link', () => {
     })
 
     expect(wrapper.classes()).toContain('disabled')
-
-    wrapper.unmount()
   })
 
   describe('click handling', () => {
@@ -201,8 +181,6 @@ describe('link', () => {
       await wrapper.get('a').trigger('click')
       expect(called).toBe(1)
       expect(evt).toBeInstanceOf(MouseEvent)
-
-      wrapper.unmount()
     })
 
     it('should invoke multiple click handlers bound by Vue when clicked on', async () => {
@@ -221,8 +199,6 @@ describe('link', () => {
       await wrapper.get('a').trigger('click')
       expect(spy1).toHaveBeenCalled()
       expect(spy2).toHaveBeenCalled()
-
-      wrapper.unmount()
     })
 
     it('should NOT invoke click handler bound by Vue when disabled and clicked', async () => {
@@ -247,8 +223,6 @@ describe('link', () => {
       await wrapper.get('a').trigger('click')
       expect(called).toBe(0)
       expect(evt).toEqual(null)
-
-      wrapper.unmount()
     })
 
     it('should NOT invoke click handler bound via "addEventListener" when disabled and clicked', async () => {
@@ -264,8 +238,6 @@ describe('link', () => {
 
       await wrapper.get('a').trigger('click')
       expect(spy).not.toHaveBeenCalled()
-
-      wrapper.unmount()
     })
   })
 
@@ -347,7 +319,7 @@ describe('link', () => {
       expect($links[4].exists()).toBe(true)
       expect($links[4].findComponent(GLink).exists()).toBe(true)
 
-      wrapper.unmount()
+      
     })
   })
   */

--- a/packages/bootstrap-vue-3/src/components/BListGroup/list-group-item.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BListGroup/list-group-item.spec.ts
@@ -1,15 +1,15 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import BListGroup from './BListGroup.vue'
 import BListGroupItem from './BListGroupItem.vue'
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 
 describe('list-group > list-group-item', () => {
+  enableAutoUnmount(afterEach)
+
   it('default should have tag div', () => {
     const wrapper = mount(BListGroupItem)
 
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('default should contain only single class of list-group-item', () => {
@@ -17,48 +17,36 @@ describe('list-group > list-group-item', () => {
 
     expect(wrapper.classes().length).toBe(1)
     expect(wrapper.classes()).toContain('list-group-item')
-
-    wrapper.unmount()
   })
 
   it('default should not have class list-group-item-action', () => {
     const wrapper = mount(BListGroupItem)
 
     expect(wrapper.classes()).not.toContain('list-group-item-action')
-
-    wrapper.unmount()
   })
 
   it('default should not have class active', () => {
     const wrapper = mount(BListGroupItem)
 
     expect(wrapper.classes()).not.toContain('active')
-
-    wrapper.unmount()
   })
 
   it('default should not have class disabled', () => {
     const wrapper = mount(BListGroupItem)
 
     expect(wrapper.classes()).not.toContain('disabled')
-
-    wrapper.unmount()
   })
 
   it('default should not have type attribute', () => {
     const wrapper = mount(BListGroupItem)
 
     expect(wrapper.attributes('type')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('default should not have disabled attribute', () => {
     const wrapper = mount(BListGroupItem)
 
     expect(wrapper.attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('should have disabled class when disabled=true', () => {
@@ -67,8 +55,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.classes()).toContain('disabled')
-
-    wrapper.unmount()
   })
 
   it('should have active class when active=true', () => {
@@ -77,8 +63,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.classes()).toContain('active')
-
-    wrapper.unmount()
   })
 
   it('should have variant class and base class when variant set', () => {
@@ -88,8 +72,6 @@ describe('list-group > list-group-item', () => {
 
     expect(wrapper.classes()).toContain('list-group-item')
     expect(wrapper.classes()).toContain('list-group-item-danger')
-
-    wrapper.unmount()
   })
 
   it('should have tag a when href is set', () => {
@@ -98,8 +80,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.element.tagName).toBe('A')
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-item-action when href is set', () => {
@@ -108,8 +88,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.classes()).toContain('list-group-item-action')
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-item-action when action=true', () => {
@@ -118,8 +96,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.classes()).toContain('list-group-item-action')
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-item-action when tag=a', () => {
@@ -128,8 +104,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.classes()).toContain('list-group-item-action')
-
-    wrapper.unmount()
   })
 
   it('should have href attribute when href is set', () => {
@@ -138,8 +112,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.attributes('href')).toBe('/foobar')
-
-    wrapper.unmount()
   })
 
   it('should have tag button when tag=button', () => {
@@ -148,8 +120,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.element.tagName).toBe('BUTTON')
-
-    wrapper.unmount()
   })
 
   it('should have tag a when tag=a', () => {
@@ -165,8 +135,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.element.tagName).toBe('BUTTON')
-
-    wrapper.unmount()
   })
 
   it('should have tag button when button=true and tag=foo', () => {
@@ -178,8 +146,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.element.tagName).toBe('BUTTON')
-
-    wrapper.unmount()
   })
 
   it('should not have href when button=true and href set', () => {
@@ -192,8 +158,6 @@ describe('list-group > list-group-item', () => {
 
     expect(wrapper.element.tagName).toBe('BUTTON')
     expect(wrapper.attributes('href')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-item-action when button=true', () => {
@@ -202,8 +166,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.classes()).toContain('list-group-item-action')
-
-    wrapper.unmount()
   })
 
   it('should have type=button when button=true', () => {
@@ -212,8 +174,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.attributes('type')).toEqual('button')
-
-    wrapper.unmount()
   })
 
   it('should have type=submit when button=true and attr type=submit', () => {
@@ -223,8 +183,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.attributes('type')).toEqual('submit')
-
-    wrapper.unmount()
   })
 
   it('should not have attribute disabled when button=true and disabled not set', () => {
@@ -233,8 +191,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('should have attribute disabled when button=true and disabled=true', () => {
@@ -246,8 +202,6 @@ describe('list-group > list-group-item', () => {
     })
 
     expect(wrapper.attributes('disabled')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('should have tag li when used within b-list-group with mounted=true', () => {
@@ -256,7 +210,5 @@ describe('list-group > list-group-item', () => {
     const $listItem = wrapper.findComponent(BListGroupItem)
     expect($listItem).toBeDefined()
     expect($listItem.element.tagName).toBe('LI')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BListGroup/list-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BListGroup/list-group.spec.ts
@@ -1,14 +1,14 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import BListGroup from './BListGroup.vue'
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 
 describe('list-group', () => {
+  enableAutoUnmount(afterEach)
+
   it('default should have tag div', () => {
     const wrapper = mount(BListGroup)
 
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('default should contain only single class of list-group', () => {
@@ -18,8 +18,6 @@ describe('list-group', () => {
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).not.toContain('list-group-flush')
     expect(wrapper.classes()).not.toContain('list-group-horizontal')
-
-    wrapper.unmount()
   })
 
   it('should have tag ul then prop tag=ul', () => {
@@ -28,8 +26,6 @@ describe('list-group', () => {
     })
 
     expect(wrapper.element.tagName).toBe('UL')
-
-    wrapper.unmount()
   })
 
   it('should have tag ol then prop numbered=true', () => {
@@ -38,8 +34,6 @@ describe('list-group', () => {
     })
 
     expect(wrapper.element.tagName).toBe('OL')
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-flush when prop flush=true', () => {
@@ -51,8 +45,6 @@ describe('list-group', () => {
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).toContain('list-group-flush')
     expect(wrapper.classes()).not.toContain('list-group-horizontal')
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-horizontal when prop horizontal=true', () => {
@@ -64,8 +56,6 @@ describe('list-group', () => {
     expect(wrapper.classes()).not.toContain('list-group-flush')
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).toContain('list-group-horizontal')
-
-    wrapper.unmount()
   })
 
   it('should have class list-group-horizontal-md when prop horizontal=md', () => {
@@ -78,8 +68,6 @@ describe('list-group', () => {
     expect(wrapper.classes()).not.toContain('list-group-horizontal')
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).toContain('list-group-horizontal-md')
-
-    wrapper.unmount()
   })
 
   it('should not have class list-group-horizontal when prop horizontal=true and flush=true', () => {
@@ -94,8 +82,6 @@ describe('list-group', () => {
     expect(wrapper.classes()).not.toContain('list-group-horizontal')
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).toContain('list-group-flush')
-
-    wrapper.unmount()
   })
 
   it('should not have class list-group-horizontal-lg when prop horizontal=lg and flush=true', () => {
@@ -111,8 +97,6 @@ describe('list-group', () => {
     expect(wrapper.classes()).not.toContain('list-group-horizontal')
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).toContain('list-group-flush')
-
-    wrapper.unmount()
   })
 
   it('should accept custom classes', () => {
@@ -125,7 +109,5 @@ describe('list-group', () => {
     expect(wrapper.classes().length).toBe(2)
     expect(wrapper.classes()).toContain('list-group')
     expect(wrapper.classes()).toContain('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNav/nav-form.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNav/nav-form.spec.ts
@@ -1,14 +1,14 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavForm from './BNavForm.vue'
 import BForm from '../BForm/BForm.vue'
 
 describe('nav-form', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains static class d-flex', () => {
     const wrapper = mount(BNavForm)
     expect(wrapper.classes()).toContain('d-flex')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -16,16 +16,12 @@ describe('nav-form', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('contains bform', () => {
     const wrapper = mount(BNavForm)
     const $bform = wrapper.findComponent(BForm)
     expect($bform.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('bform to have prop floating when prop floating', () => {
@@ -34,8 +30,6 @@ describe('nav-form', () => {
     })
     const $bform = wrapper.findComponent(BForm)
     expect($bform.props('floating')).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('bform to have attribute role when prop role', () => {
@@ -44,8 +38,6 @@ describe('nav-form', () => {
     })
     const $bform = wrapper.findComponent(BForm)
     expect($bform.attributes('role')).toBe('abc')
-
-    wrapper.unmount()
   })
 
   it('bform to have prop id when prop id', () => {
@@ -54,8 +46,6 @@ describe('nav-form', () => {
     })
     const $bform = wrapper.findComponent(BForm)
     expect($bform.props('id')).toBe('abc')
-
-    wrapper.unmount()
   })
 
   it('bform to have prop novalidate when prop novalidate', () => {
@@ -64,8 +54,6 @@ describe('nav-form', () => {
     })
     const $bform = wrapper.findComponent(BForm)
     expect($bform.props('novalidate')).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('bform to have prop validated when prop validated', () => {
@@ -74,7 +62,5 @@ describe('nav-form', () => {
     })
     const $bform = wrapper.findComponent(BForm)
     expect($bform.props('validated')).toBe(true)
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNav/nav-item-dropdown.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNav/nav-item-dropdown.spec.ts
@@ -1,29 +1,25 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavItemDropdown from './BNavItemDropdown.vue'
 import BDropdown from '../BDropdown/BDropdown.vue'
 
 describe('nav-item-dropdown', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class nav-item', () => {
     const wrapper = mount(BNavItemDropdown)
     expect(wrapper.classes()).toContain('nav-item')
-
-    wrapper.unmount()
   })
 
   it('has static class dropdown', () => {
     const wrapper = mount(BNavItemDropdown)
     expect(wrapper.classes()).toContain('dropdown')
-
-    wrapper.unmount()
   })
 
   it('contains b-dropdown', () => {
     const wrapper = mount(BNavItemDropdown)
     const $bdropdown = wrapper.findComponent(BDropdown)
     expect($bdropdown.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   // There are more tests here, but the component seems broken

--- a/packages/bootstrap-vue-3/src/components/BNav/nav-item.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNav/nav-item.spec.ts
@@ -1,30 +1,26 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavItem from './BNavItem.vue'
 import BLink from '../BLink/BLink.vue'
 
 describe('nav-item', () => {
+  enableAutoUnmount(afterEach)
+
   it('has class nav item', () => {
     const wrapper = mount(BNavItem)
     expect(wrapper.classes()).toContain('nav-item')
-
-    wrapper.unmount()
   })
 
   it('contains blink', () => {
     const wrapper = mount(BNavItem)
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('blink has nav-link class', () => {
     const wrapper = mount(BNavItem)
     const $blink = wrapper.findComponent(BLink)
     expect($blink.classes()).toContain('nav-link')
-
-    wrapper.unmount()
   })
 
   it('blink has tabindex -1 when prop disabled', () => {
@@ -35,8 +31,6 @@ describe('nav-item', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.attributes('tabindex')).toBe('-1')
-
-    wrapper.unmount()
   })
 
   it('blink has tabindex undefined when prop disabled is false', () => {
@@ -47,8 +41,6 @@ describe('nav-item', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.attributes('tabindex')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('blink has aria disabled true when prop disabled', () => {
@@ -59,8 +51,6 @@ describe('nav-item', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.attributes('aria-disabled')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('blink has aria disabled undefined when prop disabled', () => {
@@ -71,8 +61,6 @@ describe('nav-item', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.attributes('aria-disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('renders content from default slot', () => {
@@ -82,7 +70,5 @@ describe('nav-item', () => {
       },
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNav/nav-text.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNav/nav-text.spec.ts
@@ -1,13 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavText from './BNavText.vue'
 
 describe('nav-text', () => {
+  enableAutoUnmount(afterEach)
+
   it('has class navbar-text', () => {
     const wrapper = mount(BNavText)
     expect(wrapper.classes()).toContain('navbar-text')
-
-    wrapper.unmount()
   })
 
   it('is tag li', () => {
@@ -22,7 +22,5 @@ describe('nav-text', () => {
       },
     })
     expect(wrapper.text()).toEqual('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNav/nav.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNav/nav.spec.ts
@@ -1,13 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNav from './BNav.vue'
 
 describe('nav', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains static class nav', () => {
     const wrapper = mount(BNav)
     expect(wrapper.classes()).toContain('nav')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -20,8 +20,6 @@ describe('nav', () => {
   it('is tag ul by default', () => {
     const wrapper = mount(BNav)
     expect(wrapper.element.tagName).toBe('UL')
-
-    wrapper.unmount()
   })
 
   it('changes tag when prop tag is set', () => {
@@ -29,8 +27,6 @@ describe('nav', () => {
       props: {tag: 'div'},
     })
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('has class nav-tabs when prop tabs is set', async () => {
@@ -40,8 +36,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-tabs')
     await wrapper.setProps({tabs: false})
     expect(wrapper.classes()).not.toContain('nav-tabs')
-
-    wrapper.unmount()
   })
 
   it('has class nav-pills when prop tabs is set', async () => {
@@ -51,8 +45,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-pills')
     await wrapper.setProps({pills: false})
     expect(wrapper.classes()).not.toContain('nav-pills')
-
-    wrapper.unmount()
   })
 
   it('does not have class nav-pills when prop pills is set, but prop tabs is true', async () => {
@@ -62,8 +54,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-pills')
     await wrapper.setProps({tabs: true})
     expect(wrapper.classes()).not.toContain('nav-pills')
-
-    wrapper.unmount()
   })
 
   it('has class card-header-tabs when prop tabs is set and cardHeader is set', () => {
@@ -71,8 +61,6 @@ describe('nav', () => {
       props: {tabs: true, cardHeader: true},
     })
     expect(wrapper.classes()).toContain('card-header-tabs')
-
-    wrapper.unmount()
   })
 
   it('does not have class card-header-tabs when prop tabs is set and cardHeader is set, but prop vertical is set', async () => {
@@ -82,8 +70,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('card-header-tabs')
     await wrapper.setProps({vertical: true})
     expect(wrapper.classes()).not.toContain('card-header-tabs')
-
-    wrapper.unmount()
   })
 
   it('has class card-header-pills when prop pills is set and cardHeader is set', () => {
@@ -91,8 +77,6 @@ describe('nav', () => {
       props: {pills: true, cardHeader: true},
     })
     expect(wrapper.classes()).toContain('card-header-pills')
-
-    wrapper.unmount()
   })
 
   it('does not have class card-header-pills when prop pills is set and cardHeader is set, but prop vertical is set', async () => {
@@ -102,8 +86,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('card-header-pills')
     await wrapper.setProps({vertical: true})
     expect(wrapper.classes()).not.toContain('card-header-pills')
-
-    wrapper.unmount()
   })
 
   it('does not have class card-header-pills when prop pills is set and cardHeader is set, but prop tabs is set', async () => {
@@ -113,8 +95,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('card-header-pills')
     await wrapper.setProps({tabs: true})
     expect(wrapper.classes()).not.toContain('card-header-pills')
-
-    wrapper.unmount()
   })
 
   it('has class flex-column when prop vertical is set', async () => {
@@ -124,8 +104,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('flex-column')
     await wrapper.setProps({vertical: false})
     expect(wrapper.classes()).not.toContain('flex-column')
-
-    wrapper.unmount()
   })
 
   it('has class nav-fill when prop fill is set', async () => {
@@ -135,8 +113,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-fill')
     await wrapper.setProps({fill: false})
     expect(wrapper.classes()).not.toContain('nav-fill')
-
-    wrapper.unmount()
   })
 
   it('does not have nav-fill when prop fill is set, but prop vertical is also set', async () => {
@@ -146,8 +122,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-fill')
     await wrapper.setProps({vertical: true})
     expect(wrapper.classes()).not.toContain('nav-fill')
-
-    wrapper.unmount()
   })
 
   it('has class nav-justified when prop justified is set', async () => {
@@ -157,8 +131,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-justified')
     await wrapper.setProps({justified: false})
     expect(wrapper.classes()).not.toContain('nav-justified')
-
-    wrapper.unmount()
   })
 
   it('does not have nav-justified when prop justified is set, but prop vertical is also set', async () => {
@@ -168,8 +140,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('nav-justified')
     await wrapper.setProps({vertical: true})
     expect(wrapper.classes()).not.toContain('nav-justified')
-
-    wrapper.unmount()
   })
 
   it('has class justify-content-{type} when prop align is set', async () => {
@@ -179,8 +149,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('justify-content-start')
     await wrapper.setProps({align: undefined})
     expect(wrapper.classes()).not.toContain('justify-content-start')
-
-    wrapper.unmount()
   })
 
   it('does not have justify-content-{type} when prop align is set, but prop vertical is also set', async () => {
@@ -190,8 +158,6 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('justify-content-start')
     await wrapper.setProps({vertical: true})
     expect(wrapper.classes()).not.toContain('justify-content-start')
-
-    wrapper.unmount()
   })
 
   it('has class small when prop small is set', async () => {
@@ -201,7 +167,5 @@ describe('nav', () => {
     expect(wrapper.classes()).toContain('small')
     await wrapper.setProps({small: false})
     expect(wrapper.classes()).not.toContain('small')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNavbar/navbar-brand.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNavbar/navbar-brand.spec.ts
@@ -1,14 +1,14 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavbarBrand from './BNavbarBrand.vue'
 import BLink from '../BLink/BLink.vue'
 
 describe('navbar-brand', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains static class navbar-brand', () => {
     const wrapper = mount(BNavbarBrand)
     expect(wrapper.classes()).toContain('navbar-brand')
-
-    wrapper.unmount()
   })
 
   it('contains blink when has to prop', () => {
@@ -19,8 +19,6 @@ describe('navbar-brand', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('contains blink when has href prop', () => {
@@ -31,15 +29,11 @@ describe('navbar-brand', () => {
     })
     const $blink = wrapper.findComponent(BLink)
     expect($blink.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('tag is div when not isLink', () => {
     const wrapper = mount(BNavbarBrand)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('tag is prop tag when set', () => {
@@ -49,8 +43,6 @@ describe('navbar-brand', () => {
       },
     })
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('is still BLINK when tag is set, but isLink', () => {
@@ -61,8 +53,6 @@ describe('navbar-brand', () => {
       },
     })
     expect(wrapper.element.tagName).toBe('A')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -72,7 +62,5 @@ describe('navbar-brand', () => {
       },
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNavbar/navbar-nav.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNavbar/navbar-nav.spec.ts
@@ -1,20 +1,18 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavbarNav from './BNavbarNav.vue'
 
 describe('navbar-nav', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class navbar-nav', () => {
     const wrapper = mount(BNavbarNav)
     expect(wrapper.classes()).toContain('navbar-nav')
-
-    wrapper.unmount()
   })
 
   it('is tag ul', () => {
     const wrapper = mount(BNavbarNav)
     expect(wrapper.element.tagName).toBe('UL')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -22,8 +20,6 @@ describe('navbar-nav', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('contains class nav-fill when prop fill set', async () => {
@@ -33,8 +29,6 @@ describe('navbar-nav', () => {
     expect(wrapper.classes()).toContain('nav-fill')
     await wrapper.setProps({fill: false})
     expect(wrapper.classes()).not.toContain('nav-fill')
-
-    wrapper.unmount()
   })
 
   it('contains class nav-justified when prop justified set', async () => {
@@ -44,8 +38,6 @@ describe('navbar-nav', () => {
     expect(wrapper.classes()).toContain('nav-justified')
     await wrapper.setProps({justified: false})
     expect(wrapper.classes()).not.toContain('nav-justified')
-
-    wrapper.unmount()
   })
 
   it('contains class small when prop small set', async () => {
@@ -55,8 +47,6 @@ describe('navbar-nav', () => {
     expect(wrapper.classes()).toContain('small')
     await wrapper.setProps({small: false})
     expect(wrapper.classes()).not.toContain('small')
-
-    wrapper.unmount()
   })
 
   it('contains class justify-content-{type} when prop align set', async () => {
@@ -66,7 +56,5 @@ describe('navbar-nav', () => {
     expect(wrapper.classes()).toContain('justify-content-start')
     await wrapper.setProps({align: undefined})
     expect(wrapper.classes()).not.toContain('justify-content-start')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNavbar/navbar-toggle.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNavbar/navbar-toggle.spec.ts
@@ -1,20 +1,18 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavbarToggle from './BNavbarToggle.vue'
 
 describe('navbar-toggle', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains static class navbar-toggler', () => {
     const wrapper = mount(BNavbarToggle)
     expect(wrapper.classes()).toContain('navbar-toggler')
-
-    wrapper.unmount()
   })
 
   it('tag is button', () => {
     const wrapper = mount(BNavbarToggle)
     expect(wrapper.element.tagName).toBe('BUTTON')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -22,8 +20,6 @@ describe('navbar-toggle', () => {
     expect(wrapper.text()).toBe('')
     const $span = wrapper.get('span')
     expect($span.classes()).toContain('navbar-toggler-icon')
-
-    wrapper.unmount()
   })
 
   it('renders default slot custom content', () => {
@@ -31,22 +27,16 @@ describe('navbar-toggle', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('button type is button', () => {
     const wrapper = mount(BNavbarToggle)
     expect(wrapper.attributes('type')).toBe('button')
-
-    wrapper.unmount()
   })
 
   it('has aria-label by default', () => {
     const wrapper = mount(BNavbarToggle)
     expect(wrapper.attributes('aria-label')).toBe('Toggle navigation')
-
-    wrapper.unmount()
   })
 
   it('has aria-label when aria-label prop', () => {
@@ -54,15 +44,11 @@ describe('navbar-toggle', () => {
       props: {label: 'abc'},
     })
     expect(wrapper.attributes('aria-label')).toBe('abc')
-
-    wrapper.unmount()
   })
 
   it('disabled attribute is undefined by default', () => {
     const wrapper = mount(BNavbarToggle)
     expect(wrapper.attributes('disabled')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('disabled attribute is empty string when true', () => {
@@ -70,8 +56,6 @@ describe('navbar-toggle', () => {
       props: {disabled: true},
     })
     expect(wrapper.attributes('disabled')).toBe('')
-
-    wrapper.unmount()
   })
 
   it('has disabled class when prop disabled', () => {
@@ -79,8 +63,6 @@ describe('navbar-toggle', () => {
       props: {disabled: true},
     })
     expect(wrapper.classes()).toContain('disabled')
-
-    wrapper.unmount()
   })
 
   it('emits click when not disabled', async () => {
@@ -89,8 +71,6 @@ describe('navbar-toggle', () => {
     })
     await wrapper.trigger('click')
     expect(wrapper.emitted()).toHaveProperty('click')
-
-    wrapper.unmount()
   })
 
   it('does not emit click when not disabled', async () => {
@@ -99,7 +79,5 @@ describe('navbar-toggle', () => {
     })
     await wrapper.trigger('click')
     expect(wrapper.emitted()).not.toHaveProperty('click')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BNavbar/navbar.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BNavbar/navbar.spec.ts
@@ -1,34 +1,28 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BNavbar from './BNavbar.vue'
 
 describe('navbar', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains static class navbar', () => {
     const wrapper = mount(BNavbar)
     expect(wrapper.classes()).toContain('navbar')
-
-    wrapper.unmount()
   })
 
   it('tag is nav by default', () => {
     const wrapper = mount(BNavbar)
     expect(wrapper.element.tagName).toBe('NAV')
-
-    wrapper.unmount()
   })
 
   it('does not contain role attribute on default', () => {
     const wrapper = mount(BNavbar)
     expect(wrapper.attributes('navigation')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has class navbar-expand by default', () => {
     const wrapper = mount(BNavbar)
     expect(wrapper.classes()).toContain('navbar-expand')
-
-    wrapper.unmount()
   })
 
   it('has class navbar-expand on prop toggleable changes', async () => {
@@ -44,8 +38,6 @@ describe('navbar', () => {
     expect(wrapper.classes()).toContain('navbar-expand')
     await wrapper.setProps({toggleable: true})
     expect(wrapper.classes()).not.toContain('navbar-expand')
-
-    wrapper.unmount()
   })
 
   it('contains role navigation when is not tag nav', () => {
@@ -55,8 +47,6 @@ describe('navbar', () => {
       },
     })
     expect(wrapper.attributes('role')).toBe('navigation')
-
-    wrapper.unmount()
   })
 
   it('contains class d-print when prop print', async () => {
@@ -66,8 +56,6 @@ describe('navbar', () => {
     expect(wrapper.classes()).toContain('d-print')
     await wrapper.setProps({print: false})
     expect(wrapper.classes()).not.toContain('d-print')
-
-    wrapper.unmount()
   })
 
   it('contains class navbar-dark when prop dark', async () => {
@@ -77,8 +65,6 @@ describe('navbar', () => {
     expect(wrapper.classes()).toContain('navbar-dark')
     await wrapper.setProps({dark: false})
     expect(wrapper.classes()).not.toContain('navbar-dark')
-
-    wrapper.unmount()
   })
 
   it('contains class sticky when prop sticky is set', async () => {
@@ -88,8 +74,6 @@ describe('navbar', () => {
     expect(wrapper.classes()).toContain('sticky-top')
     await wrapper.setProps({sticky: undefined})
     expect(wrapper.classes()).not.toContain('sticky-top')
-
-    wrapper.unmount()
   })
 
   it('contains class bg when prop variant is set', async () => {
@@ -99,8 +83,6 @@ describe('navbar', () => {
     expect(wrapper.classes()).toContain('bg-primary')
     await wrapper.setProps({variant: undefined})
     expect(wrapper.classes()).not.toContain('bg-primary')
-
-    wrapper.unmount()
   })
 
   it('contains class fixed when prop fixed is set', async () => {
@@ -110,16 +92,12 @@ describe('navbar', () => {
     expect(wrapper.classes()).toContain('fixed-top')
     await wrapper.setProps({fixed: undefined})
     expect(wrapper.classes()).not.toContain('fixed-top')
-
-    wrapper.unmount()
   })
 
   it('contains a container-fluid on div child by default', () => {
     const wrapper = mount(BNavbar)
     const $div = wrapper.get('div')
     expect($div.classes()).toContain('container-fluid')
-
-    wrapper.unmount()
   })
 
   it('contains a container on div child when container prop is true', () => {
@@ -128,8 +106,6 @@ describe('navbar', () => {
     })
     const $div = wrapper.get('div')
     expect($div.classes()).toContain('container')
-
-    wrapper.unmount()
   })
 
   it('does not have div child when container prop is false', () => {
@@ -138,8 +114,6 @@ describe('navbar', () => {
     })
     const $div = wrapper.find('div')
     expect($div.exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('renders default slot content when container prop is false', () => {
@@ -148,8 +122,6 @@ describe('navbar', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('renders default slot content in container child when container prop is Truthy', () => {
@@ -159,8 +131,6 @@ describe('navbar', () => {
     })
     const $div = wrapper.get('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('renders default slot content in container child', () => {
@@ -169,7 +139,5 @@ describe('navbar', () => {
     })
     const $div = wrapper.get('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BTable/table-simple.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/table-simple.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTableSimple from './BTableSimple.vue'
 
 describe('table-simple', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is div when prop responsive', () => {
     const wrapper = mount(BTableSimple, {
       props: {responsive: true},

--- a/packages/bootstrap-vue-3/src/components/BTable/tbody.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/tbody.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTbody from './BTbody.vue'
 
 describe('tbody', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static attr role as rowgroup', () => {
     const wrapper = mount(BTbody)
     expect(wrapper.attributes('role')).toBe('rowgroup')

--- a/packages/bootstrap-vue-3/src/components/BTable/td.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/td.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTd from './BTd.vue'
 
 describe('td', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static attr role to be cell', () => {
     const wrapper = mount(BTd)
     expect(wrapper.attributes('role')).toBe('cell')

--- a/packages/bootstrap-vue-3/src/components/BTable/tfoot.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/tfoot.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTfoot from './BTfoot.vue'
 
 describe('tfoot', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static attr role to be rowgroup', () => {
     const wrapper = mount(BTfoot)
     expect(wrapper.attributes('role')).toBe('rowgroup')

--- a/packages/bootstrap-vue-3/src/components/BTable/th.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/th.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTh from './BTh.vue'
 
 describe('th', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static attr role to be columnheader', () => {
     const wrapper = mount(BTh)
     expect(wrapper.attributes('role')).toBe('columnheader')

--- a/packages/bootstrap-vue-3/src/components/BTable/thead.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/thead.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BThead from './BThead.vue'
 
 describe('thead', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static attr role to be rowgroup', () => {
     const wrapper = mount(BThead)
     expect(wrapper.attributes('role')).toBe('rowgroup')

--- a/packages/bootstrap-vue-3/src/components/BTable/tr.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/tr.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it, vitest} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTr from './BTr.vue'
 
 describe('tr', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static attr role to be row', () => {
     const wrapper = mount(BTr)
     expect(wrapper.attributes('role')).toBe('row')

--- a/packages/bootstrap-vue-3/src/components/BTabs/tab.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTabs/tab.spec.ts
@@ -1,11 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTab from './BTab.vue'
 // This exists, just TS being confused with *.vue vs the actual component import
 // Ie vite-end.d.ts vs the actual import which ts can't understand
 import {injectionKey} from './BTabs.vue'
 
 describe('tab', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is default div', () => {
     const wrapper = mount(BTab)
     expect(wrapper.element.tagName).toBe('DIV')

--- a/packages/bootstrap-vue-3/src/components/BToast/toast.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BToast/toast.spec.ts
@@ -1,22 +1,20 @@
-import {mount} from '@vue/test-utils'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {waitRAF} from '../../../tests/utils'
-import {describe, expect, it} from 'vitest'
+import {afterEach, describe, expect, it} from 'vitest'
 import BToast from './BToast.vue'
 import {nextTick} from 'vue'
 
 describe('toast', () => {
+  enableAutoUnmount(afterEach)
+
   it('contains static class b-toast', () => {
     const wrapper = mount(BToast)
     expect(wrapper.classes()).toContain('b-toast')
-
-    wrapper.unmount()
   })
 
   it('tag is div', () => {
     const wrapper = mount(BToast)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('child div with toast class exists', async () => {
@@ -29,8 +27,6 @@ describe('toast', () => {
     await waitRAF()
     const $toast = wrapper.find('.toast')
     expect($toast.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child element is tag div', async () => {
@@ -43,8 +39,6 @@ describe('toast', () => {
     await waitRAF()
     const $toast = wrapper.get('.toast')
     expect($toast.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('child div has static class toast', async () => {
@@ -58,8 +52,6 @@ describe('toast', () => {
     const $toast = wrapper.get('.toast')
     // Not sure why this is a test, considering it targets whoever has class toast
     expect($toast.classes()).toContain('toast')
-
-    wrapper.unmount()
   })
 
   it('child div has child whos class is toast-header', async () => {
@@ -73,8 +65,6 @@ describe('toast', () => {
     const $toast = wrapper.get('.toast')
     const $toastHeader = $toast.find('.toast-header')
     expect($toastHeader.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child div whos child has toast-header has element strong', async () => {
@@ -89,8 +79,6 @@ describe('toast', () => {
     const $toastHeader = $toast.get('.toast-header')
     const $strong = $toastHeader.find('strong')
     expect($strong.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child divs child header child strong renders text of prop title', async () => {
@@ -105,8 +93,6 @@ describe('toast', () => {
     const $toastHeader = $toast.get('.toast-header')
     const $strong = $toastHeader.get('strong')
     expect($strong.text()).toBe('Test')
-
-    wrapper.unmount()
   })
 
   it('child divs child header child strong has static class me-auto', async () => {
@@ -121,8 +107,6 @@ describe('toast', () => {
     const $toastHeader = $toast.get('.toast-header')
     const $strong = $toastHeader.get('strong')
     expect($strong.classes()).toContain('me-auto')
-
-    wrapper.unmount()
   })
 
   it('child div whos child has toast-header has element button', async () => {
@@ -137,8 +121,6 @@ describe('toast', () => {
     const $toastHeader = $toast.get('.toast-header')
     const $button = $toastHeader.find('button')
     expect($button.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child divs child header child button has static class btn-close', async () => {
@@ -153,8 +135,6 @@ describe('toast', () => {
     const $toastHeader = $toast.get('.toast-header')
     const $button = $toastHeader.find('button')
     expect($button.classes()).toContain('btn-close')
-
-    wrapper.unmount()
   })
 
   it('child div has element with class toast-body', async () => {
@@ -168,8 +148,6 @@ describe('toast', () => {
     const $toast = wrapper.get('.toast')
     const $body = $toast.find('.toast-body')
     expect($body.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('child div child whos class is toast-body is tag div', async () => {
@@ -183,8 +161,6 @@ describe('toast', () => {
     const $toast = wrapper.get('.toast')
     const $body = $toast.get('.toast-body')
     expect($body.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('child div child whos class is toast-body has classes length of 1', async () => {
@@ -198,8 +174,6 @@ describe('toast', () => {
     const $toast = wrapper.get('.toast')
     const $body = $toast.get('.toast-body')
     expect($body.classes().length).toBe(1)
-
-    wrapper.unmount()
   })
 
   it('child div child whos class is toast-body div renders text of prop body', async () => {
@@ -213,17 +187,13 @@ describe('toast', () => {
     const $toast = wrapper.get('.toast')
     const $body = $toast.get('.toast-body')
     expect($body.text()).toEqual('Test Body')
-
-    wrapper.unmount()
   })
 
   it('emits destroyed when component is unmounted', async () => {
     const wrapper = mount(BToast, {
       props: {modelValue: true, title: 'Test', body: 'Test Body'},
     })
-
     wrapper.unmount()
-
     expect(wrapper.emitted()).toHaveProperty('destroyed')
   })
 
@@ -231,12 +201,9 @@ describe('toast', () => {
     const wrapper = mount(BToast, {
       props: {modelValue: true, title: 'Test', body: 'Test Body', id: 'foobar'},
     })
-
     wrapper.unmount()
-
-    const [$emitted] = wrapper.emitted('destroyed') ?? []
-    const [$value] = $emitted
-    expect($value).toBe('foobar')
+    const $emitted = wrapper.emitted('destroyed') ?? []
+    expect($emitted[0][0]).toBe('foobar')
   })
 
   // TODO test when emits to update:modelValue

--- a/packages/bootstrap-vue-3/src/components/BToast/toaster.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BToast/toaster.spec.ts
@@ -1,10 +1,12 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BToaster from './BToaster.vue'
 import BToast from './BToast.vue'
 import {ToastInstance} from './plugin'
 
 describe('toaster', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class b-toaster', () => {
     const wrapper = mount(BToaster)
     expect(wrapper.classes()).toContain('b-toaster')

--- a/packages/bootstrap-vue-3/src/components/BTransition/transition.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTransition/transition.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BTransition from './BTransition.vue'
 
 describe('transition', () => {
+  enableAutoUnmount(afterEach)
+
   it('renders default slot', () => {
     const wrapper = mount(BTransition, {
       slots: {default: 'foobar'},

--- a/packages/bootstrap-vue-3/src/components/alert.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/alert.spec.ts
@@ -1,15 +1,15 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BAlert from './BAlert.vue'
 
 describe('alert', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class alert', () => {
     const wrapper = mount(BAlert, {
       props: {modelValue: true},
     })
     expect(wrapper.classes()).toContain('alert')
-
-    wrapper.unmount()
   })
 
   it('has static role set to alert', () => {
@@ -17,8 +17,6 @@ describe('alert', () => {
       props: {modelValue: true},
     })
     expect(wrapper.attributes('role')).toBe('alert')
-
-    wrapper.unmount()
   })
 
   it('has class alert-{type} when prop variant', async () => {
@@ -28,8 +26,6 @@ describe('alert', () => {
     expect(wrapper.classes()).toContain('alert-primary')
     await wrapper.setProps({variant: undefined})
     expect(wrapper.classes()).not.toContain('alert-primary')
-
-    wrapper.unmount()
   })
 
   it('has class show when prop modelValue', async () => {
@@ -39,8 +35,6 @@ describe('alert', () => {
     expect(wrapper.classes()).toContain('show')
     await wrapper.setProps({modelValue: false})
     expect(wrapper.classes()).not.toContain('show')
-
-    wrapper.unmount()
   })
 
   it('has class alert-dismissible when prop dismissible', async () => {
@@ -50,8 +44,6 @@ describe('alert', () => {
     expect(wrapper.classes()).toContain('alert-dismissible')
     await wrapper.setProps({dismissible: false})
     expect(wrapper.classes()).not.toContain('alert-dismissible')
-
-    wrapper.unmount()
   })
 
   it('has class fade when prop modelValue', async () => {
@@ -61,8 +53,6 @@ describe('alert', () => {
     expect(wrapper.classes()).toContain('fade')
     await wrapper.setProps({modelValue: false})
     expect(wrapper.classes()).not.toContain('fade')
-
-    wrapper.unmount()
   })
 
   it('component exists when modelValue true', () => {
@@ -71,8 +61,6 @@ describe('alert', () => {
     })
     const $div = wrapper.find('div')
     expect($div.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('component does not exist when modelValue false', () => {
@@ -81,8 +69,6 @@ describe('alert', () => {
     })
     const $div = wrapper.find('div')
     expect($div.exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('component exists when show true', () => {
@@ -91,8 +77,6 @@ describe('alert', () => {
     })
     const $div = wrapper.find('div')
     expect($div.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('component does not exist when show false', () => {
@@ -101,8 +85,6 @@ describe('alert', () => {
     })
     const $div = wrapper.find('div')
     expect($div.exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -111,8 +93,6 @@ describe('alert', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has button child if prop dismissible', () => {
@@ -121,8 +101,6 @@ describe('alert', () => {
     })
     const $button = wrapper.find('button')
     expect($button.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('does not have button child if prop dismissible false', () => {
@@ -131,8 +109,6 @@ describe('alert', () => {
     })
     const $button = wrapper.find('button')
     expect($button.exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('button child has static attribute type button', () => {
@@ -141,8 +117,6 @@ describe('alert', () => {
     })
     const $button = wrapper.get('button')
     expect($button.attributes('type')).toBe('button')
-
-    wrapper.unmount()
   })
 
   it('button child has static class btn-close', () => {
@@ -151,8 +125,6 @@ describe('alert', () => {
     })
     const $button = wrapper.get('button')
     expect($button.classes()).toContain('btn-close')
-
-    wrapper.unmount()
   })
 
   it('button child has static attribute data-bs-dismiss alert', () => {
@@ -161,8 +133,6 @@ describe('alert', () => {
     })
     const $button = wrapper.get('button')
     expect($button.attributes('data-bs-dismiss')).toBe('alert')
-
-    wrapper.unmount()
   })
 
   it('button child has aria-label Close by default', () => {
@@ -171,8 +141,6 @@ describe('alert', () => {
     })
     const $button = wrapper.get('button')
     expect($button.attributes('aria-label')).toBe('Close')
-
-    wrapper.unmount()
   })
 
   it('button child has aria-label prop dismissLabel', () => {
@@ -181,8 +149,6 @@ describe('alert', () => {
     })
     const $button = wrapper.get('button')
     expect($button.attributes('aria-label')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('button child on click emits update:modelValue', async () => {
@@ -192,8 +158,6 @@ describe('alert', () => {
     const $button = wrapper.get('button')
     await $button.trigger('click')
     expect(wrapper.emitted()).toHaveProperty('update:modelValue')
-
-    wrapper.unmount()
   })
 
   it('button child on click emits dismissed', async () => {
@@ -203,8 +167,6 @@ describe('alert', () => {
     const $button = wrapper.get('button')
     await $button.trigger('click')
     expect(wrapper.emitted()).toHaveProperty('dismissed')
-
-    wrapper.unmount()
   })
 
   it('button child on click emits update:modelValue and gives value false if prop modelValue boolean', async () => {
@@ -216,8 +178,6 @@ describe('alert', () => {
     expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
     const [event] = wrapper.emitted('update:modelValue') ?? []
     expect(event).toEqual([false])
-
-    wrapper.unmount()
   })
 
   it('button child on click emits update:modelValue and gives value 0 if prop modelValue number', async () => {
@@ -229,7 +189,5 @@ describe('alert', () => {
     expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
     const [event] = wrapper.emitted('update:modelValue') ?? []
     expect(event).toEqual([0])
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/col.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/col.spec.ts
@@ -1,13 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BCol from './BCol.vue'
 
 describe('col', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is default div', () => {
     const wrapper = mount(BCol)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('tag is prop tag', () => {
@@ -15,8 +15,6 @@ describe('col', () => {
       props: {tag: 'span'},
     })
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('has class col-{type} when prop cols', async () => {
@@ -26,8 +24,6 @@ describe('col', () => {
     expect(wrapper.classes()).toContain('col-6')
     await wrapper.setProps({cols: null})
     expect(wrapper.classes()).not.toContain('col-6')
-
-    wrapper.unmount()
   })
 
   it('has class offset-{type} when prop offset', async () => {
@@ -37,8 +33,6 @@ describe('col', () => {
     expect(wrapper.classes()).toContain('offset-6')
     await wrapper.setProps({offset: null})
     expect(wrapper.classes()).not.toContain('offset-6')
-
-    wrapper.unmount()
   })
 
   it('has class order-{type} when prop order', async () => {
@@ -48,8 +42,6 @@ describe('col', () => {
     expect(wrapper.classes()).toContain('order-6')
     await wrapper.setProps({order: null})
     expect(wrapper.classes()).not.toContain('order-6')
-
-    wrapper.unmount()
   })
 
   it('has class align-self-{type} when prop order', async () => {
@@ -59,8 +51,6 @@ describe('col', () => {
     expect(wrapper.classes()).toContain('align-self-baseline')
     await wrapper.setProps({alignSelf: null})
     expect(wrapper.classes()).not.toContain('align-self-baseline')
-
-    wrapper.unmount()
   })
 
   it('has class col when prop col', async () => {
@@ -68,8 +58,6 @@ describe('col', () => {
       props: {col: true, cols: 'auto'},
     })
     expect(wrapper.classes()).toContain('col')
-
-    wrapper.unmount()
   })
 
   // TODO this component almost always seems like it has col class
@@ -78,8 +66,6 @@ describe('col', () => {
       props: {col: false, cols: 'auto'},
     })
     expect(wrapper.classes()).not.toContain('col')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -87,7 +73,5 @@ describe('col', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/collapse.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/collapse.spec.ts
@@ -1,20 +1,18 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BCollapse from './BCollapse.vue'
 
 describe('collapse', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class collapse', () => {
     const wrapper = mount(BCollapse)
     expect(wrapper.classes()).toContain('collapse')
-
-    wrapper.unmount()
   })
 
   it('has default tag div', () => {
     const wrapper = mount(BCollapse)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('is tag when prop tag', () => {
@@ -22,15 +20,11 @@ describe('collapse', () => {
       props: {tag: 'span'},
     })
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('has default id', () => {
     const wrapper = mount(BCollapse)
     expect(wrapper.attributes('id')).toBeDefined()
-
-    wrapper.unmount()
   })
 
   it('has id as prop id', () => {
@@ -38,8 +32,6 @@ describe('collapse', () => {
       props: {id: 'foobar'},
     })
     expect(wrapper.attributes('id')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has data-bs-parent when prop accordion', () => {
@@ -47,15 +39,11 @@ describe('collapse', () => {
       props: {accordion: 'abc'},
     })
     expect(wrapper.attributes('data-bs-parent')).toBe('abc')
-
-    wrapper.unmount()
   })
 
   it('has data-bs-parent null when accordion undefined', () => {
     const wrapper = mount(BCollapse)
     expect(wrapper.attributes('data-bs-parent')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has attribute is-nav when prop is nav', async () => {
@@ -65,8 +53,6 @@ describe('collapse', () => {
     expect(wrapper.attributes('is-nav')).toBe('true')
     await wrapper.setProps({isNav: false})
     expect(wrapper.attributes('is-nav')).toBe('false')
-
-    wrapper.unmount()
   })
 
   it('renders default slot', () => {
@@ -74,8 +60,6 @@ describe('collapse', () => {
       slots: {default: 'foobar'},
     })
     expect(wrapper.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   // TODO :visible prop on default slot does not seem to have any affect on slot being visible

--- a/packages/bootstrap-vue-3/src/components/container.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/container.spec.ts
@@ -1,5 +1,5 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BContainer from './BContainer.vue'
 
 describe('container', () => {

--- a/packages/bootstrap-vue-3/src/components/img.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/img.spec.ts
@@ -1,8 +1,10 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BImg from './BImg.vue'
 
 describe('img', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is img', () => {
     const wrapper = mount(BImg)
     expect(wrapper.element.tagName).toBe('IMG')
@@ -15,8 +17,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('img-thumbnail')
     await wrapper.setProps({thumbnail: false})
     expect(wrapper.classes()).not.toContain('img-thumbnail')
-
-    wrapper.unmount()
   })
 
   it('has class img-fluid if prop fluid', async () => {
@@ -26,8 +26,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('img-fluid')
     await wrapper.setProps({fluid: false})
     expect(wrapper.classes()).not.toContain('img-fluid')
-
-    wrapper.unmount()
   })
 
   it('has class img-fluid if prop fluidGrow', async () => {
@@ -37,8 +35,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('img-fluid')
     await wrapper.setProps({fluidGrow: false})
     expect(wrapper.classes()).not.toContain('img-fluid')
-
-    wrapper.unmount()
   })
 
   it('has class w-100 if prop fluidGrow', async () => {
@@ -48,8 +44,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('w-100')
     await wrapper.setProps({fluidGrow: false})
     expect(wrapper.classes()).not.toContain('w-100')
-
-    wrapper.unmount()
   })
 
   it('has class rounded if prop rounded true', async () => {
@@ -59,8 +53,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('rounded')
     await wrapper.setProps({rounded: false})
     expect(wrapper.classes()).not.toContain('rounded')
-
-    wrapper.unmount()
   })
 
   it('has class rounded if prop rounded empty string', async () => {
@@ -70,8 +62,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('rounded')
     await wrapper.setProps({rounded: false})
     expect(wrapper.classes()).not.toContain('rounded')
-
-    wrapper.unmount()
   })
 
   it('has class rounded-{type} if prop rounded string', async () => {
@@ -81,8 +71,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('rounded-abc')
     await wrapper.setProps({rounded: false})
     expect(wrapper.classes()).not.toContain('rounded-abc')
-
-    wrapper.unmount()
   })
 
   it('has class d-block if prop block', async () => {
@@ -92,8 +80,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('d-block')
     await wrapper.setProps({block: false})
     expect(wrapper.classes()).not.toContain('d-block')
-
-    wrapper.unmount()
   })
 
   it('has class d-block if prop centerBoolean', async () => {
@@ -103,8 +89,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('d-block')
     await wrapper.setProps({center: false})
     expect(wrapper.classes()).not.toContain('d-block')
-
-    wrapper.unmount()
   })
 
   it('has class float-start if prop left', async () => {
@@ -114,8 +98,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('float-start')
     await wrapper.setProps({left: false})
     expect(wrapper.classes()).not.toContain('float-start')
-
-    wrapper.unmount()
   })
 
   it('has class float-end if prop right', async () => {
@@ -125,8 +107,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('float-end')
     await wrapper.setProps({right: false})
     expect(wrapper.classes()).not.toContain('float-end')
-
-    wrapper.unmount()
   })
 
   it('has class mx-auto if prop center', async () => {
@@ -136,8 +116,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('mx-auto')
     await wrapper.setProps({center: false})
     expect(wrapper.classes()).not.toContain('mx-auto')
-
-    wrapper.unmount()
   })
 
   it('has class float-start takes priority over prop right/center', async () => {
@@ -147,8 +125,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('float-start')
     await wrapper.setProps({left: false})
     expect(wrapper.classes()).toContain('float-end')
-
-    wrapper.unmount()
   })
 
   it('has class float-end takes priority over prop center', async () => {
@@ -158,8 +134,6 @@ describe('img', () => {
     expect(wrapper.classes()).toContain('float-end')
     await wrapper.setProps({right: false})
     expect(wrapper.classes()).toContain('mx-auto')
-
-    wrapper.unmount()
   })
 
   it('does not have any alignment classes when all props are false', () => {
@@ -169,8 +143,6 @@ describe('img', () => {
     expect(wrapper.classes()).not.toContain('float-start')
     expect(wrapper.classes()).not.toContain('float-end')
     expect(wrapper.classes()).not.toContain('mx-auto')
-
-    wrapper.unmount()
   })
 
   it('has attr loading to be lazy when prop lazy', () => {

--- a/packages/bootstrap-vue-3/src/components/modal.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/modal.spec.ts
@@ -1,14 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BModal from './BModal.vue'
 
 describe.skip('modal', () => {
+  enableAutoUnmount(afterEach)
   // Having issues getting the 'body' from the VDOM
 
   it('has static class modal', () => {
     const wrapper = mount(BModal)
     expect(wrapper.classes()).toContain('modal')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/offcanvas.spec.ts
@@ -1,34 +1,28 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BOffcanvas from './BOffcanvas.vue'
 
 describe('offcanvas', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class offcanvas', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.classes()).toContain('offcanvas')
-
-    wrapper.unmount()
   })
 
   it('has tabindex -1', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.attributes('tabindex')).toBe('-1')
-
-    wrapper.unmount()
   })
 
   it('has aria-labelledby offcanvasLabel', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.attributes('aria-labelledby')).toBe('offcanvasLabel')
-
-    wrapper.unmount()
   })
 
   it('has offcanvas-{type} when prop placement', () => {
     const wrapper = mount(BOffcanvas)
     expect(wrapper.classes()).toContain('offcanvas-start')
-
-    wrapper.unmount()
   })
 
   it('has offcanvas-{type} when prop placement not default', () => {
@@ -36,8 +30,6 @@ describe('offcanvas', () => {
       props: {placement: 'abc'},
     })
     expect(wrapper.classes()).toContain('offcanvas-abc')
-
-    wrapper.unmount()
   })
 
   it('has data-bs-backdrop', async () => {
@@ -45,8 +37,6 @@ describe('offcanvas', () => {
     expect(wrapper.attributes('data-bs-backdrop')).toBe('true')
     await wrapper.setProps({backdrop: false})
     expect(wrapper.attributes('data-bs-backdrop')).toBe('false')
-
-    wrapper.unmount()
   })
 
   it('has data-bs-scroll', async () => {
@@ -54,16 +44,12 @@ describe('offcanvas', () => {
     expect(wrapper.attributes('data-bs-scroll')).toBe('false')
     await wrapper.setProps({bodyScrolling: true})
     expect(wrapper.attributes('data-bs-scroll')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('first child div has static class offcanvas-header', () => {
     const wrapper = mount(BOffcanvas)
     const [, $div] = wrapper.findAll('div')
     expect($div.classes()).toContain('offcanvas-header')
-
-    wrapper.unmount()
   })
 
   it('first child div has child h5 with static class offcanvas-title', () => {
@@ -71,8 +57,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $h5 = $div.get('h5')
     expect($h5.classes()).toContain('offcanvas-title')
-
-    wrapper.unmount()
   })
 
   it('first child div has child h5 has id offcanvasLabel', () => {
@@ -80,8 +64,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $h5 = $div.get('h5')
     expect($h5.attributes('id')).toContain('offcanvasLabel')
-
-    wrapper.unmount()
   })
 
   it('first child div has child h5 that has slot title', () => {
@@ -91,8 +73,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $h5 = $div.get('h5')
     expect($h5.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('first child div has child h5 that has prop title', () => {
@@ -102,8 +82,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $h5 = $div.get('h5')
     expect($h5.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('first child div has child button has static type button', () => {
@@ -111,8 +89,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $button = $div.get('button')
     expect($button.attributes('type')).toBe('button')
-
-    wrapper.unmount()
   })
 
   it('first child div has child button has static class btn-close', () => {
@@ -120,8 +96,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $button = $div.get('button')
     expect($button.classes()).toContain('btn-close')
-
-    wrapper.unmount()
   })
 
   it('first child div has child button has aria-label close', () => {
@@ -129,8 +103,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $button = $div.get('button')
     expect($button.attributes('aria-label')).toBe('Close')
-
-    wrapper.unmount()
   })
 
   it('first child div has child button has aria-label prop dismissLabel', () => {
@@ -140,8 +112,6 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $button = $div.get('button')
     expect($button.attributes('aria-label')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('first child div has child button has static class text-reset', () => {
@@ -149,16 +119,12 @@ describe('offcanvas', () => {
     const [, $div] = wrapper.findAll('div')
     const $button = $div.get('button')
     expect($button.classes()).toContain('text-reset')
-
-    wrapper.unmount()
   })
 
   it('second child div has static class offcanvas-body', () => {
     const wrapper = mount(BOffcanvas)
     const [, , $div] = wrapper.findAll('div')
     expect($div.classes()).toContain('offcanvas-body')
-
-    wrapper.unmount()
   })
 
   it('second child div renders default slot', () => {
@@ -167,7 +133,5 @@ describe('offcanvas', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/src/components/popover.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/popover.spec.ts
@@ -1,49 +1,39 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BPopover from './BPopover.vue'
 
 describe('popover', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class popover', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.classes()).toContain('popover')
-
-    wrapper.unmount()
   })
 
   it('has static class b-popover', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.classes()).toContain('b-popover')
-
-    wrapper.unmount()
   })
 
   // There doesn't seem to be any way to get ref? It is not an attribute nor prop...
   it.skip('has attribute ref element', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.attributes('ref')).toBe('element')
-
-    wrapper.unmount()
   })
 
   it('has role tooltip', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.attributes('role')).toBe('tooltip')
-
-    wrapper.unmount()
   })
 
   it('has tabindex -1', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.attributes('tabindex')).toBe('-1')
-
-    wrapper.unmount()
   })
 
   it('is tag div', () => {
     const wrapper = mount(BPopover)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('has prop id', async () => {
@@ -53,8 +43,6 @@ describe('popover', () => {
     expect(wrapper.attributes('id')).toBe('abc')
     await wrapper.setProps({id: undefined})
     expect(wrapper.attributes('id')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('first child contains slot title', () => {
@@ -63,8 +51,6 @@ describe('popover', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('first child contains prop title', () => {
@@ -73,8 +59,6 @@ describe('popover', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('first child contains slot title if both slot and prop exists', () => {
@@ -84,8 +68,6 @@ describe('popover', () => {
     })
     const [, $div] = wrapper.findAll('div')
     expect($div.text()).toBe('slotbar')
-
-    wrapper.unmount()
   })
 
   it('second child contains slot default', () => {
@@ -94,8 +76,6 @@ describe('popover', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('second child contains prop content', () => {
@@ -104,8 +84,6 @@ describe('popover', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('second child contains slot default if both slot and prop exists', () => {
@@ -115,8 +93,6 @@ describe('popover', () => {
     })
     const [, , $div] = wrapper.findAll('div')
     expect($div.text()).toBe('slotbar')
-
-    wrapper.unmount()
   })
 
   it('contains b-popover-{type} if prop variant', async () => {
@@ -126,8 +102,6 @@ describe('popover', () => {
     expect(wrapper.classes()).toContain('b-popover-primary')
     await wrapper.setProps({variant: undefined})
     expect(wrapper.classes()).not.toContain('b-popover-primary')
-
-    wrapper.unmount()
   })
 
   // Functionally, this component does more, but this only tests the component

--- a/packages/bootstrap-vue-3/src/components/row.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/row.spec.ts
@@ -1,20 +1,18 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BRow from './BRow.vue'
 
 describe('row', () => {
+  enableAutoUnmount(afterEach)
+
   it('has static class row', () => {
     const wrapper = mount(BRow)
     expect(wrapper.classes()).toContain('row')
-
-    wrapper.unmount()
   })
 
   it('tag is div by default', () => {
     const wrapper = mount(BRow)
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('tag is prop tag', () => {
@@ -22,8 +20,6 @@ describe('row', () => {
       props: {tag: 'span'},
     })
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('has class gx-{type} when prop gutterX', () => {
@@ -31,8 +27,6 @@ describe('row', () => {
       props: {gutterX: '120'},
     })
     expect(wrapper.classes()).toContain('gx-120')
-
-    wrapper.unmount()
   })
 
   it('has class gx-{type} when prop gutterY', () => {
@@ -40,8 +34,6 @@ describe('row', () => {
       props: {gutterY: '120'},
     })
     expect(wrapper.classes()).toContain('gy-120')
-
-    wrapper.unmount()
   })
 
   it('has class align-items-{type} when prop alignV', async () => {
@@ -51,8 +43,6 @@ describe('row', () => {
     expect(wrapper.classes()).toContain('align-items-baseline')
     await wrapper.setProps({alignV: undefined})
     expect(wrapper.classes()).not.toContain('align-items-baseline')
-
-    wrapper.unmount()
   })
 
   it('has class justify-content-{type} when prop alignH', async () => {
@@ -62,8 +52,6 @@ describe('row', () => {
     expect(wrapper.classes()).toContain('justify-content-between')
     await wrapper.setProps({alignH: undefined})
     expect(wrapper.classes()).not.toContain('justify-content-between')
-
-    wrapper.unmount()
   })
 
   it('has class align-content-{type} when prop alignContent', async () => {
@@ -73,8 +61,6 @@ describe('row', () => {
     expect(wrapper.classes()).toContain('align-content-between')
     await wrapper.setProps({alignContent: undefined})
     expect(wrapper.classes()).not.toContain('align-content-between')
-
-    wrapper.unmount()
   })
 
   it('has class g-0 when prop noGutters', async () => {

--- a/packages/bootstrap-vue-3/src/components/spinner.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/spinner.spec.ts
@@ -1,13 +1,13 @@
-import {mount} from '@vue/test-utils'
-import {describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
 import BSpinner from './BSpinner.vue'
 
 describe('spinner', () => {
+  enableAutoUnmount(afterEach)
+
   it('tag is span by default', () => {
     const wrapper = mount(BSpinner)
     expect(wrapper.element.tagName).toBe('SPAN')
-
-    wrapper.unmount()
   })
 
   it('tag is tag prop', () => {
@@ -15,8 +15,6 @@ describe('spinner', () => {
       props: {tag: 'div'},
     })
     expect(wrapper.element.tagName).toBe('DIV')
-
-    wrapper.unmount()
   })
 
   it('has class spinner-border when prop type is border', async () => {
@@ -26,8 +24,6 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-border')
     await wrapper.setProps({type: 'grow'})
     expect(wrapper.classes()).not.toContain('spinner-border')
-
-    wrapper.unmount()
   })
 
   it('has class spinner-border-sm when both prop type border and prop small', async () => {
@@ -38,7 +34,6 @@ describe('spinner', () => {
     await wrapper.setProps({type: 'grow'})
     expect(wrapper.classes()).not.toContain('spinner-border-sm')
 
-    wrapper.unmount()
     // TODO bspinner has both spinner-border and spinner-border-sm , is this intentional?
   })
 
@@ -49,8 +44,6 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-grow')
     await wrapper.setProps({type: 'border'})
     expect(wrapper.classes()).not.toContain('spinner-grow')
-
-    wrapper.unmount()
   })
 
   it('has class spinner-grow-sm when prop type is grow and prop small', async () => {
@@ -60,8 +53,6 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-grow-sm')
     await wrapper.setProps({type: 'border'})
     expect(wrapper.classes()).not.toContain('spinner-grow-sm')
-
-    wrapper.unmount()
   })
 
   it('has class spinner-grow when prop type is grow', async () => {
@@ -71,8 +62,6 @@ describe('spinner', () => {
     expect(wrapper.classes()).toContain('spinner-grow')
     await wrapper.setProps({type: 'border'})
     expect(wrapper.classes()).not.toContain('spinner-grow')
-
-    wrapper.unmount()
   })
 
   it('has class text-{type} when prop variant', async () => {
@@ -83,8 +72,6 @@ describe('spinner', () => {
     await wrapper.setProps({variant: 'secondary'})
     expect(wrapper.classes()).toContain('text-secondary')
     expect(wrapper.classes()).not.toContain('text-primary')
-
-    wrapper.unmount()
   })
 
   it('does not have role when prop role, but has no label', () => {
@@ -92,8 +79,6 @@ describe('spinner', () => {
       props: {role: 'foobar'},
     })
     expect(wrapper.attributes('role')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has role when prop role but also has prop label', () => {
@@ -101,8 +86,6 @@ describe('spinner', () => {
       props: {role: 'foobar', label: 'someLabel'},
     })
     expect(wrapper.attributes('role')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has role when prop role but also has slot label', () => {
@@ -111,8 +94,6 @@ describe('spinner', () => {
       slots: {label: 'someLabel'},
     })
     expect(wrapper.attributes('role')).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('has role status by default when label exists', () => {
@@ -120,8 +101,6 @@ describe('spinner', () => {
       slots: {label: 'foobar'},
     })
     expect(wrapper.attributes('role')).toBe('status')
-
-    wrapper.unmount()
   })
 
   it('has aria-hidden undefined when prop label', () => {
@@ -129,8 +108,6 @@ describe('spinner', () => {
       props: {label: 'foobar'},
     })
     expect(wrapper.attributes('aria-hidden')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has aria-hidden undefined when slot label', () => {
@@ -138,15 +115,11 @@ describe('spinner', () => {
       slots: {label: 'foobar'},
     })
     expect(wrapper.attributes('aria-hidden')).toBeUndefined()
-
-    wrapper.unmount()
   })
 
   it('has aria-hidden true when no label', () => {
     const wrapper = mount(BSpinner)
     expect(wrapper.attributes('aria-hidden')).toBe('true')
-
-    wrapper.unmount()
   })
 
   it('does not have span child if no label', () => {
@@ -155,8 +128,6 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(false)
-
-    wrapper.unmount()
   })
 
   it('has span child if prop label', () => {
@@ -165,8 +136,6 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('has span child if prop label', () => {
@@ -176,8 +145,6 @@ describe('spinner', () => {
     })
     const $span = wrapper.find('span')
     expect($span.exists()).toBe(true)
-
-    wrapper.unmount()
   })
 
   it('span child has text for slot label', () => {
@@ -187,8 +154,6 @@ describe('spinner', () => {
     })
     const $span = wrapper.get('span')
     expect($span.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('span child has text for prop label', () => {
@@ -197,8 +162,6 @@ describe('spinner', () => {
     })
     const $span = wrapper.get('span')
     expect($span.text()).toBe('foobar')
-
-    wrapper.unmount()
   })
 
   it('prioritizes slot label over prop label if both exist', () => {
@@ -208,8 +171,6 @@ describe('spinner', () => {
     })
     const $span = wrapper.get('span')
     expect($span.text()).toBe('labelbar')
-
-    wrapper.unmount()
   })
 
   it('span child when has label has static class visually-hidden', () => {
@@ -218,7 +179,5 @@ describe('spinner', () => {
     })
     const $span = wrapper.get('span')
     expect($span.classes()).toContain('visually-hidden')
-
-    wrapper.unmount()
   })
 })

--- a/packages/bootstrap-vue-3/vite.config.ts
+++ b/packages/bootstrap-vue-3/vite.config.ts
@@ -67,6 +67,9 @@ const config = defineConfig({
   test: {
     // globals: true,
     environment: 'jsdom',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
   },
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,7 @@ importers:
       '@popperjs/core': ^2.11.6
       '@types/bootstrap': ^5.2.2
       '@vitejs/plugin-vue': ^3.0.0
+      '@vitest/coverage-c8': ^0.22.1
       '@vue/runtime-core': ^3.2.37
       '@vue/shared': ^3.2.37
       '@vue/test-utils': ^2.0.2
@@ -90,6 +91,7 @@ importers:
       '@popperjs/core': 2.11.6
       '@types/bootstrap': 5.2.2
       '@vitejs/plugin-vue': 3.0.3_vite@3.0.9+vue@3.2.37
+      '@vitest/coverage-c8': 0.22.1_jsdom@20.0.0+sass@1.54.4
       '@vue/runtime-core': 3.2.37
       '@vue/shared': 3.2.37
       '@vue/test-utils': 2.0.2_vue@3.2.37
@@ -173,6 +175,10 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       to-fast-properties: 2.0.0
 
+  /@bcoe/v8-coverage/0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
   /@conventional-commits/parser/0.4.1:
     resolution: {integrity: sha512-H2ZmUVt6q+KBccXfMBhbBF14NlANeqHTXL4qCL6QGbMzrc4HDXyzWuxPxPNbz71f/5UkR5DrycP5VO9u7crahg==}
     dependencies:
@@ -236,6 +242,27 @@ packages:
 
   /@iarna/toml/2.2.5:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+    dev: true
+
+  /@istanbuljs/schema/0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.15:
+    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@lerna/child-process/4.0.0:
@@ -665,6 +692,10 @@ packages:
       '@types/node': 18.7.7
     dev: true
 
+  /@types/istanbul-lib-coverage/2.0.4:
+    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -878,6 +909,24 @@ packages:
     dependencies:
       vite: 3.0.9_sass@1.54.4
       vue: 3.2.37
+    dev: true
+
+  /@vitest/coverage-c8/0.22.1_jsdom@20.0.0+sass@1.54.4:
+    resolution: {integrity: sha512-KOOYpO7EGpaF+nD8GD+Y05D0JtZp12NUu6DdLXvBPqSOPo2HkZ7KNBtfR0rb6gOy3NLtGiWTYTzCwhajgb2HlA==}
+    dependencies:
+      c8: 7.12.0
+      vitest: 0.22.1_jsdom@20.0.0+sass@1.54.4
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - sass
+      - stylus
+      - supports-color
+      - terser
     dev: true
 
   /@volar/code-gen/0.38.9:
@@ -1597,6 +1646,25 @@ packages:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
     dev: true
 
+  /c8/7.12.0:
+    resolution: {integrity: sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==}
+    engines: {node: '>=10.12.0'}
+    hasBin: true
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 2.0.0
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.0
+      istanbul-reports: 3.1.5
+      rimraf: 3.0.2
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.0.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+    dev: true
+
   /cac/6.7.12:
     resolution: {integrity: sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==}
     engines: {node: '>=8'}
@@ -1844,6 +1912,12 @@ packages:
     dependencies:
       lodash.ismatch: 4.4.0
       modify-values: 1.0.1
+    dev: true
+
+  /convert-source-map/1.8.0:
+    resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
+    dependencies:
+      safe-buffer: 5.1.2
     dev: true
 
   /core-util-is/1.0.3:
@@ -2645,6 +2719,14 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
+  /foreground-child/2.0.0:
+    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 3.0.7
+    dev: true
+
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -2849,6 +2931,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       whatwg-encoding: 2.0.0
+    dev: true
+
+  /html-escaper/2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
   /http-proxy-agent/5.0.0:
@@ -3056,6 +3142,28 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /istanbul-lib-coverage/3.2.0:
+    resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report/3.0.0:
+    resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
+    engines: {node: '>=8'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.0
+      make-dir: 3.1.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-reports/3.1.5:
+    resolution: {integrity: sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.0
     dev: true
 
   /jju/1.4.0:
@@ -3330,6 +3438,13 @@ packages:
     dependencies:
       pify: 4.0.1
       semver: 5.7.1
+    dev: true
+
+  /make-dir/3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+    dependencies:
+      semver: 6.3.0
     dev: true
 
   /map-obj/1.0.1:
@@ -4393,6 +4508,15 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
 
+  /test-exclude/6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+    dev: true
+
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -4756,6 +4880,15 @@ packages:
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
+    dev: true
+
+  /v8-to-istanbul/9.0.1:
+    resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.15
+      '@types/istanbul-lib-coverage': 2.0.4
+      convert-source-map: 1.8.0
     dev: true
 
   /validate-npm-package-license/3.0.4:

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,10 @@
       "outputs": [],
       "inputs": ["**/tests/*.ts", "**/tests/*.js", "**/*.spec.ts", "**/*.spec.js", "**/*.test.ts", "**/*.test.js"]
     },
+    "test:coverage": {
+      "outputs": [],
+      "inputs": ["**/tests/*.ts", "**/tests/*.js", "**/*.spec.ts", "**/*.spec.js", "**/*.test.ts", "**/*.test.js"]
+    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
chore: create a test:coverage script

chore: include c8 coverage plugin to test settings

fix(BButton): prop type is strongly typed ButtonType

fix(BButton): prop pressed is default false was null

fix(BButton): prop rel is default undefined was null

refactor(BButton): strongly type undefined checks

test(Button): test component