### PR TITLE
fix(composables): Spread out children from Fragment slots

### DIFF
--- a/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
+++ b/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
@@ -84,6 +84,8 @@ const getGroupClasses = (items: {
     [`btn-group-${items.size}`]: items.size,
   }))
 
+// TODO this function is similarly used in BTabs and may be capable of being a util function
+// Investigate if it can be done to reduce complexity
 /**
  * @param slots
  * @param nodeType

--- a/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
+++ b/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
@@ -92,9 +92,9 @@ const getGroupClasses = (items: {
  */
 const slotsToElements = (slots: Array<any>, nodeType: string, disabled: boolean) =>
   slots
-    .reduce((acc: Array<any>, slot: any) => slot.type.name === 'Symbol(Fragment)' ?
+    .reduce((acc: Array<any>, slot: any) => slot.type.toString() === 'Symbol(Fragment)' ?
         acc.concat(slot.children) : acc.concat([slot]), [])
-    .filter((e: any) => e.type.name === nodeType)
+    .filter((e: any) => (e.type.__name || e.type.name) === nodeType)
     .map((e: any) => {
       const txtChild = (e.children.default ? e.children.default() : []).find(
         (e: any) => e.type.toString() === 'Symbol(Text)'

--- a/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
+++ b/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
@@ -92,6 +92,8 @@ const getGroupClasses = (items: {
  */
 const slotsToElements = (slots: Array<any>, nodeType: string, disabled: boolean) =>
   slots
+    .reduce((acc: Array<any>, slot: any) => slot.type.name === 'Symbol(Fragment)' ?
+        acc.concat(...slot.children) : acc.concat([slot]), [])
     .filter((e: any) => e.type.name === nodeType)
     .map((e: any) => {
       const txtChild = (e.children.default ? e.children.default() : []).find(

--- a/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
+++ b/packages/bootstrap-vue-3/src/composables/useFormCheck.ts
@@ -93,7 +93,7 @@ const getGroupClasses = (items: {
 const slotsToElements = (slots: Array<any>, nodeType: string, disabled: boolean) =>
   slots
     .reduce((acc: Array<any>, slot: any) => slot.type.name === 'Symbol(Fragment)' ?
-        acc.concat(...slot.children) : acc.concat([slot]), [])
+        acc.concat(slot.children) : acc.concat([slot]), [])
     .filter((e: any) => e.type.name === nodeType)
     .map((e: any) => {
       const txtChild = (e.children.default ? e.children.default() : []).find(


### PR DESCRIPTION
# Describe the PR

Vue3 introduced the concept of Fragments, which allow placing multiple elements as roots of a component, but also they're used to group elements iterated through in a `v-for` directive.

For example, when we write
```vue
<template>
    <b-form-radio-group>
        <b-form-radio v-for="option in options" :value="option">
            {{ option }}
        </b-form-radio>
    </b-form-radio-group>
</template>
<script>
export default {
    computed: {
        options() {
            return [ 1, 2, 3 ];
        }
    }
}
</script>
```

it compiles (roughly) to:
```json
{
  "type": "Symbol(Fragment)",
  "children": [
    {
      "type": {
        "__name": "BFormRadio"
      }
    },
    {
      "type": {
        "__name": "BFormRadio"
      }
    },
    {
      "type": {
        "__name": "BFormRadio"
      }
    }
  ]
}
```

So this PR makes the conversion of slots into elements recognise that, if we have fragments like this in the slots, we need to spread out the children so that they are rendered as well, otherwise they will be filtered out by the `.filter()` chain that disregards all nodes that are not of the expected type.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type**
