### PR TITLE
fix: scoped slots docs now work when clicked on

### DIFF
--- a/apps/docs/docs/.vuepress/PluginComponentReference/client/components/component-doc.vue
+++ b/apps/docs/docs/.vuepress/PluginComponentReference/client/components/component-doc.vue
@@ -107,7 +107,7 @@
             class="py-0"
             @click="toggleDetails()"
           >
-          {{item}}
+          {{ detailsShowing ? 'Hide scope' : 'Show scope' }}
           </b-button>
         </template>
         <template #row-details="{ item }">
@@ -143,7 +143,7 @@
   </div>
 </template>
 <script lang="ts">
-import {resolveComponent, defineComponent, computed, ComputedRef, ConcreteComponent} from 'vue'
+import {resolveComponent, defineComponent, computed, ComputedRef, ConcreteComponent, ref, Ref} from 'vue'
 import AnchoredHeading from './anchored-heading'
 import {hyphenate} from '../../../utils'
 // type definitions
@@ -315,9 +315,10 @@ export default defineComponent({
       ]
     })
 
-    const slotsItems: ComputedRef<any> = computed(() => {
-      return props.slots ? props.slots.map(slot => ({ ...slot as any})) : []
-    })
+    const slotsItems: Ref<any[]> = ref(
+       props.slots ? props.slots.map(slot => ({ ...slot as any})) : []
+    )
+
 
     const vmodelItems: ComputedRef<any> = computed(() => {
       //TODO loop through props and emits to determine v-model


### PR DESCRIPTION
# Describe the PR

Small fix regarding docs. 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type**

BEGIN_COMMIT_OVERRIDE
docs: scoped slots docs now work when clicked on

END_COMMIT_OVERRIDE