### PR TITLE
BModal header's close button not updating v-model value

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -24,6 +24,7 @@
               :class="computedCloseButtonClasses"
               data-bs-dismiss="modal"
               :aria-label="headerCloseLabel"
+              @click="hide()"
             >
               <slot name="header-close" />
             </button>
@@ -282,12 +283,12 @@ const modalHide = (e: Event) => {
 }
 
 const show = () => {
-  emit('update:modelValue', true)
+  if (modelValueBoolean.value) emit('update:modelValue', true)
   getInstance().show()
 }
 
 const hide = () => {
-  emit('update:modelValue', false)
+  if (modelValueBoolean.value) emit('update:modelValue', false)
   getInstance().hide()
 }
 


### PR DESCRIPTION
This issue mentioned in https://github.com/cdmoro/bootstrap-vue-3/pull/658
He was correct in the second comment https://github.com/cdmoro/bootstrap-vue-3/pull/658#issuecomment-1245293371 
The close event should be fired through vue's click handler, Events should never depend on Bootstrap's event callbacks in such matter since we can't fully control the events coming from Bootstrap

BEGIN_COMMIT_OVERRIDE
fix(BModal): fixed the modal's close button located in the header where the button click was not updating ``v-model`` value
END_COMMIT_OVERRIDE

