### PR TITLE
feat(b-dropdown-item): :sparkles: Bind class attribute to the root

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownItem.vue
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li role="presentation">
+  <li role="presentation" :class="$attrs.class">
     <component
       :is="tag"
       class="dropdown-item"

--- a/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/BDropdownItemButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <li role="presentation">
+  <li role="presentation" :class="$attrs.class">
     <!-- Should click be click.prevent ? -->
     <button
       role="menu"


### PR DESCRIPTION
# Describe the PR

In [bootstrap vue](https://github.com/bootstrap-vue/bootstrap-vue/blob/fab4161c90ad6e178b16540f15928f52149cdba3/src/components/dropdown/dropdown-item.js#L64) it was handled to bind classes to `b-dropdown-item` and `b-dropdown-item-button`  and I have added it now.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature - `feat(...)`
