### PR TITLE
BTable selection handling methods along with a few fixes

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -62,6 +62,9 @@
           :key="ind"
           :class="getRowClasses(tr)"
           @click.prevent="onRowClick(tr, ind, $event)"
+          @dblclick.prevent="onRowDblClick(tr, ind, $event)"
+          @mouseenter.prevent="onRowMouseEnter(tr, ind, $event)"
+          @mouseleave.prevent="onRowMouseLeave(tr, ind, $event)"
         >
           <td v-if="addSelectableCell">
             <slot name="selectCell">
@@ -196,6 +199,18 @@ interface BTableEmits {
     e: 'rowClicked',
     ...value: Parameters<(item: TableItem, index: number, event: MouseEvent) => any>
   ): void
+  (
+    e: 'rowDblClicked',
+    ...value: Parameters<(item: TableItem, index: number, event: MouseEvent) => any>
+  ): void
+  (
+    e: 'rowHovered',
+    ...value: Parameters<(item: TableItem, index: number, event: MouseEvent) => any>
+  ): void
+  (
+    e: 'rowUnhovered',
+    ...value: Parameters<(item: TableItem, index: number, event: MouseEvent) => any>
+  ): void
   (e: 'rowSelected', value: TableItem): void
   (e: 'rowUnselected', value: TableItem): void
   (e: 'selection', value: TableItem[]): void
@@ -272,6 +287,12 @@ const onRowClick = (row: TableItem, index: number, e: MouseEvent) => {
 
   handleRowSelection(row, index, e.shiftKey)
 }
