### PR TITLE
Possible fix for close button in the top right of modal to emit an update to v-model value.

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -269,6 +269,10 @@ const modalShowed = (e: Event) => {
 
 const modalHided = (e: Event) => {
   emit('hidden', e)
+  
+  if (modelValueBoolean.value) {
+    emit('update:modelValue', false)
+  }
 
   if (lazyBoolean.value === true) lazyLoadCompleted.value = false
 }

--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -269,10 +269,6 @@ const modalShowed = (e: Event) => {
 
 const modalHided = (e: Event) => {
   emit('hidden', e)
-  
-  if (modelValueBoolean.value) {
-    emit('update:modelValue', false)
-  }
 
   if (lazyBoolean.value === true) lazyLoadCompleted.value = false
 }
@@ -283,6 +279,10 @@ const modalShow = (e: Event) => {
 
 const modalHide = (e: Event) => {
   emit('hide', e)
+  
+  if (modelValueBoolean.value) {
+    emit('update:modelValue', false)
+  }
 }
 
 const show = () => {


### PR DESCRIPTION
This is a possible fix for #657: The close button in the top right of <BModal> does not emit an update to v-model value.