### PR TITLE
BTable customizable sort icon, and show-empty prop

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -27,10 +27,19 @@
             @click="headerClicked(field, $event)"
           >
             <div class="d-inline-flex flex-nowrap align-items-center gap-1">
-              <span
-                v-if="isSortable && field.sortable && field.key === sortBy"
-                class="b-table-sort-icon text-muted small"
-              />
+              <slot
+                name="sortIcon"
+                :field="field"
+                :sort-by="sortBy"
+                :selected="field.key === sortBy"
+                :is-desc="sortDescBoolean"
+                :direction="sortDescBoolean ? 'desc' : 'asc'"
+              >
+                <span
+                  v-if="isSortable && field.sortable && field.key === sortBy"
+                  class="b-table-sort-icon text-muted small"
+                />
+              </slot>
               <div>
                 <slot
                   v-if="$slots['head(' + field.key + ')'] || $slots['head()']"

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -132,6 +132,17 @@
             </slot>
           </td>
         </tr>
+        <tr v-if="showEmptyBoolean && computedItems.length === 0" class="b-table-empty-slot">
+          <td :colspan="computedFieldsTotal">
+            <slot name="empty" :items="computedItems" :filtered="isFilterableTable">
+              {{
+                isFilterableTable
+                  ? 'There are no records matching your request'
+                  : 'There are no records to show'
+              }}
+            </slot>
+          </td>
+        </tr>
       </tbody>
       <tfoot v-if="footCloneBoolean">
         <tr>
@@ -215,6 +226,7 @@ interface BTableProps {
   selectionVariant?: ColorVariant
   stickyHeader?: Booleanish
   busy?: Booleanish
+  showEmpty?: Booleanish
   perPage?: number
   currentPage?: number
   filter?: string
@@ -242,6 +254,7 @@ const props = withDefaults(defineProps<BTableProps>(), {
   selectionVariant: 'primary',
   stickyHeader: false,
   busy: false,
+  showEmpty: false,
   currentPage: 1,
 })
 
@@ -259,6 +272,7 @@ const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
 const stickyHeaderBoolean = useBooleanish(toRef(props, 'stickyHeader'))
 const stickySelectBoolean = useBooleanish(toRef(props, 'stickySelect'))
 const busyBoolean = useBooleanish(toRef(props, 'busy'))
+const showEmptyBoolean = useBooleanish(toRef(props, 'showEmpty'))
 
 interface BTableEmits {
   (

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -135,11 +135,7 @@
         <tr v-if="showEmptyBoolean && computedItems.length === 0" class="b-table-empty-slot">
           <td :colspan="computedFieldsTotal">
             <slot name="empty" :items="computedItems" :filtered="isFilterableTable">
-              {{
-                isFilterableTable
-                  ? 'There are no records matching your request'
-                  : 'There are no records to show'
-              }}
+              {{ isFilterableTable ? emptyFilteredText : emptyText }}
             </slot>
           </td>
         </tr>
@@ -231,6 +227,8 @@ interface BTableProps {
   currentPage?: number
   filter?: string
   filterable?: string[]
+  emptyText?: string
+  emptyFilteredText?: string
 }
 
 const props = withDefaults(defineProps<BTableProps>(), {
@@ -256,6 +254,8 @@ const props = withDefaults(defineProps<BTableProps>(), {
   busy: false,
   showEmpty: false,
   currentPage: 1,
+  emptyText: 'There are no records to show',
+  emptyFilteredText: 'There are no records matching your request',
 })
 
 const captionTopBoolean = useBooleanish(toRef(props, 'captionTop'))
@@ -343,7 +343,7 @@ const computedFieldsTotal = computed(
   () => computedFields.value.length + (selectableBoolean.value ? 1 : 0)
 )
 
-const isFilterableTable = computed(() => props.filter !== undefined)
+const isFilterableTable = computed(() => props.filter !== undefined && props.filter !== '')
 
 const requireItemsMapping = computed(() => isSortable.value && sortInternalBoolean.value === true)
 const computedItems = computed(() =>


### PR DESCRIPTION
feat(BTable): added ``sortIcon`` slot, the slot allows you to customize the table's sort icons by providing you some info about the applied sort
feat(BTable): added ``show-empty`` prop along with the ``#empty`` slot to customize the empty message
feat(BTable): added ``emptyText`` and ``emptyFilteredText`` props to customize the shown message when the table is empty and ``show-empty`` prop is set to true