### PR TITLE
BTable sticky header, columns, and selection. Along with a few fixes/additions

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -104,7 +104,7 @@
           </tr>
 
           <tr v-if="tr._showDetails === true && $slots['row-details']" :class="getRowClasses(tr)">
-            <td :colspan="computedFields.length + (selectableBoolean ? 1 : 0)">
+            <td :colspan="computedFieldsTotal">
               <slot name="row-details" :item="tr" :toggle-details="() => toggleRowDetails(tr)" />
             </td>
           </tr>
@@ -274,6 +274,9 @@ const classes = computed(() => [
 
 const itemHelper = useItemHelper()
 const computedFields = computed(() => itemHelper.normaliseFields(props.fields, props.items))
+const computedFieldsTotal = computed(
+  () => computedFields.value.length + (selectableBoolean.value ? 1 : 0)
+)
 const computedItems = computed(() =>
   sortInternalBoolean.value === true
     ? itemHelper.sortItems(props.fields, props.items, {

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -109,6 +109,16 @@
             </td>
           </tr>
         </template>
+        <tr v-if="busyBoolean" class="b-table-busy-slot">
+          <td :colspan="computedFieldsTotal">
+            <slot name="table-busy">
+              <div class="d-flex align-items-center justify-content-center gap-2">
+                <b-spinner class="align-middle"></b-spinner>
+                <strong>Loading...</strong>
+              </div>
+            </slot>
+          </td>
+        </tr>
       </tbody>
       <tfoot v-if="footCloneBoolean">
         <tr>
@@ -144,6 +154,7 @@
 import {computed, ref, toRef, useSlots} from 'vue'
 import {useBooleanish} from '../../composables'
 import {titleCase} from '../../utils/stringUtils'
+import BSpinner from '../BSpinner.vue'
 
 import type {
   Booleanish,
@@ -181,6 +192,7 @@ interface BTableProps {
   selectMode?: 'multi' | 'single' | 'range'
   selectionVariant?: ColorVariant
   stickyHeader?: Booleanish
+  busy?: Booleanish
 }
 
 const props = withDefaults(defineProps<BTableProps>(), {
@@ -203,6 +215,7 @@ const props = withDefaults(defineProps<BTableProps>(), {
   selectMode: 'single',
   selectionVariant: 'primary',
   stickyHeader: false,
+  busy: false,
 })
 
 const captionTopBoolean = useBooleanish(toRef(props, 'captionTop'))
@@ -218,6 +231,7 @@ const sortInternalBoolean = useBooleanish(toRef(props, 'sortInternal'))
 const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
 const stickyHeaderBoolean = useBooleanish(toRef(props, 'stickyHeader'))
 const stickySelectBoolean = useBooleanish(toRef(props, 'stickySelect'))
+const busyBoolean = useBooleanish(toRef(props, 'busy'))
 
 interface BTableEmits {
   (
@@ -269,6 +283,7 @@ const classes = computed(() => [
     'b-table-selectable': selectableBoolean.value,
     [`b-table-select-${props.selectMode}`]: selectableBoolean.value,
     'b-table-selecting user-select-none': selectableBoolean.value && isSelecting.value,
+    'b-table-busy': busyBoolean.value,
   },
 ])
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -75,14 +75,7 @@
             v-for="(field, index) in computedFields"
             :key="field.key"
             v-bind="field.tdAttr"
-            :class="[
-              field.class,
-              field.tdClass,
-              field.variant ? `table-${field.variant}` : '',
-              tr?._cellVariants && tr?._cellVariants[field.key]
-                ? `table-${tr?._cellVariants[field.key]}`
-                : '',
-            ]"
+            :class="getFieldRowClasses(field, tr)"
           >
             <slot
               v-if="$slots['cell(' + field.key + ')'] || $slots['cell()']"
@@ -365,6 +358,15 @@ const getFieldColumnClasses = (field: TableFieldObject) => [
   field.thClass,
   field.variant ? `table-${field.variant}` : undefined,
   {'b-table-sortable-column': isSortable.value && field.sortable},
+]
+const getFieldRowClasses = (field: TableFieldObject, tr: TableItem) => [
+  field.class,
+  field.tdClass,
+  field.variant ? `table-${field.variant}` : '',
+  tr?._cellVariants && tr?._cellVariants[field.key] ? `table-${tr?._cellVariants[field.key]}` : '',
+  {
+    'b-table-sticky-column': field.stickyColumn,
+  },
 ]
 
 const getRowClasses = (item: TableItem) => [

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -357,7 +357,10 @@ const getFieldColumnClasses = (field: TableFieldObject) => [
   field.class,
   field.thClass,
   field.variant ? `table-${field.variant}` : undefined,
-  {'b-table-sortable-column': isSortable.value && field.sortable},
+  {
+    'b-table-sortable-column': isSortable.value && field.sortable,
+    'b-table-sticky-column': field.stickyColumn,
+  },
 ]
 const getFieldRowClasses = (field: TableFieldObject, tr: TableItem) => [
   field.class,

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -63,44 +63,52 @@
         </tr>
       </thead>
       <tbody>
-        <tr
-          v-for="(tr, ind) in computedItems"
-          :key="ind"
-          :class="getRowClasses(tr)"
-          @click.prevent="onRowClick(tr, ind, $event)"
-          @dblclick.prevent="onRowDblClick(tr, ind, $event)"
-          @mouseenter.prevent="onRowMouseEnter(tr, ind, $event)"
-          @mouseleave.prevent="onRowMouseLeave(tr, ind, $event)"
-        >
-          <td
-            v-if="addSelectableCell"
-            class="b-table-selection-column"
-            :class="{
-              'b-table-sticky-column': stickySelectBoolean,
-            }"
+        <template v-for="(tr, ind) in computedItems" :key="ind">
+          <tr
+            :class="getRowClasses(tr)"
+            @click.prevent="onRowClick(tr, ind, $event)"
+            @dblclick.prevent="onRowDblClick(tr, ind, $event)"
+            @mouseenter.prevent="onRowMouseEnter(tr, ind, $event)"
+            @mouseleave.prevent="onRowMouseLeave(tr, ind, $event)"
           >
-            <slot name="selectCell">
-              <span :class="selectedItems.has(tr) ? 'text-primary' : ''">🗹</span>
-            </slot>
-          </td>
-          <td
-            v-for="(field, index) in computedFields"
-            :key="field.key"
-            v-bind="field.tdAttr"
-            :class="getFieldRowClasses(field, tr)"
-          >
-            <slot
-              v-if="$slots['cell(' + field.key + ')'] || $slots['cell()']"
-              :name="$slots['cell(' + field.key + ')'] ? 'cell(' + field.key + ')' : 'cell()'"
-              :value="tr[field.key]"
-              :index="index"
-              :item="tr"
-              :field="field"
-              :items="items"
-            />
-            <template v-else>{{ tr[field.key] }}</template>
-          </td>
-        </tr>
+            <td
+              v-if="addSelectableCell"
+              class="b-table-selection-column"
+              :class="{
+                'b-table-sticky-column': stickySelectBoolean,
+              }"
+            >
+              <slot name="selectCell">
+                <span :class="selectedItems.has(tr) ? 'text-primary' : ''">🗹</span>
+              </slot>
+            </td>
+            <td
+              v-for="(field, index) in computedFields"
+              :key="field.key"
+              v-bind="field.tdAttr"
+              :class="getFieldRowClasses(field, tr)"
+            >
+              <slot
+                v-if="$slots['cell(' + field.key + ')'] || $slots['cell()']"
+                :name="$slots['cell(' + field.key + ')'] ? 'cell(' + field.key + ')' : 'cell()'"
+                :value="tr[field.key]"
+                :index="index"
+                :item="tr"
+                :field="field"
+                :items="items"
+                :toggle-details="() => toggleRowDetails(tr)"
+                :details-showing="tr._showDetails"
+              />
+              <template v-else>{{ tr[field.key] }}</template>
+            </td>
+          </tr>
+
+          <tr v-if="tr._showDetails === true && $slots['row-details']" :class="getRowClasses(tr)">
+            <td :colspan="computedFields.length + (selectableBoolean ? 1 : 0)">
+              <slot name="row-details" :item="tr" :toggle-details="() => toggleRowDetails(tr)" />
+            </td>
+          </tr>
+        </template>
       </tbody>
       <tfoot v-if="footCloneBoolean">
         <tr>
@@ -366,6 +374,10 @@ const handleRowSelection = (row: TableItem, index: number, shiftClicked = false)
   }
 
   notifySelectionEvent()
+}
+
+const toggleRowDetails = (tr: TableItem) => {
+  tr._showDetails = !tr._showDetails
 }
 
 const getFieldColumnClasses = (field: TableFieldObject) => [

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -4,7 +4,13 @@
       <thead>
         <slot v-if="$slots['thead-top']" name="thead-top" />
         <tr>
-          <th v-if="addSelectableCell">
+          <th
+            v-if="addSelectableCell"
+            class="b-table-selection-column"
+            :class="{
+              'b-table-sticky-column': stickySelectBoolean,
+            }"
+          >
             <slot name="selectHead">
               {{ typeof selectHead === 'boolean' ? 'Selected' : selectHead }}
             </slot>
@@ -66,7 +72,13 @@
           @mouseenter.prevent="onRowMouseEnter(tr, ind, $event)"
           @mouseleave.prevent="onRowMouseLeave(tr, ind, $event)"
         >
-          <td v-if="addSelectableCell">
+          <td
+            v-if="addSelectableCell"
+            class="b-table-selection-column"
+            :class="{
+              'b-table-sticky-column': stickySelectBoolean,
+            }"
+          >
             <slot name="selectCell">
               <span :class="selectedItems.has(tr) ? 'text-primary' : ''">🗹</span>
             </slot>
@@ -156,6 +168,7 @@ interface BTableProps {
   sortDesc?: Booleanish
   sortInternal?: Booleanish
   selectable?: Booleanish
+  stickySelect?: Booleanish
   selectHead?: boolean | string
   selectMode?: 'multi' | 'single' | 'range'
   selectionVariant?: ColorVariant
@@ -177,6 +190,7 @@ const props = withDefaults(defineProps<BTableProps>(), {
   sortDesc: false,
   sortInternal: false,
   selectable: false,
+  stickySelect: false,
   selectHead: true,
   selectMode: 'single',
   selectionVariant: 'primary',
@@ -195,6 +209,7 @@ const sortDescBoolean = useBooleanish(toRef(props, 'sortDesc'))
 const sortInternalBoolean = useBooleanish(toRef(props, 'sortInternal'))
 const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
 const stickyHeaderBoolean = useBooleanish(toRef(props, 'stickyHeader'))
+const stickySelectBoolean = useBooleanish(toRef(props, 'stickySelect'))
 
 interface BTableEmits {
   (

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -166,6 +166,7 @@ interface BTableProps {
   selectHead?: boolean | string
   selectMode?: 'multi' | 'single' | 'range'
   selectionVariant?: ColorVariant
+  stickyHeader?: Booleanish
 }
 
 const props = withDefaults(defineProps<BTableProps>(), {
@@ -186,7 +187,21 @@ const props = withDefaults(defineProps<BTableProps>(), {
   selectHead: true,
   selectMode: 'single',
   selectionVariant: 'primary',
+  stickyHeader: false,
 })
+
+const captionTopBoolean = useBooleanish(toRef(props, 'captionTop'))
+const borderlessBoolean = useBooleanish(toRef(props, 'borderless'))
+const borderedBoolean = useBooleanish(toRef(props, 'bordered'))
+const darkBoolean = useBooleanish(toRef(props, 'dark'))
+const footCloneBoolean = useBooleanish(toRef(props, 'footClone'))
+const hoverBoolean = useBooleanish(toRef(props, 'hover'))
+const smallBoolean = useBooleanish(toRef(props, 'small'))
+const stripedBoolean = useBooleanish(toRef(props, 'striped'))
+const sortDescBoolean = useBooleanish(toRef(props, 'sortDesc'))
+const sortInternalBoolean = useBooleanish(toRef(props, 'sortInternal'))
+const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
+const stickyHeaderBoolean = useBooleanish(toRef(props, 'stickyHeader'))
 
 interface BTableEmits {
   (
@@ -222,20 +237,8 @@ interface BTableEmits {
 const emits = defineEmits<BTableEmits>()
 const slots = useSlots()
 
-const captionTopBoolean = useBooleanish(toRef(props, 'captionTop'))
-const borderlessBoolean = useBooleanish(toRef(props, 'borderless'))
-const borderedBoolean = useBooleanish(toRef(props, 'bordered'))
-const darkBoolean = useBooleanish(toRef(props, 'dark'))
-const footCloneBoolean = useBooleanish(toRef(props, 'footClone'))
-const hoverBoolean = useBooleanish(toRef(props, 'hover'))
-const smallBoolean = useBooleanish(toRef(props, 'small'))
-const stripedBoolean = useBooleanish(toRef(props, 'striped'))
-const sortDescBoolean = useBooleanish(toRef(props, 'sortDesc'))
-const sortInternalBoolean = useBooleanish(toRef(props, 'sortInternal'))
-const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
-
 const classes = computed(() => [
-  'table',
+  'table b-table',
   {
     [`align-${props.align}`]: props.align !== undefined,
     [`table-${props.variant}`]: props.variant !== undefined,
@@ -267,6 +270,7 @@ const computedItems = computed(() =>
 const responsiveClasses = computed(() => ({
   'table-responsive': typeof props.responsive === 'boolean' && props.responsive,
   [`table-responsive-${props.responsive}`]: typeof props.responsive === 'string',
+  'b-table-sticky-header': stickyHeaderBoolean.value,
 }))
 
 const getFieldHeadLabel = (field: TableField) => {

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -51,27 +51,80 @@
   margin: 0;
 }
 
-.b-table-sticky-header > .table.b-table > tbody > tr > .b-table-sticky-column,
-.b-table-sticky-header > .table.b-table > tfoot > tr > .b-table-sticky-column,
-.table-responsive > .table.b-table > tbody > tr > .b-table-sticky-column,
-.table-responsive > .table.b-table > tfoot > tr > .b-table-sticky-column,
-[class*="table-responsive-"] > .table.b-table > tbody > tr > .b-table-sticky-column,
-[class*="table-responsive-"] > .table.b-table > tfoot > tr > .b-table-sticky-column {
-  z-index: 2;
+.b-table-sticky-header,
+.table-responsive,
+[class*="table-responsive-"] {
+  // Move the table bottom margin to the wrapper
+  margin-bottom: $spacer;
+
+  > .table {
+    // Reset `margin-bottom` to we don't get a space after
+    // the table inside the scroll area
+    margin-bottom: 0;
+  }
 }
 
-.b-table-sticky-header > .table.b-table > tbody > tr > .b-table-sticky-column,
-.b-table-sticky-header > .table.b-table > tfoot > tr > .b-table-sticky-column,
-.b-table-sticky-header > .table.b-table > thead > tr > .b-table-sticky-column,
-.table-responsive > .table.b-table > tbody > tr > .b-table-sticky-column,
-.table-responsive > .table.b-table > tfoot > tr > .b-table-sticky-column,
-.table-responsive > .table.b-table > thead > tr > .b-table-sticky-column,
-[class*="table-responsive-"] > .table.b-table > tbody > tr > .b-table-sticky-column,
-[class*="table-responsive-"] > .table.b-table > tfoot > tr > .b-table-sticky-column,
-[class*="table-responsive-"] > .table.b-table > thead > tr > .b-table-sticky-column {
-  position: -webkit-sticky;
-  position: sticky;
-  left: 0;
+.b-table-sticky-header {
+  overflow-y: auto;
+  // Annoyingly, when overflow-y is set, browsers convert
+  // 'overflow-x: visible' to 'overflow-x: auto' - so it becomes
+  // responsive in the x axis automatically
+  // Default `max-height` before a scrollbar will show
+  // We don't use `height` as table could be shorter than this value
+}
+
+@media print {
+  // Override any styles (including inline styles)
+  // when printing
+  .b-table-sticky-header {
+    overflow-y: visible !important;
+    max-height: none !important;
+  }
+}
+
+@supports (position: sticky) {
+  // Positioning of sticky headers
+  .b-table-sticky-header > .table.b-table > thead > tr > th {
+    // Header cells need to be sticky on top
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+
+  // Positioning of sticky columns
+  // Sticky columns only work when table has sticky
+  // headers and/or is responsive
+  .b-table-sticky-header,
+  .table-responsive,
+  [class*="table-responsive-"] {
+    > .table.b-table {
+      > thead,
+      > tbody,
+      > tfoot {
+        > tr > .b-table-sticky-column {
+          position: sticky;
+          left: 0;
+        }
+      }
+
+      > thead {
+        > tr > .b-table-sticky-column {
+          // z-index needs to be higher than sticky columns and
+          // sticky headers for correct layering
+          z-index: 5;
+        }
+      }
+
+      > tbody,
+      > tfoot {
+        > tr > .b-table-sticky-column {
+          // z-index needs to be lower than sticky header that
+          // is also a sticky column
+          z-index: 2;
+        }
+      }
+    }
+  }
 }
 
 .table.b-table > tbody > tr > .table-b-table-default,

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -140,10 +140,31 @@
   }
 }
 
-.table {
+.b-table {
   &.b-table-selectable {
     td {
       cursor: pointer;
+    }
+  }
+
+  &.b-table-busy {
+    position: relative;
+
+    .b-table-busy-slot {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #ffffffa8;
+
+      & > td {
+        border: none;
+        padding: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
feat(BTable): completed the ``TableItem.sticky-column`` prop logic, according to bootstrap-vue2 docs
feat(BTable): added ``sticky-header`` prop feature, according to bootstrap-vue2 docs
feat(BTable): new ``sticky-select`` prop was added, the prop converts the selection column to the sticky mode when the selectable prop is passed as true to the table
feat(BTable): row's ``_showDetails`` prop logic was completed
feat(BTable): added ``busy`` prop logic, the prop shows a spinner and message that can be replaced through a slot template ``#table-busy``
