### PR TITLE
A possible solution for BModal escape-key close event

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -1,7 +1,7 @@
 <template>
   <teleport to="body">
     <div
-      :id="elementId"
+      :id="computedId"
       ref="element"
       class="modal"
       :class="modalClasses"
@@ -79,9 +79,8 @@
 // import type {BModalEmits, BModalProps} from '../types/components'
 import {Modal} from 'bootstrap'
 import {computed, nextTick, onMounted, ref, toRef, useSlots, watch} from 'vue'
-import {useBooleanish, useEventListener} from '../composables'
+import {useBooleanish, useEventListener, useId} from '../composables'
 import type {Booleanish, ColorVariant, InputSize} from '../types'
-import {getId} from './../utils'
 import BButton from './BButton/BButton.vue'
 
 interface BModalProps {
@@ -184,8 +183,7 @@ const titleSrOnlyBoolean = useBooleanish(toRef(props, 'titleSrOnly'))
 
 const lazyLoadCompleted = ref(false)
 
-const bsId = ref(getId('bmodal'))
-const elementId = computed(() => props.id ?? bsId.value)
+const computedId = useId(toRef(props, 'id'), 'modal')
 
 interface BModalEmits {
   (e: 'update:modelValue', value: boolean): void

--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -1,6 +1,13 @@
 <template>
   <teleport to="body">
-    <div :id="id" ref="element" class="modal" :class="modalClasses" tabindex="-1" v-bind="$attrs">
+    <div
+      :id="elementId"
+      ref="element"
+      class="modal"
+      :class="modalClasses"
+      tabindex="-1"
+      v-bind="$attrs"
+    >
       <div class="modal-dialog" :class="modalDialogClasses">
         <div
           v-if="
@@ -74,6 +81,7 @@ import {Modal} from 'bootstrap'
 import {computed, nextTick, onMounted, ref, toRef, useSlots, watch} from 'vue'
 import {useBooleanish, useEventListener} from '../composables'
 import type {Booleanish, ColorVariant, InputSize} from '../types'
+import {getId} from './../utils'
 import BButton from './BButton/BButton.vue'
 
 interface BModalProps {
@@ -176,6 +184,9 @@ const titleSrOnlyBoolean = useBooleanish(toRef(props, 'titleSrOnly'))
 
 const lazyLoadCompleted = ref(false)
 
+const bsId = ref(getId('bmodal'))
+const elementId = computed(() => props.id ?? bsId.value)
+
 interface BModalEmits {
   (e: 'update:modelValue', value: boolean): void
   (e: 'show', value: Event): void
@@ -266,12 +277,20 @@ const modalShowed = (e: Event) => {
   emit('shown', e)
 
   if (lazyBoolean.value === true) lazyLoadCompleted.value = true
+  if (modelValueBoolean.value === false) emit('update:modelValue', true)
+  ;(e.target as HTMLElement).focus()
 }
 
 const modalHided = (e: Event) => {
   emit('hidden', e)
 
   if (lazyBoolean.value === true) lazyLoadCompleted.value = false
+  if (modelValueBoolean.value === true) emit('update:modelValue', false)
+
+  const parentModal = document.querySelector('.modal')
+  if (parentModal) {
+    ;(parentModal as HTMLElement).focus()
+  }
 }
 
 const modalShow = (e: Event) => {


### PR DESCRIPTION
PR for issue https://github.com/cdmoro/bootstrap-vue-3/issues/674
____
I have tried my best to make the events vue-based only but it was not working out smoothly. that's the best result I've got so far.
This PR will fix the issue and also make sure escape-key closing works fine with nested modals since bootstrap's modal does not really support multiple/nested modal instances

example of working code
```vue
<div>
      <b-button @click="showModal = true">Show Modal</b-button>

      <b-modal v-model="showModal" id="my-modal">
        Hello From My Modal!

        <b-button @click="showNestedModal = true">Show Modal</b-button>

        <b-modal v-model="showNestedModal" id="my-modal">Hello From Nested Modal!</b-modal>
      </b-modal>
    </div>
```