### PR TITLE
test: various tests and refactor and include html-self-closing rule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,9 @@
 
 A clear and concise description of what the pull request does.
 
-_This can be a copy/paste of all **Conventional Commits** messages_
+## Small replication
+
+If the change is large enough, a small replication can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.
 
 ## PR checklist
 

--- a/packages/bootstrap-vue-3/src/components/BAvatar/BAvatar.vue
+++ b/packages/bootstrap-vue-3/src/components/BAvatar/BAvatar.vue
@@ -18,7 +18,7 @@
     </span>
 
     <span v-if="showBadge" class="b-avatar-badge" :class="badgeClasses" :style="badgeStyle">
-      <slot v-if="hasBadgeSlot" name="badge"></slot>
+      <slot v-if="hasBadgeSlot" name="badge" />
       <span v-else :class="badgeTextClasses">{{ badgeText }}</span>
     </span>
   </component>

--- a/packages/bootstrap-vue-3/src/components/BFormTags/BFormTag.vue
+++ b/packages/bootstrap-vue-3/src/components/BFormTags/BFormTag.vue
@@ -22,7 +22,7 @@
       :aria-controls="id"
       :aria-describedby="taglabelId"
       @click="emit('remove', tagText)"
-    ></button>
+    />
   </component>
 </template>
 

--- a/packages/bootstrap-vue-3/src/components/BFormTextarea/BFormTextarea.vue
+++ b/packages/bootstrap-vue-3/src/components/BFormTextarea/BFormTextarea.vue
@@ -19,7 +19,7 @@
     @input="onInput($event)"
     @change="onChange($event)"
     @blur="onBlur($event)"
-  ></textarea>
+  />
 </template>
 
 <script lang="ts">

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroup.vue
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroup.vue
@@ -2,9 +2,9 @@
   <component :is="tag" :id="id" class="input-group" :class="classes" role="group">
     <slot name="prepend">
       <span v-if="hasPrepend" class="input-group-text">
-        <span v-if="!showPrependHtml">{{ prepend }}</span>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <span v-if="showPrependHtml" v-html="prependHtml"></span>
+        <span v-if="!!prependHtml" v-html="prependHtml" />
+        <span v-else>{{ prepend }}</span>
       </span>
     </slot>
 
@@ -12,9 +12,9 @@
 
     <slot name="append">
       <span v-if="hasAppend" class="input-group-text">
-        <span v-if="!showAppendHtml">{{ append }}</span>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <span v-if="showAppendHtml" v-html="appendHtml"></span>
+        <span v-if="!!appendHtml" v-html="appendHtml" />
+        <span v-else>{{ append }}</span>
       </span>
     </slot>
   </component>
@@ -38,6 +38,8 @@ const props = withDefaults(defineProps<BInputGroupProps>(), {
   tag: 'div',
 })
 
