### PR TITLE
BContainer tag prop, BTable items/rows selection

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BContainer.vue
+++ b/packages/bootstrap-vue-3/src/components/BContainer.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type {Breakpoint, Position} from '../types'
 import {computed, defineComponent, h, onMounted, PropType, ref, VNode} from 'vue'
-import {ToastInstance, useToast} from './BToast/plugin'
+import type {Breakpoint, Position} from '../types'
 import BToaster from './BToast/BToaster.vue'
+import {ToastInstance, useToast} from './BToast/plugin'
 export default defineComponent({
   name: 'BContainer',
   props: {
@@ -11,6 +11,7 @@ export default defineComponent({
     fluid: {type: [Boolean, String] as PropType<boolean | Breakpoint>, default: false},
     toast: {type: Object},
     position: {type: String as PropType<Position>, required: false},
+    tag: {type: String, default: 'div'},
   },
   setup(props, {slots, expose}) {
     const container = ref()
@@ -45,7 +46,7 @@ export default defineComponent({
         subContainers.push(h(BToaster, {key: position, instance: toastInstance, position}))
       })
 
-      return h('div', {class: [classes.value, props.position], ref: container}, [
+      return h(props.tag, {class: [classes.value, props.position], ref: container}, [
         ...subContainers,
         slots.default?.(),
       ])

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -173,7 +173,7 @@ const props = withDefaults(defineProps<BTableProps>(), {
   responsive: false,
   small: false,
   striped: false,
-  sortInternal: true,
+  sortInternal: false,
   selectable: false,
   selectHead: true,
   selectMode: 'single',

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -153,9 +153,9 @@ interface BTableProps {
   striped?: Booleanish
   variant?: ColorVariant
   sortBy?: string
-  sortDesc?: boolean
-  sortInternal?: boolean
-  selectable?: boolean
+  sortDesc?: Booleanish
+  sortInternal?: Booleanish
+  selectable?: Booleanish
   selectHead?: boolean | string
   selectMode?: 'multi' | 'single' | 'range'
   selectionVariant?: ColorVariant
@@ -185,8 +185,8 @@ interface BTableEmits {
   (e: 'rowUnselected', value: TableItem): void
   (e: 'selection', value: TableItem[]): void
   (e: 'update:sortBy', value: string): void
-  (e: 'update:sortDesc', value: boolean): void
-  (e: 'sorted', ...value: Parameters<(sort?: {by?: string; desc?: boolean}) => any>): void
+  (e: 'update:sortDesc', value: Booleanish): void
+  (e: 'sorted', ...value: Parameters<(sort?: {by?: string; desc?: Booleanish}) => any>): void
 }
 
 const emits = defineEmits<BTableEmits>()
@@ -236,7 +236,7 @@ const responsiveClasses = computed(() => ({
 }))
 
 const addSelectableCell = computed(
-  () => selectableBoolean && (props.selectHead || slots.selectHead !== undefined)
+  () => selectableBoolean.value && (props.selectHead || slots.selectHead !== undefined)
 )
 
 const isSortable = computed(

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -173,6 +173,7 @@ const props = withDefaults(defineProps<BTableProps>(), {
   responsive: false,
   small: false,
   striped: false,
+  sortDesc: false,
   sortInternal: false,
   selectable: false,
   selectHead: true,
@@ -185,8 +186,8 @@ interface BTableEmits {
   (e: 'rowUnselected', value: TableItem): void
   (e: 'selection', value: TableItem[]): void
   (e: 'update:sortBy', value: string): void
-  (e: 'update:sortDesc', value: Booleanish): void
-  (e: 'sorted', ...value: Parameters<(sort?: {by?: string; desc?: Booleanish}) => any>): void
+  (e: 'update:sortDesc', value: boolean): void
+  (e: 'sorted', ...value: Parameters<(sort?: {by?: string; desc?: boolean}) => any>): void
 }
 
 const emits = defineEmits<BTableEmits>()
@@ -200,6 +201,7 @@ const footCloneBoolean = useBooleanish(toRef(props, 'footClone'))
 const hoverBoolean = useBooleanish(toRef(props, 'hover'))
 const smallBoolean = useBooleanish(toRef(props, 'small'))
 const stripedBoolean = useBooleanish(toRef(props, 'striped'))
+const sortDescBoolean = useBooleanish(toRef(props, 'sortDesc'))
 const sortInternalBoolean = useBooleanish(toRef(props, 'sortInternal'))
 const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
 
@@ -226,7 +228,10 @@ const itemHelper = useItemHelper()
 const computedFields = computed(() => itemHelper.normaliseFields(props.fields, props.items))
 const computedItems = computed(() =>
   sortInternalBoolean.value === true
-    ? itemHelper.sortItems(props.fields, props.items, {key: props.sortBy, desc: props.sortDesc})
+    ? itemHelper.sortItems(props.fields, props.items, {
+        key: props.sortBy,
+        desc: sortDescBoolean.value,
+      })
     : props.items
 )
 
@@ -251,12 +256,12 @@ const columnClicked = (field: TableField<Record<string, unknown>>) => {
   const fieldSortable = typeof field === 'string' ? false : field.sortable
   if (isSortable.value === true && fieldSortable === true) {
     if (fieldKey === props.sortBy) {
-      emits('update:sortDesc', !props.sortDesc)
+      emits('update:sortDesc', !sortDescBoolean.value)
     } else {
       emits('update:sortBy', typeof field === 'string' ? field : field.key)
       emits('update:sortDesc', false)
     }
-    emits('sorted', {by: props.sortBy, desc: props.sortDesc})
+    emits('sorted', {by: props.sortBy, desc: sortDescBoolean.value})
   }
 }
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -241,7 +241,7 @@ const responsiveClasses = computed(() => ({
 }))
 
 const addSelectableCell = computed(
-  () => selectableBoolean.value && (props.selectHead || slots.selectHead !== undefined)
+  () => selectableBoolean.value && (!!props.selectHead || slots.selectHead !== undefined)
 )
 
 const isSortable = computed(

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -30,8 +30,8 @@
               </span>
               <div>
                 <slot
-                  v-if="$slots['head(' + field.key + ')']"
-                  :name="'head(' + field.key + ')'"
+                  v-if="$slots['head(' + field.key + ')'] || $slots['head()']"
+                  :name="$slots['head(' + field.key + ')'] ? 'head(' + field.key + ')' : 'head()'"
                   :label="field.label"
                 />
                 <template v-else>{{ field.label }}</template>
@@ -82,8 +82,8 @@
             ]"
           >
             <slot
-              v-if="$slots['cell(' + field.key + ')']"
-              :name="'cell(' + field.key + ')'"
+              v-if="$slots['cell(' + field.key + ')'] || $slots['cell()']"
+              :name="$slots['cell(' + field.key + ')'] ? 'cell(' + field.key + ')' : 'cell()'"
               :value="tr[field.key]"
               :index="index"
               :item="tr"

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -158,6 +158,7 @@ interface BTableProps {
   selectable?: boolean
   selectHead?: boolean | string
   selectMode?: 'multi' | 'single' | 'range'
+  selectionVariant?: ColorVariant
 }
 
 const props = withDefaults(defineProps<BTableProps>(), {
@@ -176,6 +177,7 @@ const props = withDefaults(defineProps<BTableProps>(), {
   selectable: false,
   selectHead: true,
   selectMode: 'single',
+  selectionVariant: 'primary',
 })
 
 interface BTableEmits {
@@ -306,6 +308,9 @@ const getFieldColumnClasses = (field: TableFieldObject) => [
 
 const getRowClasses = (item: TableItem) => [
   item._rowVariant ? `table-${item._rowVariant}` : null,
-  selectableBoolean.value && selectedItems.value.has(item) ? `selected table-primary` : null,
+  item._rowVariant ? `table-${item._rowVariant}` : null,
+  selectableBoolean.value && selectedItems.value.has(item)
+    ? `selected table-${props.selectionVariant}`
+    : null,
 ]
 </script>

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -86,3 +86,11 @@
     cursor: pointer;
   }
 }
+
+.table {
+  &.b-table-selectable {
+    tr {
+      cursor: pointer;
+    }
+  }
+}

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -1,4 +1,4 @@
-import type {TableField, TableFieldObject, TableItem} from '../../types'
+import type {Booleanish, TableField, TableFieldObject, TableItem} from '../../types'
 import {isObject, isString, startCase} from '../../utils'
 
 const useItemHelper = () => {
@@ -27,7 +27,7 @@ const useItemHelper = () => {
   const sortItems = (
     fields: TableField[],
     items: TableItem<Record<string, any>>[],
-    sort?: {key?: string; desc?: boolean}
+    sort?: {key?: string; desc?: Booleanish}
   ) => {
     if (!sort || !sort.key) return items
     const sortKey = sort.key

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -1,4 +1,4 @@
-import type {Booleanish, TableField, TableFieldObject, TableItem} from '../../types'
+import type {TableField, TableFieldObject, TableItem} from '../../types'
 import {isObject, isString, startCase} from '../../utils'
 
 const useItemHelper = () => {
@@ -27,7 +27,7 @@ const useItemHelper = () => {
   const sortItems = (
     fields: TableField[],
     items: TableItem<Record<string, any>>[],
-    sort?: {key?: string; desc?: Booleanish}
+    sort?: {key?: string; desc?: boolean}
   ) => {
     if (!sort || !sort.key) return items
     const sortKey = sort.key

--- a/packages/bootstrap-vue-3/src/styles/styles.scss
+++ b/packages/bootstrap-vue-3/src/styles/styles.scss
@@ -12,6 +12,11 @@
 @import "../components/BTable/table";
 @import "../components/BToast/index";
 
+.container,
+.container-fluid {
+  display: block;
+}
+
 .input-group
   > .form-floating:not(:first-child)
   > :not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {

--- a/packages/bootstrap-vue-3/src/types/components/BTable/BTable.d.ts
+++ b/packages/bootstrap-vue-3/src/types/components/BTable/BTable.d.ts
@@ -16,6 +16,9 @@ export interface Props {
   small?: boolean
   striped?: boolean
   variant?: ColorVariant
+  sortInternal?: boolean
+  selectable?: boolean
+  selectMode?: 'multi' | 'single' | 'range'
 }
 // Emits
 


### PR DESCRIPTION
BREAKING CHANGES: .container & .container-fluid CSS classes now have a default 'block' display to behave as a 'div' element when the BContainer tag is changed
BREAKING CHANGE: BTable 'sorted' event output value was changed to an object with keys [sort(string), desc(boolean)] for better ts type support.
BREAKING CHANGES: BTable sortInternal prop default value is now 'false'

fix: added a few missing props to the BTable.d.ts file
fix: replaced BTable emits definition array with a typescript interface for better type support
fix: update the data type of a few of BTable props


feat: Added 'tag' prop to BContainer component
feat: Added BTable selectable prop that adds the selection functionality to the table
feat: Added BTable select-mode prop with a value of [multi, single, range] to expand how the table selection can be used.
feat: Added Btable select-head prop to show an extra Head & Cell to the table
feat: Added selectHead & selectCell slots to customize the selection of the extra head & cells.
feat: BTable selection-variant prop was added, giving the ability to use bootstrap's colors as bg to the selected rows