+const onRowDblClick = (row: TableItem, index: number, e: MouseEvent) =>
+  emits('rowDblClicked', row, index, e)
+const onRowMouseEnter = (row: TableItem, index: number, e: MouseEvent) =>
+  emits('rowHovered', row, index, e)
+const onRowMouseLeave = (row: TableItem, index: number, e: MouseEvent) =>
+  emits('rowUnhovered', row, index, e)
 
 const addSelectableCell = computed(
   () => selectableBoolean.value && (!!props.selectHead || slots.selectHead !== undefined)

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -339,7 +339,17 @@ const selectAllRows = () => {
   emits('selection', Array.from(selectedItems.value))
 }
 
+const clearSelected = () => {
+  if (!selectableBoolean.value) return
+  selectedItems.value.forEach((item) => {
+    emits('rowUnselected', item)
+  })
+  selectedItems.value = new Set([])
+  emits('selection', Array.from(selectedItems.value))
+}
+
 defineExpose({
   selectAllRows,
+  clearSelected,
 })
 </script>

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -126,7 +126,8 @@
 <script setup lang="ts">
 // import type {Breakpoint} from '../../types'
 import {computed, ref, toRef, useSlots} from 'vue'
-import {useBooleanish, useTitleCase} from '../../composables'
+import {useBooleanish} from '../../composables'
+import {titleCase} from '../../utils/stringUtils'
 
 import type {
   Booleanish,
@@ -250,9 +251,9 @@ const responsiveClasses = computed(() => ({
 }))
 
 const getFieldHeadLabel = (field: TableField) => {
-  if (typeof field === 'string') return useTitleCase(field)
+  if (typeof field === 'string') return titleCase(field)
   if (field.label !== undefined) return field.label
-  if (typeof field.key === 'string') return useTitleCase(field.key)
+  if (typeof field.key === 'string') return titleCase(field.key)
   return field.key
 }
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -34,7 +34,7 @@
                   :name="$slots['head(' + field.key + ')'] ? 'head(' + field.key + ')' : 'head()'"
                   :label="field.label"
                 />
-                <template v-else>{{ field.label }}</template>
+                <template v-else>{{ getFieldHeadLabel(field) }}</template>
               </div>
             </div>
           </th>
@@ -125,7 +125,8 @@
 <script setup lang="ts">
 // import type {Breakpoint} from '../../types'
 import {computed, ref, toRef, useSlots} from 'vue'
-import {useBooleanish} from '../../composables'
+import {useBooleanish, useTitleCase} from '../../composables'
+
 import type {
   Booleanish,
   ColorVariant,
@@ -240,6 +241,13 @@ const responsiveClasses = computed(() => ({
   'table-responsive': typeof props.responsive === 'boolean' && props.responsive,
   [`table-responsive-${props.responsive}`]: typeof props.responsive === 'string',
 }))
+
+const getFieldHeadLabel = (field: TableField) => {
+  if (typeof field === 'string') return useTitleCase(field)
+  if (field.label !== undefined) return field.label
+  if (typeof field.key === 'string') return useTitleCase(field.key)
+  return field.key
+}
 
 const addSelectableCell = computed(
   () => selectableBoolean.value && (!!props.selectHead || slots.selectHead !== undefined)

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -192,6 +192,10 @@ interface BTableEmits {
       (key: TableFieldObject['key'], field: TableField, event: MouseEvent, isFooter: boolean) => any
     >
   ): void
+  (
+    e: 'rowClicked',
+    ...value: Parameters<(item: TableItem, index: number, event: MouseEvent) => any>
+  ): void
   (e: 'rowSelected', value: TableItem): void
   (e: 'rowUnselected', value: TableItem): void
   (e: 'selection', value: TableItem[]): void
@@ -263,6 +267,11 @@ const headerClicked = (field: TableField, event: MouseEvent, isFooter = false) =
 
   handleFieldSorting(field)
 }
+const onRowClick = (row: TableItem, index: number, e: MouseEvent) => {
+  emits('rowClicked', row, index, e)
+
+  handleRowSelection(row, index, e.shiftKey)
+}
 
 const addSelectableCell = computed(
   () => selectableBoolean.value && (!!props.selectHead || slots.selectHead !== undefined)
@@ -291,9 +300,6 @@ const handleFieldSorting = (field: TableField) => {
 const selectedItems = ref<Set<TableItem>>(new Set([]))
 const isSelecting = computed(() => selectedItems.value.size > 0)
 
-const onRowClick = (row: TableItem, index: number, e: MouseEvent) => {
-  handleRowSelection(row, index, e.shiftKey)
-}
 const notifySelectionEvent = () => {
   if (!selectableBoolean.value) return
   emits('selection', Array.from(selectedItems.value))

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -309,13 +309,11 @@ const handleFieldSorting = (field: TableField) => {
   const fieldSortable = typeof field === 'string' ? false : field.sortable
   if (isSortable.value === true && fieldSortable === true) {
     const sortDesc = !sortDescBoolean.value
-    if (fieldKey === props.sortBy) {
-      emits('update:sortDesc', sortDesc)
-    } else {
-      emits('update:sortBy', typeof field === 'string' ? field : field.key)
-      emits('update:sortDesc', false)
+    if (fieldKey !== props.sortBy) {
+      emits('update:sortBy', fieldKey)
     }
-    if (props.sortBy !== undefined) emits('sorted', props.sortBy, sortDesc)
+    emits('update:sortDesc', sortDesc)
+    emits('sorted', fieldKey, sortDesc)
   }
 }
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -216,7 +216,7 @@ interface BTableEmits {
   (e: 'selection', value: TableItem[]): void
   (e: 'update:sortBy', value: string): void
   (e: 'update:sortDesc', value: boolean): void
-  (e: 'sorted', ...value: Parameters<(sort?: {by?: string; desc?: boolean}) => any>): void
+  (e: 'sorted', ...value: Parameters<(sortBy: string, isDesc: boolean) => any>): void
 }
 
 const emits = defineEmits<BTableEmits>()
@@ -308,13 +308,14 @@ const handleFieldSorting = (field: TableField) => {
   const fieldKey = typeof field === 'string' ? field : field.key
   const fieldSortable = typeof field === 'string' ? false : field.sortable
   if (isSortable.value === true && fieldSortable === true) {
+    const sortDesc = !sortDescBoolean.value
     if (fieldKey === props.sortBy) {
-      emits('update:sortDesc', !sortDescBoolean.value)
+      emits('update:sortDesc', sortDesc)
     } else {
       emits('update:sortBy', typeof field === 'string' ? field : field.key)
       emits('update:sortDesc', false)
     }
-    emits('sorted', {by: props.sortBy, desc: sortDescBoolean.value})
+    if (props.sortBy !== undefined) emits('sorted', props.sortBy, sortDesc)
   }
 }
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -330,7 +330,13 @@ const getRowClasses = (item: TableItem) => [
 
 const selectAllRows = () => {
   if (!selectableBoolean.value) return
+  const unselectableItems = selectedItems.value.size > 0 ? Array.from(selectedItems.value) : []
   selectedItems.value = new Set([...computedItems.value])
+  selectedItems.value.forEach((item) => {
+    if (unselectableItems.includes(item)) return
+    emits('rowSelected', item)
+  })
+  emits('selection', Array.from(selectedItems.value))
 }
 
 defineExpose({

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -280,7 +280,10 @@ const isSelecting = computed(() => selectedItems.value.size > 0)
 const onRowClick = (row: TableItem, index: number, e: MouseEvent) => {
   handleRowSelection(row, index, e.shiftKey)
 }
-
+const notifySelectionEvent = () => {
+  if (!selectableBoolean.value) return
+  emits('selection', Array.from(selectedItems.value))
+}
 const handleRowSelection = (row: TableItem, index: number, shiftClicked = false) => {
   if (!selectableBoolean.value) return
 
@@ -310,7 +313,7 @@ const handleRowSelection = (row: TableItem, index: number, shiftClicked = false)
     }
   }
 
-  emits('selection', Array.from(selectedItems.value))
+  notifySelectionEvent()
 }
 
 const getFieldColumnClasses = (field: TableFieldObject) => [
@@ -336,7 +339,7 @@ const selectAllRows = () => {
     if (unselectableItems.includes(item)) return
     emits('rowSelected', item)
   })
-  emits('selection', Array.from(selectedItems.value))
+  notifySelectionEvent()
 }
 
 const clearSelected = () => {
@@ -345,7 +348,7 @@ const clearSelected = () => {
     emits('rowUnselected', item)
   })
   selectedItems.value = new Set([])
-  emits('selection', Array.from(selectedItems.value))
+  notifySelectionEvent()
 }
 
 const selectRow = (index: number) => {
@@ -354,6 +357,7 @@ const selectRow = (index: number) => {
   if (!item || selectedItems.value.has(item)) return
   selectedItems.value.add(item)
   emits('rowSelected', item)
+  notifySelectionEvent()
 }
 const unselectRow = (index: number) => {
   if (!selectableBoolean.value) return
@@ -361,6 +365,7 @@ const unselectRow = (index: number) => {
   if (!item || !selectedItems.value.has(item)) return
   selectedItems.value.delete(item)
   emits('rowUnselected', item)
+  notifySelectionEvent()
 }
 
 defineExpose({

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -348,8 +348,25 @@ const clearSelected = () => {
   emits('selection', Array.from(selectedItems.value))
 }
 
+const selectRow = (index: number) => {
+  if (!selectableBoolean.value) return
+  const item = computedItems.value[index]
+  if (!item || selectedItems.value.has(item)) return
+  selectedItems.value.add(item)
+  emits('rowSelected', item)
+}
+const unselectRow = (index: number) => {
+  if (!selectableBoolean.value) return
+  const item = computedItems.value[index]
+  if (!item || !selectedItems.value.has(item)) return
+  selectedItems.value.delete(item)
+  emits('rowUnselected', item)
+}
+
 defineExpose({
   selectAllRows,
   clearSelected,
+  selectRow,
+  unselectRow,
 })
 </script>

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -327,4 +327,13 @@ const getRowClasses = (item: TableItem) => [
     ? `selected table-${props.selectionVariant}`
     : null,
 ]
+
+const selectAllRows = () => {
+  if (!selectableBoolean.value) return
+  selectedItems.value = new Set([...computedItems.value])
+}
+
+defineExpose({
+  selectAllRows,
+})
 </script>

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -89,7 +89,7 @@
 
 .table {
   &.b-table-selectable {
-    tr {
+    td {
       cursor: pointer;
     }
   }

--- a/packages/bootstrap-vue-3/src/composables/index.ts
+++ b/packages/bootstrap-vue-3/src/composables/index.ts
@@ -15,7 +15,6 @@ import {
 import useFormInput, {COMMON_INPUT_PROPS} from './useFormInput'
 import {normalizeOptions} from './useFormSelect'
 import useId from './useId'
-import useTitleCase from './useTitleCase'
 
 export {
   useAlignment,
@@ -24,7 +23,6 @@ export {
   useEventListener,
   bindGroupProps,
   useBooleanish,
-  useTitleCase,
   getClasses,
   getGroupAttr,
   getGroupClasses,

--- a/packages/bootstrap-vue-3/src/composables/index.ts
+++ b/packages/bootstrap-vue-3/src/composables/index.ts
@@ -1,4 +1,5 @@
 import useAlignment from './useAlignment'
+import useBooleanish from './useBooleanish'
 import {createBreadcrumb, useBreadcrumb} from './useBreadcrumb'
 import useEventListener from './useEventListener'
 import {
@@ -13,8 +14,8 @@ import {
 } from './useFormCheck'
 import useFormInput, {COMMON_INPUT_PROPS} from './useFormInput'
 import {normalizeOptions} from './useFormSelect'
-import useBooleanish from './useBooleanish'
 import useId from './useId'
+import useTitleCase from './useTitleCase'
 
 export {
   useAlignment,
@@ -23,6 +24,7 @@ export {
   useEventListener,
   bindGroupProps,
   useBooleanish,
+  useTitleCase,
   getClasses,
   getGroupAttr,
   getGroupClasses,

--- a/packages/bootstrap-vue-3/src/composables/useTitleCase.ts
+++ b/packages/bootstrap-vue-3/src/composables/useTitleCase.ts
@@ -1,8 +1,0 @@
-import {RX_LOWER_UPPER, RX_START_SPACE_WORD, RX_UNDERSCORE} from '../constants/regex'
-
-export default (input: string): string => {
-  return input
-    .replace(RX_UNDERSCORE, ' ')
-    .replace(RX_LOWER_UPPER, (str, $1, $2) => $1 + ' ' + $2)
-    .replace(RX_START_SPACE_WORD, (str, $1, $2) => $1 + $2.toUpperCase())
-}

--- a/packages/bootstrap-vue-3/src/composables/useTitleCase.ts
+++ b/packages/bootstrap-vue-3/src/composables/useTitleCase.ts
@@ -1,0 +1,8 @@
+import {RX_LOWER_UPPER, RX_START_SPACE_WORD, RX_UNDERSCORE} from '../constants/regex'
+
+export default (input: string): string => {
+  return input
+    .replace(RX_UNDERSCORE, ' ')
+    .replace(RX_LOWER_UPPER, (str, $1, $2) => $1 + ' ' + $2)
+    .replace(RX_START_SPACE_WORD, (str, $1, $2) => $1 + $2.toUpperCase())
+}

--- a/packages/bootstrap-vue-3/src/utils/stringUtils.ts
+++ b/packages/bootstrap-vue-3/src/utils/stringUtils.ts
@@ -1,5 +1,10 @@
-import {RX_FIRST_START_SPACE_WORD, RX_LOWER_UPPER, RX_UNDERSCORE} from '../constants/regex'
 import {isArray, isPlainObject, isString, isUndefinedOrNull} from '.'
+import {
+  RX_FIRST_START_SPACE_WORD,
+  RX_LOWER_UPPER,
+  RX_START_SPACE_WORD,
+  RX_UNDERSCORE,
+} from '../constants/regex'
 
 /**
  * Convert a value to a string that can be rendered `undefined`/`null` will be converted to `''` Plain objects and arrays will be JSON stringified
@@ -24,6 +29,16 @@ export const startCase: (str: string) => string = (str) =>
     .replace(RX_UNDERSCORE, ' ')
     .replace(RX_LOWER_UPPER, (str, $1, $2) => `${$1} ${$2}`)
     .replace(RX_FIRST_START_SPACE_WORD, (str, $1, $2) => $1 + $2.toUpperCase())
+
+/**
+ * @param str
+ * @returns
+ */
+export const titleCase: (str: string) => string = (str) =>
+  str
+    .replace(RX_UNDERSCORE, ' ')
+    .replace(RX_LOWER_UPPER, (str, $1, $2) => `${$1} ${$2}`)
+    .replace(RX_START_SPACE_WORD, (str, $1, $2) => $1 + $2.toUpperCase())
 
 /**
  * Uppercases the first letter of a string and returns a new string


### PR DESCRIPTION
BREAKING CHANGES: updated BTable sorted event output from an object to standalone args

fix(BTable): fixes 'sorted' event not emitted with fully synced values

feat(BTable): The field key now appears in the header when the given field has no ``label``.
feat(BTable): added ``selectAllRows`` method that selects all of the given items when ``selectable`` prop is 'true'
feat(BTable): added ``clearSelected`` method that unselects all of the selected items and notifies the updates through rowUnselectedand selection events
feat(BTable): added ``selectRow`` and unselectRow methods, both methods take a number input which is the index of the item to either select or unselect its row.
feat(BTable): added ``head-clicked`` event functionality, according to the docs of vue2-bootstrap
feat(BTable): added ``row-clicked`` event functionality, according to the docs of vue2-bootstrap
feat(BTable): added ``row-hovered`` and `row-unhovered`` events functionality, according to the docs of vue2-bootstrap