+// TODO size md does not seem to do anything. Consider adding
+// Exclude<InputSize, 'md'> to props
 const classes = computed(() => ({
   'input-group-sm': props.size === 'sm',
   'input-group-lg': props.size === 'lg',
@@ -45,6 +47,4 @@ const classes = computed(() => ({
 
 const hasAppend = computed<boolean>(() => !!props.append || !!props.appendHtml)
 const hasPrepend = computed<boolean>(() => !!props.prepend || !!props.prependHtml)
-const showAppendHtml = computed<boolean>(() => !!props.appendHtml)
-const showPrependHtml = computed<boolean>(() => !!props.prependHtml)
 </script>

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroupAppend.vue
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroupAppend.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-input-group-addon :id="id" :is-text="isTextBoolean" :tag="tag" append>
+  <b-input-group-addon v-bind="computedAttrs">
     <slot />
   </b-input-group-addon>
 </template>
@@ -7,8 +7,7 @@
 <script setup lang="ts">
 // import type {BInputGroupAppendProps} from '../../types/components'
 import BInputGroupAddon from './BInputGroupAddon.vue'
-import {toRef} from 'vue'
-import {useBooleanish} from '../../composables'
+import {computed} from 'vue'
 import type {Booleanish} from '../../types'
 
 interface BInputGroupAppendProps {
@@ -22,5 +21,10 @@ const props = withDefaults(defineProps<BInputGroupAppendProps>(), {
   isText: false,
 })
 
-const isTextBoolean = useBooleanish(toRef(props, 'isText'))
+const computedAttrs = computed(() => ({
+  id: props.id,
+  isText: props.isText,
+  tag: props.tag,
+  append: true,
+}))
 </script>

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroupPrepend.vue
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroupPrepend.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-input-group-addon :id="id" :is-text="isTextBoolean" :tag="tag" :append="false">
+  <b-input-group-addon v-bind="computedAttrs">
     <slot />
   </b-input-group-addon>
 </template>
@@ -7,8 +7,7 @@
 <script setup lang="ts">
 // import type {BInputGroupPrependProps} from '../../types/components'
 import BInputGroupAddon from './BInputGroupAddon.vue'
-import {toRef} from 'vue'
-import {useBooleanish} from '../../composables'
+import {computed} from 'vue'
 import type {Booleanish} from '../../types'
 
 interface BInputGroupPrependProps {
@@ -22,5 +21,10 @@ const props = withDefaults(defineProps<BInputGroupPrependProps>(), {
   isText: false,
 })
 
-const isTextBoolean = useBooleanish(toRef(props, 'isText'))
+const computedAttrs = computed(() => ({
+  id: props.id,
+  isText: props.isText,
+  tag: props.tag,
+  append: false,
+}))
 </script>

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroupText.vue
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/BInputGroupText.vue
@@ -1,6 +1,8 @@
 <template>
   <component :is="tag" class="input-group-text">
-    <slot />
+    <slot>
+      {{ text }}
+    </slot>
   </component>
 </template>
 
@@ -9,6 +11,7 @@
 
 interface BInputGroupTextProps {
   tag?: string
+  text?: string
 }
 
 withDefaults(defineProps<BInputGroupTextProps>(), {

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/input-group-addon.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/input-group-addon.spec.ts
@@ -1,0 +1,80 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BInputGroupAddon from './BInputGroupAddon.vue'
+import BInputGroupText from './BInputGroupText.vue'
+import {afterEach, describe, expect, it} from 'vitest'
+
+describe('input-group-addon', () => {
+  enableAutoUnmount(afterEach)
+
+  it('tag is div by default', () => {
+    const wrapper = mount(BInputGroupAddon)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('tag is prop tag', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('has attr id when prop id', async () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {id: 'foobar'},
+    })
+    expect(wrapper.attributes('id')).toBe('foobar')
+    await wrapper.setProps({id: 'bar'})
+    expect(wrapper.attributes('id')).toBe('bar')
+  })
+
+  it('has static class d-flex', () => {
+    const wrapper = mount(BInputGroupAddon)
+    expect(wrapper.classes()).toContain('d-flex')
+  })
+
+  it('has class input-group-append when prop append', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {append: true},
+    })
+    expect(wrapper.classes()).toContain('input-group-append')
+  })
+
+  it('has class input-group-prepend when prop append is false', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {append: false},
+    })
+    expect(wrapper.classes()).toContain('input-group-prepend')
+  })
+
+  it('has BInputGroupText when prop isText', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {isText: true},
+    })
+    const $inputgrouptext = wrapper.findComponent(BInputGroupText)
+    expect($inputgrouptext.exists()).toBe(true)
+  })
+
+  it('does not have BInputGroupText when prop not isText', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {isText: false},
+    })
+    const $inputgrouptext = wrapper.findComponent(BInputGroupText)
+    expect($inputgrouptext.exists()).toBe(false)
+  })
+
+  it('BInputGroupText renders default slot', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      props: {isText: true},
+      slots: {default: 'foobar'},
+    })
+    const $inputgrouptext = wrapper.getComponent(BInputGroupText)
+    expect($inputgrouptext.text()).toBe('foobar')
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BInputGroupAddon, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/input-group-append.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/input-group-append.spec.ts
@@ -1,0 +1,50 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BInputGroupAppend from './BInputGroupAppend.vue'
+import BInputGroupAddon from './BInputGroupAddon.vue'
+import {afterEach, describe, expect, it} from 'vitest'
+
+describe('input-group-append', () => {
+  enableAutoUnmount(afterEach)
+
+  it('child is BInputGroupAddon', () => {
+    const wrapper = mount(BInputGroupAppend)
+    const $inputgroupaddon = wrapper.findComponent(BInputGroupAddon)
+    expect($inputgroupaddon.exists()).toBe(true)
+  })
+
+  it('BInputGroupAddon is given prop id', async () => {
+    const wrapper = mount(BInputGroupAppend, {
+      props: {id: 'foobar'},
+    })
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('id')).toBe('foobar')
+    await wrapper.setProps({id: 'foo'})
+    expect($inputgroupaddon.props('id')).toBe('foo')
+  })
+
+  it('BInputGroupAddon is given prop isText', async () => {
+    const wrapper = mount(BInputGroupAppend, {
+      props: {isText: true},
+    })
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('isText')).toBe(true)
+    await wrapper.setProps({isText: false})
+    expect($inputgroupaddon.props('isText')).toBe(false)
+  })
+
+  it('BInputGroupAddon is given prop tag', async () => {
+    const wrapper = mount(BInputGroupAppend, {
+      props: {tag: 'span'},
+    })
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('tag')).toBe('span')
+    await wrapper.setProps({tag: 'div'})
+    expect($inputgroupaddon.props('tag')).toBe('div')
+  })
+
+  it('BInputGroupAddon is given prop append to be true', () => {
+    const wrapper = mount(BInputGroupAppend)
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('append')).toBe(true)
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/input-group-text.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/input-group-text.spec.ts
@@ -1,0 +1,46 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BInputGroupText from './BInputGroupText.vue'
+import {afterEach, describe, expect, it} from 'vitest'
+
+describe('input-group-text', () => {
+  enableAutoUnmount(afterEach)
+
+  it('tag is div by default', () => {
+    const wrapper = mount(BInputGroupText)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('tag is prop tag', () => {
+    const wrapper = mount(BInputGroupText, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('has static class input-group-text', () => {
+    const wrapper = mount(BInputGroupText)
+    expect(wrapper.classes()).toContain('input-group-text')
+  })
+
+  it('renders default slot', () => {
+    const wrapper = mount(BInputGroupText, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+
+  it('renders prop text', () => {
+    const wrapper = mount(BInputGroupText, {
+      props: {text: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+
+  it('renders default slot over prop text', () => {
+    const wrapper = mount(BInputGroupText, {
+      slots: {default: 'slots'},
+      props: {text: 'props'},
+    })
+    expect(wrapper.text()).toBe('slots')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/input-group.prepend.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/input-group.prepend.spec.ts
@@ -1,0 +1,50 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BInputGroupPrepend from './BInputGroupPrepend.vue'
+import BInputGroupAddon from './BInputGroupAddon.vue'
+import {afterEach, describe, expect, it} from 'vitest'
+
+describe('input-group-prepend', () => {
+  enableAutoUnmount(afterEach)
+
+  it('child is BInputGroupAddon', () => {
+    const wrapper = mount(BInputGroupPrepend)
+    const $inputgroupaddon = wrapper.findComponent(BInputGroupAddon)
+    expect($inputgroupaddon.exists()).toBe(true)
+  })
+
+  it('BInputGroupAddon is given prop id', async () => {
+    const wrapper = mount(BInputGroupPrepend, {
+      props: {id: 'foobar'},
+    })
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('id')).toBe('foobar')
+    await wrapper.setProps({id: 'foo'})
+    expect($inputgroupaddon.props('id')).toBe('foo')
+  })
+
+  it('BInputGroupAddon is given prop isText', async () => {
+    const wrapper = mount(BInputGroupPrepend, {
+      props: {isText: true},
+    })
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('isText')).toBe(true)
+    await wrapper.setProps({isText: false})
+    expect($inputgroupaddon.props('isText')).toBe(false)
+  })
+
+  it('BInputGroupAddon is given prop tag', async () => {
+    const wrapper = mount(BInputGroupPrepend, {
+      props: {tag: 'span'},
+    })
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('tag')).toBe('span')
+    await wrapper.setProps({tag: 'div'})
+    expect($inputgroupaddon.props('tag')).toBe('div')
+  })
+
+  it('BInputGroupAddon is given prop append to be false', () => {
+    const wrapper = mount(BInputGroupPrepend)
+    const $inputgroupaddon = wrapper.getComponent(BInputGroupAddon)
+    expect($inputgroupaddon.props('append')).toBe(false)
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BInputGroup/input-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BInputGroup/input-group.spec.ts
@@ -1,0 +1,278 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BInputGroup from './BInputGroup.vue'
+import {afterEach, describe, expect, it} from 'vitest'
+
+describe('input-group', () => {
+  enableAutoUnmount(afterEach)
+
+  it('tag is div by default', () => {
+    const wrapper = mount(BInputGroup)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('tag is prop tag', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('has static class input-group', () => {
+    const wrapper = mount(BInputGroup)
+    expect(wrapper.classes()).toContain('input-group')
+  })
+
+  it('has static attr role to be group', () => {
+    const wrapper = mount(BInputGroup)
+    expect(wrapper.attributes('role')).toBe('group')
+  })
+
+  it('has attr id to be prop id', async () => {
+    const wrapper = mount(BInputGroup, {
+      props: {id: 'foobar'},
+    })
+    expect(wrapper.attributes('id')).toBe('foobar')
+    await wrapper.setProps({id: 'foo'})
+    expect(wrapper.attributes('id')).toBe('foo')
+  })
+
+  it('has class input-group-sm when prop size is sm', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {size: 'sm'},
+    })
+    expect(wrapper.classes()).toContain('input-group-sm')
+  })
+
+  it('has class input-group-lg when prop size is lg', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {size: 'lg'},
+    })
+    expect(wrapper.classes()).toContain('input-group-lg')
+  })
+
+  it('renders slot prepend', () => {
+    const wrapper = mount(BInputGroup, {
+      slots: {prepend: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+
+  it('renders slot append', () => {
+    const wrapper = mount(BInputGroup, {
+      slots: {append: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+
+  it('renders default', () => {
+    const wrapper = mount(BInputGroup, {
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.text()).toBe('foobar')
+  })
+
+  it('renders in correct order', () => {
+    const wrapper = mount(BInputGroup, {
+      slots: {prepend: 'prepend', default: 'default', append: 'append'},
+    })
+    expect(wrapper.text()).toBe('prependdefaultappend')
+  })
+
+  it('has child span if prop prepend', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prepend: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(true)
+  })
+
+  it('child span has static class input-group-text', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prepend: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    expect($span.classes()).toContain('input-group-text')
+  })
+
+  it('child span has an additional span element', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prepend: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.find('span')
+    expect($nested.exists()).toBe(true)
+  })
+
+  it('child span further child span element renders prop prepend', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prepend: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    expect($nested.text()).toBe('foobar')
+  })
+
+  it('has child span element when prop prependHtml', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prependHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(true)
+  })
+
+  it('has child span has further child span when prop prependHtml', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prependHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.find('span')
+    expect($nested.exists()).toBe(true)
+  })
+
+  it('has child span has further child renders html', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prependHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    const $h1 = $nested.find('h1')
+    expect($h1.exists()).toBe(true)
+  })
+
+  it('has child span has further child renders html text', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prependHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    const $h1 = $nested.get('h1')
+    expect($h1.text()).toBe('foobar')
+  })
+
+  it('child span prefers to render prop prependHtml over prepend', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prependHtml: '<h1>html</h1>', prepend: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    expect($nested.text()).toBe('html')
+  })
+
+  it('does not have child span if prop prepend, but also slot prepend', () => {
+    // May break if a span element is ever non v-if on the element
+    const wrapper = mount(BInputGroup, {
+      props: {prepend: 'foobar'},
+      slots: {prepend: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(false)
+  })
+
+  it('does not have child span if prop append, but also slot append', () => {
+    // May break if a span element is ever non v-if on the element
+    const wrapper = mount(BInputGroup, {
+      props: {append: 'foobar'},
+      slots: {append: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(false)
+  })
+
+  it('has child span if prop append', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {append: 'foobar'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(true)
+  })
+
+  it('child span has static class input-group-text', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {append: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    expect($span.classes()).toContain('input-group-text')
+  })
+
+  it('child span has an additional span element', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {append: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.find('span')
+    expect($nested.exists()).toBe(true)
+  })
+
+  it('child span further child span element renders prop append', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {append: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    expect($nested.text()).toBe('foobar')
+  })
+
+  it('has child span element when prop appendHtml', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {appendHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.find('span')
+    expect($span.exists()).toBe(true)
+  })
+
+  it('has child span has further child span when prop appendHtml', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {appendHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.find('span')
+    expect($nested.exists()).toBe(true)
+  })
+
+  it('has child span has further child renders html', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {appendHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    const $h1 = $nested.find('h1')
+    expect($h1.exists()).toBe(true)
+  })
+
+  it('has child span has further child renders html text', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {appendHtml: '<h1>foobar</h1>'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    const $h1 = $nested.get('h1')
+    expect($h1.text()).toBe('foobar')
+  })
+
+  it('child span prefers to render prop appendHtml over append', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {appendHtml: '<h1>html</h1>', append: 'foobar'},
+    })
+    const $span = wrapper.get('span')
+    const $nested = $span.get('span')
+    expect($nested.text()).toBe('html')
+  })
+
+  it('prop prepend prop append and slot default render in correct order', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prepend: 'prepend', append: 'append'},
+      slots: {default: 'default'},
+    })
+    expect(wrapper.text()).toBe('prependdefaultappend')
+  })
+
+  it('prop prependHtml prop appendHtml and slot default render in correct order', () => {
+    const wrapper = mount(BInputGroup, {
+      props: {prependHtml: 'prepend', appendHtml: 'append'},
+      slots: {default: 'default'},
+    })
+    expect(wrapper.text()).toBe('prependdefaultappend')
+  })
+
+  // TODO root component is finished, do internals
+})

--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -25,7 +25,7 @@
               data-bs-dismiss="modal"
               :aria-label="headerCloseLabel"
             >
-              <slot name="header-close"></slot>
+              <slot name="header-close" />
             </button>
           </div>
           <div class="modal-body" :class="computedBodyClasses">
@@ -62,7 +62,7 @@
         v-if="hideBackdropBoolean === false"
         class="modal-backdrop fade show"
         @click.prevent="noCloseOnBackdropBoolean === false && hide()"
-      ></div>
+      />
     </div>
   </teleport>
 </template>

--- a/packages/bootstrap-vue-3/src/components/BProgress/BProgress.vue
+++ b/packages/bootstrap-vue-3/src/components/BProgress/BProgress.vue
@@ -1,18 +1,7 @@
 <template>
   <div class="progress" :style="{height}">
     <slot>
-      <b-progress-bar
-        v-bind="{
-          animated: animatedBoolean,
-          max,
-          precision,
-          showProgress: showProgressBoolean,
-          showValue: showValueBoolean,
-          striped: stripedBoolean,
-          value,
-          variant,
-        }"
-      />
+      <b-progress-bar v-bind="computedAttrs" />
     </slot>
   </div>
 </template>
@@ -22,7 +11,7 @@
 import BProgressBar from './BProgressBar.vue'
 import type {Booleanish, ColorVariant} from '../../types'
 import {useBooleanish} from '../../composables'
-import {InjectionKey, provide, toRef} from 'vue'
+import {computed, InjectionKey, provide, toRef} from 'vue'
 
 interface BProgressProps {
   variant?: ColorVariant
@@ -49,6 +38,17 @@ const animatedBoolean = useBooleanish(toRef(props, 'animated'))
 const showProgressBoolean = useBooleanish(toRef(props, 'showProgress'))
 const showValueBoolean = useBooleanish(toRef(props, 'showValue'))
 const stripedBoolean = useBooleanish(toRef(props, 'striped'))
+
+const computedAttrs = computed(() => ({
+  animated: animatedBoolean.value,
+  max: props.max,
+  precision: props.precision,
+  showProgress: showProgressBoolean.value,
+  showValue: showValueBoolean.value,
+  striped: stripedBoolean.value,
+  value: props.value,
+  variant: props.variant,
+}))
 
 // TODO check and see if doing animatedBoolean.value is reactive for provide
 // It may be possible that a toRef() is required for these types of systems.

--- a/packages/bootstrap-vue-3/src/components/BProgress/progress.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BProgress/progress.spec.ts
@@ -1,0 +1,120 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BProgress from './BProgress.vue'
+import BProgressBar from './BProgressBar.vue'
+import {afterEach, describe, expect, it} from 'vitest'
+
+describe('progress', () => {
+  enableAutoUnmount(afterEach)
+
+  it('tag is div', () => {
+    const wrapper = mount(BProgress)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('has static class progress', () => {
+    const wrapper = mount(BProgress)
+    expect(wrapper.classes()).toContain('progress')
+  })
+
+  // TODO this does not work for some reason
+  it.skip('has style to be prop height', async () => {
+    const wrapper = mount(BProgress, {
+      props: {height: '100'},
+    })
+    expect(wrapper.attributes('style')).toContain('height: 100')
+  })
+
+  it('has BProgressBar in slot by default', () => {
+    const wrapper = mount(BProgress)
+    const $progressbar = wrapper.findComponent(BProgressBar)
+    expect($progressbar.exists()).toBe(true)
+  })
+
+  it('does not have BProgressBar when default slot', () => {
+    const wrapper = mount(BProgress, {
+      slots: {default: 'foobar'},
+    })
+    const $progressbar = wrapper.findComponent(BProgressBar)
+    expect($progressbar.exists()).toBe(false)
+  })
+
+  it('BProgressBar has prop animated to be prop animated', async () => {
+    const wrapper = mount(BProgress, {
+      props: {animated: true},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('animated')).toBe(true)
+    await wrapper.setProps({animated: false})
+    expect($progressbar.props('animated')).toBe(false)
+  })
+
+  it('BProgressBar has prop max to be prop max', async () => {
+    const wrapper = mount(BProgress, {
+      props: {max: '50'},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('max')).toBe('50')
+    await wrapper.setProps({max: '20'})
+    expect($progressbar.props('max')).toBe('20')
+  })
+
+  it('BProgressBar has prop precision to be prop precision', async () => {
+    const wrapper = mount(BProgress, {
+      props: {precision: '50'},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('precision')).toBe('50')
+    await wrapper.setProps({precision: '20'})
+    expect($progressbar.props('precision')).toBe('20')
+  })
+
+  it('BProgressBar has prop showProgress to be prop showProgress', async () => {
+    const wrapper = mount(BProgress, {
+      props: {showProgress: true},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('showProgress')).toBe(true)
+    await wrapper.setProps({showProgress: false})
+    expect($progressbar.props('showProgress')).toBe(false)
+  })
+
+  it('BProgressBar has prop showValue to be prop showValue', async () => {
+    const wrapper = mount(BProgress, {
+      props: {showValue: true},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('showValue')).toBe(true)
+    await wrapper.setProps({showValue: false})
+    expect($progressbar.props('showValue')).toBe(false)
+  })
+
+  it('BProgressBar has prop striped to be prop striped', async () => {
+    const wrapper = mount(BProgress, {
+      props: {striped: true},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('striped')).toBe(true)
+    await wrapper.setProps({striped: false})
+    expect($progressbar.props('striped')).toBe(false)
+  })
+
+  it('BProgressBar has prop value to be prop value', async () => {
+    const wrapper = mount(BProgress, {
+      props: {value: '50'},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('value')).toBe('50')
+    await wrapper.setProps({value: '20'})
+    expect($progressbar.props('value')).toBe('20')
+  })
+
+  it('BProgressBar has prop variant to be prop variant', async () => {
+    const wrapper = mount(BProgress, {
+      props: {variant: 'danger'},
+    })
+    const $progressbar = wrapper.getComponent(BProgressBar)
+    expect($progressbar.props('variant')).toBe('danger')
+    await wrapper.setProps({variant: 'secondary'})
+    expect($progressbar.props('variant')).toBe('secondary')
+  })
+})

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -113,7 +113,7 @@
           <td :colspan="computedFieldsTotal">
             <slot name="table-busy">
               <div class="d-flex align-items-center justify-content-center gap-2">
-                <b-spinner class="align-middle"></b-spinner>
+                <b-spinner class="align-middle" />
                 <strong>Loading...</strong>
               </div>
             </slot>

--- a/packages/eslint-config-custom/index.cjs
+++ b/packages/eslint-config-custom/index.cjs
@@ -66,5 +66,17 @@ module.exports = {
     'yoda': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
     'vue/require-default-prop': 'off',
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          void: 'always',
+          normal: 'always',
+          component: 'always',
+        },
+        svg: 'always',
+        math: 'always',
+      },
+    ],
   },
 }


### PR DESCRIPTION
# Describe the PR

[refactor(BInputGroup): change order of template](https://github.com/cdmoro/bootstrap-vue-3/commit/2fa30b1fbe59c43afe27c6bb7659d11bf3cd78ca) 

test: input-group.spec.ts

chore(eslint): introduce 'vue/html-self-closing' rule

docs: small change to pull_request_template

[refactor(BInputGroupAppend): move attrs](https://github.com/cdmoro/bootstrap-vue-3/commit/c3ba8e4fec28e019016f4d1db01795d12a2ebe25) 

refactor(BInputGroupPrepend): move attrs

feat(BInputGroupText): add optional text prop

refactor(BProgress): move attrs out of template

test: progress.spec.ts

test: input-group-addon.spec.ts

test: input-group-append.spec.ts

test: input-group-text.spec.ts

test: input-group-prepend.spec.ts

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [x] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type**
