### PR TITLE
revert(83f5e53): rename to remove 'es' at end

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BAvatar/BAvatar.vue
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/BAvatar.vue
@@ -51,7 +51,7 @@ interface BAvatarProps {
   square?: Booleanish
   src?: string
   text?: string
-  textVariant?: ColorVariant // not standard BootstrapVue props
+  textVariant?: ColorVariant
   variant?: ColorVariant
 }
 

--- a/packages/bootstrap-vue-3/src/components/BCard/BCard.vue
+++ b/packages/bootstrap-vue-3/src/components/BCard/BCard.vue
@@ -4,13 +4,13 @@
     <b-card-header
       v-if="header || $slots.header || headerHtml"
       v-bind="headerAttrs"
-      :class="headerClasses"
+      :class="headerClass"
     >
       <slot name="header">
         {{ header }}
       </slot>
     </b-card-header>
-    <b-card-body v-if="!noBodyBoolean" v-bind="bodyAttrs" :class="bodyClasses">
+    <b-card-body v-if="!noBodyBoolean" v-bind="bodyAttrs" :class="bodyClass">
       <slot>
         {{ bodyText }}
       </slot>
@@ -21,7 +21,7 @@
     <b-card-footer
       v-if="footer || $slots.footer || footerHtml"
       v-bind="footerAttrs"
-      :class="footerClasses"
+      :class="footerClass"
     >
       <slot name="footer">
         {{ footer }}
