### PR TITLE
BTable: added slot "custom-foot"

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -144,6 +144,9 @@
           </th>
         </tr>
       </tfoot>
+      <tfoot v-else-if="$slots['custom-foot']">
+        <slot name="custom-foot" :fields="computedFields" :items="items" :columns="computedFields?.length"></slot>
+      </tfoot>
       <caption v-if="$slots['table-caption']">
         <slot name="table-caption" />
       </caption>


### PR DESCRIPTION
Added slot "custom-foot" to BTable in order to improve compatibility with [bootstrap-vue](https://bootstrap-vue.org/docs/components/table#creating-a-custom-footer) 