@@ -45,21 +45,21 @@ interface BCardProps {
   align?: Alignment
   bgVariant?: ColorVariant
   bodyBgVariant?: ColorVariant
-  bodyClasses?: ClassValue
+  bodyClass?: ClassValue
   bodyTag?: string
   bodyTextVariant?: TextColorVariant
   borderVariant?: ColorVariant
   footer?: string
   footerBgVariant?: ColorVariant
   footerBorderVariant?: ColorVariant
-  footerClasses?: ClassValue
+  footerClass?: ClassValue
   footerHtml?: string
   footerTag?: string
   footerTextVariant?: TextColorVariant
   header?: string
   headerBgVariant?: ColorVariant
   headerBorderVariant?: ColorVariant
-  headerClasses?: ClassValue
+  headerClass?: ClassValue
   headerHtml?: string
   headerTag?: string
   headerTextVariant?: TextColorVariant

--- a/packages/bootstrap-vue-3/src/components/BCard/BCard.vue
+++ b/packages/bootstrap-vue-3/src/components/BCard/BCard.vue
@@ -4,13 +4,13 @@
     <b-card-header
       v-if="header || $slots.header || headerHtml"
       v-bind="headerAttrs"
-      :class="headerClass"
+      :class="headerClasses"
     >
       <slot name="header">
         {{ header }}
       </slot>
     </b-card-header>
-    <b-card-body v-if="!noBodyBoolean" v-bind="bodyAttrs" :class="bodyClass">
+    <b-card-body v-if="!noBodyBoolean" v-bind="bodyAttrs" :class="bodyClasses">
       <slot>
         {{ bodyText }}
       </slot>
@@ -21,7 +21,7 @@
     <b-card-footer
       v-if="footer || $slots.footer || footerHtml"
       v-bind="footerAttrs"
-      :class="footerClass"
+      :class="footerClasses"
     >
       <slot name="footer">
         {{ footer }}
@@ -45,21 +45,21 @@ interface BCardProps {
   align?: Alignment
   bgVariant?: ColorVariant
   bodyBgVariant?: ColorVariant
-  bodyClass?: ClassValue
+  bodyClasses?: ClassValue
   bodyTag?: string
   bodyTextVariant?: TextColorVariant
   borderVariant?: ColorVariant
   footer?: string
   footerBgVariant?: ColorVariant
   footerBorderVariant?: ColorVariant
-  footerClass?: ClassValue
+  footerClasses?: ClassValue
   footerHtml?: string
   footerTag?: string
   footerTextVariant?: TextColorVariant
   header?: string
   headerBgVariant?: ColorVariant
   headerBorderVariant?: ColorVariant
-  headerClass?: ClassValue
+  headerClasses?: ClassValue
   headerHtml?: string
   headerTag?: string
   headerTextVariant?: TextColorVariant

--- a/packages/bootstrap-vue-3/src/components/BCard/card.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BCard/card.spec.ts
@@ -190,9 +190,9 @@ describe('card', () => {
     expect($header.exists()).toBe(true)
   })
 
-  it('child BCardHeader is given class of headerClass', () => {
+  it('child BCardHeader is given class of headerClasses', () => {
     const wrapper = mount(BCard, {
-      props: {header: 'foobar', headerClass: ['foobar']},
+      props: {header: 'foobar', headerClasses: ['foobar']},
     })
     const $header = wrapper.getComponent(BCardHeader)
     expect($header.classes()).toContain('foobar')
@@ -325,9 +325,9 @@ describe('card', () => {
     expect(wrapper.text()).toBe('slots')
   })
 
-  it('child BCardBody is given prop bodyClass', () => {
+  it('child BCardBody is given prop bodyClasses', () => {
     const wrapper = mount(BCard, {
-      props: {bodyClass: ['foobar']},
+      props: {bodyClasses: ['foobar']},
     })
     const $body = wrapper.getComponent(BCardBody)
     expect($body.classes()).toContain('foobar')
@@ -435,9 +435,9 @@ describe('card', () => {
     expect($footer.exists()).toBe(true)
   })
 
-  it('child BCardFooter contains class prop footerClass', () => {
+  it('child BCardFooter contains class prop footerClasses', () => {
     const wrapper = mount(BCard, {
-      props: {footer: 'foobar', footerClass: ['foobar']},
+      props: {footer: 'foobar', footerClasses: ['foobar']},
     })
     const $footer = wrapper.getComponent(BCardFooter)
     expect($footer.classes()).toContain('foobar')

--- a/packages/bootstrap-vue-3/src/components/BCard/card.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BCard/card.spec.ts
@@ -190,9 +190,9 @@ describe('card', () => {
     expect($header.exists()).toBe(true)
   })
 
-  it('child BCardHeader is given class of headerClasses', () => {
+  it('child BCardHeader is given class of headerClass', () => {
     const wrapper = mount(BCard, {
-      props: {header: 'foobar', headerClasses: ['foobar']},
+      props: {header: 'foobar', headerClass: ['foobar']},
     })
     const $header = wrapper.getComponent(BCardHeader)
     expect($header.classes()).toContain('foobar')
@@ -325,9 +325,9 @@ describe('card', () => {
     expect(wrapper.text()).toBe('slots')
   })
 
-  it('child BCardBody is given prop bodyClasses', () => {
+  it('child BCardBody is given prop bodyClass', () => {
     const wrapper = mount(BCard, {
-      props: {bodyClasses: ['foobar']},
+      props: {bodyClass: ['foobar']},
     })
     const $body = wrapper.getComponent(BCardBody)
     expect($body.classes()).toContain('foobar')
@@ -435,9 +435,9 @@ describe('card', () => {
     expect($footer.exists()).toBe(true)
   })
 
-  it('child BCardFooter contains class prop footerClasses', () => {
+  it('child BCardFooter contains class prop footerClass', () => {
     const wrapper = mount(BCard, {
-      props: {footer: 'foobar', footerClasses: ['foobar']},
+      props: {footer: 'foobar', footerClass: ['foobar']},
     })
     const $footer = wrapper.getComponent(BCardFooter)
     expect($footer.classes()).toContain('foobar')

--- a/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownGroup.vue
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownGroup.vue
@@ -4,7 +4,7 @@
       :is="headerTag"
       :id="headerId"
       class="dropdown-header"
-      :class="[classes, headerClasses]"
+      :class="[classes, headerClass]"
       :role="headerRole"
     >
       <slot name="header">
@@ -32,14 +32,14 @@ interface BDropdownGroupProps {
   id?: string
   ariaDescribedby?: string
   header?: string
-  headerClasses?: ClassValue
+  headerClass?: ClassValue
   headerTag?: string
   headerVariant?: ColorVariant
 }
 
 const props = withDefaults(defineProps<BDropdownGroupProps>(), {
   headerTag: 'header',
-  headerClasses: undefined,
+  headerClass: undefined,
 })
 
 const headerId = computed<string | undefined>(() =>

--- a/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownGroup.vue
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownGroup.vue
@@ -40,11 +40,10 @@ interface BDropdownGroupProps {
 const props = withDefaults(defineProps<BDropdownGroupProps>(), {
   headerTag: 'header',
   headerClasses: undefined,
-  headerVariant: undefined,
 })
 
 const headerId = computed<string | undefined>(() =>
-  props.id ? [props.id, 'group_dd_header'].join('_') : undefined
+  props.id ? `${props.id}_group_dd_header` : undefined
 )
 
 const headerRole = computed<'heading' | undefined>(() =>
@@ -52,7 +51,7 @@ const headerRole = computed<'heading' | undefined>(() =>
 )
 
 const classes = computed(() => ({
-  [`text-${props.headerVariant}`]: !!props.headerVariant,
+  [`text-${props.headerVariant}`]: props.headerVariant !== undefined,
 }))
 </script>
 

--- a/packages/bootstrap-vue-3/src/components/BDropdown/dropdown-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/dropdown-group.spec.ts
@@ -1,0 +1,170 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
+import BDropdownGroup from './BDropdownGroup.vue'
+
+describe('dropdown-form', () => {
+  enableAutoUnmount(afterEach)
+
+  it('is tag li', () => {
+    const wrapper = mount(BDropdownGroup)
+    expect(wrapper.element.tagName).toBe('LI')
+  })
+
+  it('has static attr role to be presentation', () => {
+    const wrapper = mount(BDropdownGroup)
+    expect(wrapper.attributes('role')).toBe('presentation')
+  })
+
+  it('has ul child', () => {
+    const wrapper = mount(BDropdownGroup)
+    const $ul = wrapper.find('ul')
+    expect($ul.exists()).toBe(true)
+  })
+
+  it('ul child has static attr role to be group', () => {
+    const wrapper = mount(BDropdownGroup)
+    const $ul = wrapper.get('ul')
+    expect($ul.attributes('role')).toBe('group')
+  })
+
+  it('ul child has static class list-unstyled', () => {
+    const wrapper = mount(BDropdownGroup)
+    const $ul = wrapper.get('ul')
+    expect($ul.classes()).toContain('list-unstyled')
+  })
+
+  it('ul child has id when prop id', async () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {id: 'foobar'},
+    })
+    const $ul = wrapper.get('ul')
+    expect($ul.attributes('id')).toBe('foobar')
+    await wrapper.setProps({id: undefined})
+    expect($ul.attributes('id')).toBeUndefined()
+  })
+
+  it('ul child has attr aria-describedby to be prop ariaDescribedby', async () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {ariaDescribedby: 'foobar'},
+    })
+    const $ul = wrapper.get('ul')
+    expect($ul.attributes('aria-describedby')).toBe('foobar')
+    await wrapper.setProps({ariaDescribedby: undefined})
+    expect($ul.attributes('aria-describedby')).toBeUndefined()
+  })
+
+  it('ul child has attr aria-describedby to be prop id when not ariaDescribedby', async () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {id: 'foobar'},
+    })
+    const $ul = wrapper.get('ul')
+    expect($ul.attributes('aria-describedby')).toBe('foobar_group_dd_header')
+    await wrapper.setProps({id: undefined})
+    expect($ul.attributes('aria-describedby')).toBeUndefined()
+  })
+
+  it('ul child has attr aria-describedby to prefer ariaDescribedby instead of id', () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {id: 'id', ariaDescribedby: 'aria'},
+    })
+    const $ul = wrapper.get('ul')
+    expect($ul.attributes('aria-describedby')).toBe('aria')
+  })
+
+  it('ul child renders default slot', () => {
+    const wrapper = mount(BDropdownGroup, {
+      slots: {default: 'foobar'},
+    })
+    const $ul = wrapper.get('ul')
+    expect($ul.text()).toBe('foobar')
+  })
+
+  it('has dynamic component whos tag is default header', () => {
+    const wrapper = mount(BDropdownGroup)
+    const $header = wrapper.find('header')
+    expect($header.exists()).toBe(true)
+  })
+
+  it('has dynamic component is prop headerTag', () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {headerTag: 'h1'},
+    })
+    const $header = wrapper.find('header')
+    const $h1 = wrapper.find('h1')
+    expect($header.exists()).toBe(false)
+    expect($h1.exists()).toBe(true)
+  })
+
+  it('dynamic header tag has attr id to be prop id', async () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {id: 'foobar'},
+    })
+    const $header = wrapper.get('header')
+    expect($header.attributes('id')).toBe('foobar_group_dd_header')
+    await wrapper.setProps({id: undefined})
+    expect($header.attributes('id')).toBeUndefined()
+  })
+
+  it('dynamic header tag has static class dropdown-header', () => {
+    const wrapper = mount(BDropdownGroup)
+    const $header = wrapper.get('header')
+    expect($header.classes()).toContain('dropdown-header')
+  })
+
+  it('dynamic header tag has class to include prop headerClasses', () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {headerClasses: ['foo']},
+    })
+    const $header = wrapper.get('header')
+    expect($header.classes()).toContain('foo')
+  })
+
+  it('dynamic header tag has class text-{type} when prop headerVariant', async () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {headerVariant: 'danger'},
+    })
+    const $header = wrapper.get('header')
+    expect($header.classes()).toContain('text-danger')
+    await wrapper.setProps({headerVariant: undefined})
+    expect($header.classes()).not.toContain('text-danger')
+  })
+
+  it('dynamic header tag has role to be undefined when tag is header', () => {
+    const wrapper = mount(BDropdownGroup)
+    const $header = wrapper.get('header')
+    expect($header.attributes('role')).toBeUndefined()
+  })
+
+  it('dynamic header tag has role to be heading when tag is not header', () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {headerTag: 'h1'},
+    })
+    const $h1 = wrapper.get('h1')
+    expect($h1.attributes('role')).toBe('heading')
+  })
+
+  it('dynamic header tag renders slot header', () => {
+    const wrapper = mount(BDropdownGroup, {
+      slots: {header: 'foobar'},
+    })
+    const $header = wrapper.get('header')
+    expect($header.text()).toBe('foobar')
+  })
+
+  it('dynamic header tag renders prop header', () => {
+    const wrapper = mount(BDropdownGroup, {
+      props: {header: 'foobar'},
+    })
+    const $header = wrapper.get('header')
+    expect($header.text()).toBe('foobar')
+  })
+
+  it('dynamic header tag renders slot header over prop header', () => {
+    const wrapper = mount(BDropdownGroup, {
+      slots: {header: 'slots'},
+      props: {header: 'props'},
+    })
+    const $header = wrapper.get('header')
+    expect($header.text()).toBe('slots')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BDropdown/dropdown-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/dropdown-group.spec.ts
@@ -111,9 +111,9 @@ describe('dropdown-form', () => {
     expect($header.classes()).toContain('dropdown-header')
   })
 
-  it('dynamic header tag has class to include prop headerClasses', () => {
+  it('dynamic header tag has class to include prop headerClass', () => {
     const wrapper = mount(BDropdownGroup, {
-      props: {headerClasses: ['foo']},
+      props: {headerClass: ['foo']},
     })
     const $header = wrapper.get('header')
     expect($header.classes()).toContain('foo')

--- a/packages/bootstrap-vue-3/src/components/BImg.vue
+++ b/packages/bootstrap-vue-3/src/components/BImg.vue
@@ -74,6 +74,7 @@ const makeBlankImgSrc = (width: any, height: any, color: string): string => {
 }
 
 const attrs = computed(() => {
+  // TODO decompose this and make business logic into separate computed functions
   let {src} = props
   let width =
     (typeof props.width === 'number' ? props.width : parseInt(props.width as string, 10)) ||
@@ -109,6 +110,7 @@ const attrs = computed(() => {
       height = 1
     }
     // Make a blank SVG image
+    // TODO unexpected mutation of props
     src = makeBlankImgSrc(width, height, props.blankColor || 'transparent')
     // Disable srcset and sizes
     srcset = ''

--- a/packages/bootstrap-vue-3/src/components/BTable/BTableContainer.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTableContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="responsive" :class="responsiveClasses">
+  <div v-if="responsive" :class="responsiveClass">
     <slot />
   </div>
   <template v-else>
@@ -12,7 +12,7 @@ import type {ClassValue} from '../../types'
 
 interface BTableContainerProps {
   responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
-  responsiveClasses?: ClassValue
+  responsiveClass?: ClassValue
 }
 
 withDefaults(defineProps<BTableContainerProps>(), {

--- a/packages/bootstrap-vue-3/src/composables/useBooleanish.ts
+++ b/packages/bootstrap-vue-3/src/composables/useBooleanish.ts
@@ -2,6 +2,8 @@ import type {Booleanish} from '../types'
 import {computed, ComputedRef, Ref} from 'vue'
 import {resolveBooleanish} from '../utils'
 
+// function useBooleanish<T>(el: Ref<Booleanish | T>): ComputedRef<boolean | T>
+// This may possibily be used in Vue 3.3 to include Booleanish and complex types ie Booleanish | string
 function useBooleanish(el: Ref<Booleanish>): ComputedRef<boolean>
 function useBooleanish(el: Ref<Booleanish | undefined>): ComputedRef<boolean | undefined>
 function useBooleanish(


### PR DESCRIPTION
# Describe the PR

[revert(](https://github.com/cdmoro/bootstrap-vue-3/commit/3c721260160970fe3898b196ae6365a67745828e)https://github.com/cdmoro/bootstrap-vue-3/commit/83f5e53bbd5686fc426681523105c0252986bc62[): rename to remove 'es' at end](https://github.com/cdmoro/bootstrap-vue-3/commit/3c721260160970fe3898b196ae6365a67745828e) 

Though it may make more sense to include 'es' at the end, (since it can contain many classes), it is more standard to exclude the 'es'

chore(BImg): add some notes about TODOs

chore(useBooleanish): add note about future Vue code possibilities

fix(BTableContainer): rename prop responsiveClasses to responsiveClass

fix(BDropdownGroup): rename headerClasses prop to headerClass

chore(BAvatar): remove old note

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type**
