### PR TITLE
Fix renamed bootstrap 5 utilities classes

### DIFF
--- a/apps/docs/docs/components/ButtonToolbar.md
+++ b/apps/docs/docs/components/ButtonToolbar.md
@@ -52,12 +52,12 @@
   <b-card>
     <div>
       <b-button-toolbar aria-label="Toolbar with button groups and input groups">
-        <b-button-group size="sm" class="mr-1">
+        <b-button-group size="sm" class="me-1">
           <b-button>Save</b-button>
           <b-button>Cancel</b-button>
         </b-button-group>
         <b-input-group size="sm" prepend="$" append=".00">
-          <b-form-input value="100" class="text-right"></b-form-input>
+          <b-form-input value="100" class="text-end"></b-form-input>
         </b-input-group>
       </b-button-toolbar>
     </div>
@@ -67,12 +67,12 @@
 ```html
 <div>
   <b-button-toolbar aria-label="Toolbar with button groups and input groups">
-    <b-button-group size="sm" class="mr-1">
+    <b-button-group size="sm" class="me-1">
       <b-button>Save</b-button>
       <b-button>Cancel</b-button>
     </b-button-group>
     <b-input-group size="sm" prepend="$" append=".00">
-      <b-form-input value="100" class="text-right"></b-form-input>
+      <b-form-input value="100" class="text-end"></b-form-input>
     </b-input-group>
   </b-button-toolbar>
 </div>

--- a/apps/docs/docs/components/Form.md
+++ b/apps/docs/docs/components/Form.md
@@ -172,7 +172,7 @@ visitors with class `.visually-hidden`.
         <div class="col-lg-3">
           <b-form-input
             id="inline-form-input-name"
-            class="mb-2 mr-sm-2 mb-sm-0"
+            class="mb-2 me-sm-2 mb-sm-0"
             placeholder="Jane Doe"
           ></b-form-input>
         </div>
@@ -180,11 +180,11 @@ visitors with class `.visually-hidden`.
           >Username</label
         >
         <div class="col-lg-3">
-          <b-input-group prepend="@" class="col-lg-4 mb-2 mr-sm-2 mb-sm-0">
+          <b-input-group prepend="@" class="col-lg-4 mb-2 me-sm-2 mb-sm-0">
             <b-form-input id="inline-form-input-username" placeholder="Username"></b-form-input>
           </b-input-group>
         </div>
-        <b-form-checkbox class="col-form-label col-lg-2 mb-2 mr-sm-2 mb-sm-0"
+        <b-form-checkbox class="col-form-label col-lg-2 mb-2 me-sm-2 mb-sm-0"
           >Remember me</b-form-checkbox
         >
         <div class="col-lg-1">
@@ -205,7 +205,7 @@ visitors with class `.visually-hidden`.
         <div class="col-lg-3">
           <b-form-input
             id="inline-form-input-name"
-            class="mb-2 mr-sm-2 mb-sm-0"
+            class="mb-2 me-sm-2 mb-sm-0"
             placeholder="Jane Doe"
           ></b-form-input>
         </div>
@@ -213,11 +213,11 @@ visitors with class `.visually-hidden`.
           >Username</label
         >
         <div class="col-lg-3">
-          <b-input-group prepend="@" class="col-lg-4 mb-2 mr-sm-2 mb-sm-0">
+          <b-input-group prepend="@" class="col-lg-4 mb-2 me-sm-2 mb-sm-0">
             <b-form-input id="inline-form-input-username" placeholder="Username"></b-form-input>
           </b-input-group>
         </div>
-        <b-form-checkbox class="col-form-label col-lg-2 mb-2 mr-sm-2 mb-sm-0"
+        <b-form-checkbox class="col-form-label col-lg-2 mb-2 me-sm-2 mb-sm-0"
           >Remember me</b-form-checkbox
         >
         <div class="col-lg-1">
@@ -236,18 +236,18 @@ Custom form controls and selects are also supported.
   <div>
     <b-form>
       <div class="row">
-        <label class="col-form-label col-lg-2 mr-sm-2" for="inline-form-custom-select-pref"
+        <label class="col-form-label col-lg-2 me-sm-2" for="inline-form-custom-select-pref"
           >Preference</label
         >
         <div class="col-lg-2">
           <b-form-select
             id="inline-form-custom-select-pref"
-            class="mb-2 mr-sm-2 mb-sm-0"
+            class="mb-2 me-sm-2 mb-sm-0"
             :options="[{ text: 'Choose...', value: null }, 'One', 'Two', 'Three']"
             :value="null"
           ></b-form-select>
         </div>
-        <b-form-checkbox class="col-form-label col-lg-3 mb-2 mr-sm-2 mb-sm-0"
+        <b-form-checkbox class="col-form-label col-lg-3 mb-2 me-sm-2 mb-sm-0"
           >Remember my preference</b-form-checkbox
         >
         <div class="col-lg-2 col-form-label">
@@ -264,18 +264,18 @@ Custom form controls and selects are also supported.
   <div>
     <b-form>
       <div class="row">
-        <label class="col-form-label col-lg-2 mr-sm-2" for="inline-form-custom-select-pref"
+        <label class="col-form-label col-lg-2 me-sm-2" for="inline-form-custom-select-pref"
           >Preference</label
         >
         <div class="col-lg-2">
           <b-form-select
             id="inline-form-custom-select-pref"
-            class="mb-2 mr-sm-2 mb-sm-0"
+            class="mb-2 me-sm-2 mb-sm-0"
             :options="[{ text: 'Choose...', value: null }, 'One', 'Two', 'Three']"
             :value="null"
           ></b-form-select>
         </div>
-        <b-form-checkbox class="col-form-label col-lg-3 mb-2 mr-sm-2 mb-sm-0"
+        <b-form-checkbox class="col-form-label col-lg-3 mb-2 me-sm-2 mb-sm-0"
           >Remember my preference</b-form-checkbox
         >
         <div class="col-lg-2 col-form-label">

--- a/apps/docs/docs/components/FormTags.md
+++ b/apps/docs/docs/components/FormTags.md
@@ -418,8 +418,8 @@ The following example includes the suggested ARIA attributes and roles needed fo
           :key="tag"
           :id="`my-custom-tags-tag_${tag.replace(/\s/g, '_')}_`"
           tag="li"
-          class="mt-1 mr-1"
-          body-class="py-1 pr-2 text-nowrap"
+          class="mt-1 me-1"
+          body-class="py-1 pe-2 text-nowrap"
         >
           <strong>{{ tag }}</strong>
           <b-button
@@ -464,8 +464,8 @@ The following example includes the suggested ARIA attributes and roles needed fo
           :key="tag"
           :id="`my-custom-tags-tag_${tag.replace(/\s/g, '_')}_`"
           tag="li"
-          class="mt-1 mr-1"
-          body-class="py-1 pr-2 text-nowrap"
+          class="mt-1 me-1"
+          body-class="py-1 pe-2 text-nowrap"
         >
           <strong>{{ tag }}</strong>
           <b-button
@@ -515,7 +515,7 @@ In this example, we are using the [`<b-form-tag>` helper component](#b-form-tag-
         :key="tag"
         :title="tag"
         :variant="tagVariant"
-        class="mr-1"
+        class="me-1"
       >{{ tag }}</b-form-tag>
     </div>
   </template>
@@ -544,7 +544,7 @@ In this example, we are using the [`<b-form-tag>` helper component](#b-form-tag-
           :key="tag"
           :title="tag"
           :variant="tagVariant"
-          class="mr-1"
+          class="me-1"
           >{{ tag }}</b-form-tag
         >
       </div>
@@ -707,7 +707,7 @@ Duplicate tag value cannot be added again!
   <ul v-if="tags.length > 0" class="mb-0">
     <li v-for="tag in tags" :key="tag" :title="`Tag: ${tag}`" class="mt-2">
       <span  class="d-flex align-items-center">
-        <span class="mr-2">{{ tag }}</span>
+        <span class="me-2">{{ tag }}</span>
         <b-button
           :disabled="disabled"
           size="sm"
@@ -759,7 +759,7 @@ Duplicate tag value cannot be added again!
       <ul v-if="tags.length > 0" class="mb-0">
         <li v-for="tag in tags" :key="tag" :title="`Tag: ${tag}`" class="mt-2">
           <span class="d-flex align-items-center">
-            <span class="mr-2">{{ tag }}</span>
+            <span class="me-2">{{ tag }}</span>
             <b-button
               :disabled="disabled"
               size="sm"

--- a/apps/docs/docs/components/InputGroup.md
+++ b/apps/docs/docs/components/InputGroup.md
@@ -260,7 +260,7 @@ the addon:
     <div>
       <b-input-group class="mb-2">
         <b-input-group-prepend is-text>
-          <b-form-checkbox class="mr-n2">
+          <b-form-checkbox class="me-n2">
             <span class="visually-hidden">Checkbox for following text input</span>
           </b-form-checkbox>
         </b-input-group-prepend>
@@ -268,7 +268,7 @@ the addon:
       </b-input-group>
       <b-input-group class="mb-2">
         <b-input-group-prepend is-text>
-          <b-form-radio class="mr-n2">
+          <b-form-radio class="me-n2">
             <span class="visually-hidden">Radio for following text input</span>
           </b-form-radio>
         </b-input-group-prepend>
@@ -276,7 +276,7 @@ the addon:
       </b-input-group>
       <b-input-group>
         <b-input-group-prepend is-text>
-          <b-form-checkbox switch class="mr-n2">
+          <b-form-checkbox switch class="me-n2">
             <span class="visually-hidden">Switch for following text input</span>
           </b-form-checkbox>
         </b-input-group-prepend>
@@ -290,7 +290,7 @@ the addon:
 <div>
   <b-input-group class="mb-2">
     <b-input-group-prepend is-text>
-      <b-form-checkbox class="mr-n2">
+      <b-form-checkbox class="me-n2">
         <span class="visually-hidden">Checkbox for following text input</span>
       </b-form-checkbox>
     </b-input-group-prepend>
@@ -298,7 +298,7 @@ the addon:
   </b-input-group>
   <b-input-group class="mb-2">
     <b-input-group-prepend is-text>
-      <b-form-radio class="mr-n2">
+      <b-form-radio class="me-n2">
         <span class="visually-hidden">Radio for following text input</span>
       </b-form-radio>
     </b-input-group-prepend>
@@ -306,7 +306,7 @@ the addon:
   </b-input-group>
   <b-input-group>
     <b-input-group-prepend is-text>
-      <b-form-checkbox switch class="mr-n2">
+      <b-form-checkbox switch class="me-n2">
         <span class="visually-hidden">Switch for following text input</span>
       </b-form-checkbox>
     </b-input-group-prepend>
@@ -317,7 +317,7 @@ the addon:
 
 In the above example, we have used the `.visually-hidden` class on a `<span>` to visually hide the custom
 control's label content (while making them still accessible to screen reader users), and used the
-utility class `.mr-n2` to add a negative right margin to compensate for the "gutter" space between
+utility class `.me-n2` to add a negative right margin to compensate for the "gutter" space between
 the control and the hidden label.
 
 ## Multiple inputs
@@ -471,7 +471,7 @@ required to make everything fit correctly, depending on the size chosen:
       <b-input-group size="sm" prepend="Small" class="mb-2">
         <b-form-input aria-label="Small text input with custom switch"></b-form-input>
         <b-input-group-append is-text>
-        <b-form-checkbox switch class="mr-n2 mb-n1">
+        <b-form-checkbox switch class="me-n2 mb-n1">
             <span class="visually-hidden">Checkbox for previous text input</span>
         </b-form-checkbox>
         </b-input-group-append>
@@ -479,7 +479,7 @@ required to make everything fit correctly, depending on the size chosen:
       <b-input-group size="lg" prepend="Large" class="mb-2">
         <b-form-input aria-label="Large text input with switch"></b-form-input>
         <b-input-group-append is-text>
-          <b-form-checkbox switch class="mr-n2">
+          <b-form-checkbox switch class="me-n2">
             <span class="visually-hidden">Switch for previous text input</span>
           </b-form-checkbox>
         </b-input-group-append>
@@ -493,7 +493,7 @@ required to make everything fit correctly, depending on the size chosen:
   <b-input-group size="sm" prepend="Small" class="mb-2">
     <b-form-input aria-label="Small text input with custom switch"></b-form-input>
     <b-input-group-append is-text>
-      <b-form-checkbox switch class="mr-n2 mb-n1">
+      <b-form-checkbox switch class="me-n2 mb-n1">
         <span class="visually-hidden">Checkbox for previous text input</span>
       </b-form-checkbox>
     </b-input-group-append>
@@ -501,7 +501,7 @@ required to make everything fit correctly, depending on the size chosen:
   <b-input-group size="lg" prepend="Large" class="mb-2">
     <b-form-input aria-label="Large text input with switch"></b-form-input>
     <b-input-group-append is-text>
-      <b-form-checkbox switch class="mr-n2">
+      <b-form-checkbox switch class="me-n2">
         <span class="visually-hidden">Switch for previous text input</span>
       </b-form-checkbox>
     </b-input-group-append>

--- a/apps/docs/docs/components/Overlay.md
+++ b/apps/docs/docs/components/Overlay.md
@@ -511,7 +511,7 @@ relative positioning (either via the utility class `'position-relative'`, or CSS
 <ClientOnly>
   <b-card>
     <div class="position-relative p-4 bg-info">
-      <p class="text-light font-weight-bold">
+      <p class="text-light fw-bold">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </p>
       <b-card title="Card with parent overlay">
@@ -521,7 +521,7 @@ relative positioning (either via the utility class `'position-relative'`, or CSS
           Show overlay
         </b-button>
       </b-card>
-      <p class="text-light font-weight-bold mb-0">
+      <p class="text-light fw-bold mb-0">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </p>
       <b-overlay :show="showNoWrapEx" no-wrap>
@@ -535,7 +535,7 @@ relative positioning (either via the utility class `'position-relative'`, or CSS
 <template>
   <b-card>
     <div class="position-relative p-4 bg-info">
-      <p class="text-light font-weight-bold">
+      <p class="text-light fw-bold">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </p>
       <b-card title="Card with parent overlay">
@@ -545,7 +545,7 @@ relative positioning (either via the utility class `'position-relative'`, or CSS
           Show overlay
         </b-button>
       </b-card>
-      <p class="text-light font-weight-bold mb-0">
+      <p class="text-light fw-bold mb-0">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       </p>
       <b-overlay :show="showNoWrapEx" no-wrap> </b-overlay>
@@ -803,7 +803,7 @@ This example also demonstrates additional accessibility markup.
           >
             <p><strong id="form-confirm-label">Are you sure?</strong></p>
             <div class="d-flex"  style="column-gap: 5%;">
-              <b-button variant="outline-danger" class="mr-3" @click="onFormCancel">
+              <b-button variant="outline-danger" class="me-3" @click="onFormCancel">
                 Cancel
               </b-button>
               <b-button variant="outline-success" @click="onFormOK">OK</b-button>
@@ -855,7 +855,7 @@ This example also demonstrates additional accessibility markup.
           >
             <p><strong id="form-confirm-label">Are you sure?</strong></p>
             <div class="d-flex" style="column-gap: 5%;">
-              <b-button variant="outline-danger" class="mr-3" @click="onFormCancel">
+              <b-button variant="outline-danger" class="me-3" @click="onFormCancel">
                 Cancel
               </b-button>
               <b-button variant="outline-success" @click="onFormOK">OK</b-button>

--- a/apps/docs/docs/components/Table.md
+++ b/apps/docs/docs/components/Table.md
@@ -39,7 +39,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
       <b-tbody>
         <b-tr>
           <b-th rowspan="3">Belgium</b-th>
-          <b-th class="text-right">Antwerp</b-th>
+          <b-th class="text-end">Antwerp</b-th>
           <b-td>56</b-td>
           <b-td>22</b-td>
           <b-td>43</b-td>
@@ -47,7 +47,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
           <b-td>23</b-td>
         </b-tr>
         <b-tr>
-          <b-th class="text-right">Gent</b-th>
+          <b-th class="text-end">Gent</b-th>
           <b-td>46</b-td>
           <b-td variant="warning">18</b-td>
           <b-td>50</b-td>
@@ -55,7 +55,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
           <b-td variant="danger">15</b-td>
         </b-tr>
         <b-tr>
-          <b-th class="text-right">Brussels</b-th>
+          <b-th class="text-end">Brussels</b-th>
           <b-td>51</b-td>
           <b-td>27</b-td>
           <b-td>38</b-td>
@@ -64,7 +64,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
         </b-tr>
         <b-tr>
           <b-th rowspan="2">The Netherlands</b-th>
-          <b-th class="text-right">Amsterdam</b-th>
+          <b-th class="text-end">Amsterdam</b-th>
           <b-td variant="success">89</b-td>
           <b-td>34</b-td>
           <b-td>69</b-td>
@@ -72,7 +72,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
           <b-td>38</b-td>
         </b-tr>
         <b-tr>
-          <b-th class="text-right">Utrecht</b-th>
+          <b-th class="text-end">Utrecht</b-th>
           <b-td>80</b-td>
           <b-td variant="danger">12</b-td>
           <b-td>43</b-td>
@@ -82,7 +82,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
       </b-tbody>
       <b-tfoot>
         <b-tr>
-          <b-td colspan="7" variant="secondary" class="text-right">
+          <b-td colspan="7" variant="secondary" class="text-end">
             Total Rows: <b>5</b>
           </b-td>
         </b-tr>
@@ -127,7 +127,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
   <b-tbody>
     <b-tr>
       <b-th rowspan="3">Belgium</b-th>
-      <b-th class="text-right">Antwerp</b-th>
+      <b-th class="text-end">Antwerp</b-th>
       <b-td>56</b-td>
       <b-td>22</b-td>
       <b-td>43</b-td>
@@ -135,7 +135,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
       <b-td>23</b-td>
     </b-tr>
     <b-tr>
-      <b-th class="text-right">Gent</b-th>
+      <b-th class="text-end">Gent</b-th>
       <b-td>46</b-td>
       <b-td variant="warning">18</b-td>
       <b-td>50</b-td>
@@ -143,7 +143,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
       <b-td variant="danger">15</b-td>
     </b-tr>
     <b-tr>
-      <b-th class="text-right">Brussels</b-th>
+      <b-th class="text-end">Brussels</b-th>
       <b-td>51</b-td>
       <b-td>27</b-td>
       <b-td>38</b-td>
@@ -152,7 +152,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
     </b-tr>
     <b-tr>
       <b-th rowspan="2">The Netherlands</b-th>
-      <b-th class="text-right">Amsterdam</b-th>
+      <b-th class="text-end">Amsterdam</b-th>
       <b-td variant="success">89</b-td>
       <b-td>34</b-td>
       <b-td>69</b-td>
@@ -160,7 +160,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
       <b-td>38</b-td>
     </b-tr>
     <b-tr>
-      <b-th class="text-right">Utrecht</b-th>
+      <b-th class="text-end">Utrecht</b-th>
       <b-td>80</b-td>
       <b-td variant="danger">12</b-td>
       <b-td>43</b-td>
@@ -170,7 +170,7 @@ Since b-table-simple is just a wrapper component, of which you will need to rend
   </b-tbody>
   <b-tfoot>
     <b-tr>
-      <b-td colspan="7" variant="secondary" class="text-right"> Total Rows: <b>5</b> </b-td>
+      <b-td colspan="7" variant="secondary" class="text-end"> Total Rows: <b>5</b> </b-td>
     </b-tr>
   </b-tfoot>
 </b-table-simple>
@@ -211,7 +211,7 @@ Here is the same table as above, set to be always stacked, which has the extra m
       <b-tbody>
         <b-tr>
           <b-th rowspan="3" class="text-center">Belgium (3 Cities)</b-th>
-          <b-th stacked-heading="City" class="text-left">Antwerp</b-th>
+          <b-th stacked-heading="City" class="text-start">Antwerp</b-th>
           <b-td stacked-heading="Clothes: Trousers">56</b-td>
           <b-td stacked-heading="Clothes: Skirts">22</b-td>
           <b-td stacked-heading="Clothes: Dresses">43</b-td>
@@ -254,7 +254,7 @@ Here is the same table as above, set to be always stacked, which has the extra m
       </b-tbody>
       <b-tfoot>
         <b-tr>
-          <b-td colspan="7" variant="secondary" class="text-right">
+          <b-td colspan="7" variant="secondary" class="text-end">
             Total Rows: <b>5</b>
           </b-td>
         </b-tr>
@@ -299,7 +299,7 @@ Here is the same table as above, set to be always stacked, which has the extra m
   <b-tbody>
     <b-tr>
       <b-th rowspan="3" class="text-center">Belgium (3 Cities)</b-th>
-      <b-th stacked-heading="City" class="text-left">Antwerp</b-th>
+      <b-th stacked-heading="City" class="text-start">Antwerp</b-th>
       <b-td stacked-heading="Clothes: Trousers">56</b-td>
       <b-td stacked-heading="Clothes: Skirts">22</b-td>
       <b-td stacked-heading="Clothes: Dresses">43</b-td>
@@ -342,7 +342,7 @@ Here is the same table as above, set to be always stacked, which has the extra m
   </b-tbody>
   <b-tfoot>
     <b-tr>
-      <b-td colspan="7" variant="secondary" class="text-right"> Total Rows: <b>5</b> </b-td>
+      <b-td colspan="7" variant="secondary" class="text-end"> Total Rows: <b>5</b> </b-td>
     </b-tr>
   </b-tfoot>
 </b-table-simple>

--- a/apps/docs/docs/components/Tabs.md
+++ b/apps/docs/docs/components/Tabs.md
@@ -374,8 +374,8 @@ To apply classes to the currently active control or tab use the `active-nav-item
 <ClientOnly>
   <b-card no-body>
     <b-tabs
-      active-nav-item-class="font-weight-bold text-uppercase text-danger"
-      active-tab-class="font-weight-bold text-success"
+      active-nav-item-class="fw-bold text-uppercase text-danger"
+      active-tab-class="fw-bold text-success"
       content-class="mt-3"
     >
       <b-tab title="First" active><p>I'm the first tab</p></b-tab>
@@ -388,8 +388,8 @@ To apply classes to the currently active control or tab use the `active-nav-item
 ```html
 <div>
   <b-tabs
-    active-nav-item-class="font-weight-bold text-uppercase text-danger"
-    active-tab-class="font-weight-bold text-success"
+    active-nav-item-class="fw-bold text-uppercase text-danger"
+    active-tab-class="fw-bold text-success"
     content-class="mt-3"
   >
     <b-tab title="First" active><p>I'm the first tab</p></b-tab>

--- a/apps/playground/src/components/Comps/TTableSimple.vue
+++ b/apps/playground/src/components/Comps/TTableSimple.vue
@@ -98,7 +98,7 @@
           <b-tbody>
             <b-tr>
               <b-th rowspan="3">Belgium</b-th>
-              <b-th class="text-right">Antwerp</b-th>
+              <b-th class="text-end">Antwerp</b-th>
               <b-td>56</b-td>
               <b-td>22</b-td>
               <b-td>43</b-td>
@@ -106,7 +106,7 @@
               <b-td>23</b-td>
             </b-tr>
             <b-tr>
-              <b-th class="text-right">Gent</b-th>
+              <b-th class="text-end">Gent</b-th>
               <b-td>46</b-td>
               <b-td variant="warning">18</b-td>
               <b-td>50</b-td>
@@ -114,7 +114,7 @@
               <b-td variant="danger">15</b-td>
             </b-tr>
             <b-tr>
-              <b-th class="text-right">Brussels</b-th>
+              <b-th class="text-end">Brussels</b-th>
               <b-td>51</b-td>
               <b-td>27</b-td>
               <b-td>38</b-td>
@@ -123,7 +123,7 @@
             </b-tr>
             <b-tr>
               <b-th rowspan="2">The Netherlands</b-th>
-              <b-th class="text-right">Amsterdam</b-th>
+              <b-th class="text-end">Amsterdam</b-th>
               <b-td variant="success">89</b-td>
               <b-td>34</b-td>
               <b-td>69</b-td>
@@ -131,7 +131,7 @@
               <b-td>38</b-td>
             </b-tr>
             <b-tr>
-              <b-th class="text-right">Utrecht</b-th>
+              <b-th class="text-end">Utrecht</b-th>
               <b-td>80</b-td>
               <b-td variant="danger">12</b-td>
               <b-td>43</b-td>
@@ -188,7 +188,7 @@
           <b-tbody>
             <b-tr>
               <b-th rowspan="3" class="text-center">Belgium (3 Cities)</b-th>
-              <b-th stacked-heading="City" class="text-left">Antwerp</b-th>
+              <b-th stacked-heading="City" class="text-start">Antwerp</b-th>
               <b-td stacked-heading="Clothes: Trousers">56</b-td>
               <b-td stacked-heading="Clothes: Skirts">22</b-td>
               <b-td stacked-heading="Clothes: Dresses">43</b-td>
@@ -231,7 +231,7 @@
           </b-tbody>
           <b-tfoot>
             <b-tr>
-              <b-td colspan="7" variant="secondary" class="text-right">
+              <b-td colspan="7" variant="secondary" class="text-end">
                 Total Rows:
                 <b>5</b>
               </b-td>

--- a/packages/bootstrap-vue-3/src/components/BCard/BCardImg.vue
+++ b/packages/bootstrap-vue-3/src/components/BCard/BCardImg.vue
@@ -54,7 +54,7 @@ const attrs = computed(() => ({
 }))
 
 const alignment = computed(() =>
-  leftBoolean.value ? 'float-left' : rightBoolean.value ? 'float-right' : ''
+  leftBoolean.value ? 'float-start' : rightBoolean.value ? 'float-end' : ''
 )
 
 const baseClass = computed(() =>

--- a/packages/bootstrap-vue-3/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/BDropdown.vue
@@ -160,7 +160,7 @@ const buttonClasses = computed(() => ({
 
 const dropdownMenuClasses = computed(() => ({
   'dropdown-menu-dark': darkBoolean.value,
-  'dropdown-menu-right': rightBoolean.value,
+  'dropdown-menu-end': rightBoolean.value,
 }))
 
 const buttonAttr = computed(() => ({

--- a/packages/bootstrap-vue-3/src/components/BDropdown/dropdown.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BDropdown/dropdown.spec.ts
@@ -94,14 +94,14 @@ describe('dropdown', () => {
     expect($ul.classes()).not.toContain('dropdown-menu-dark')
   })
 
-  it('child ul has class dropdown-menu-right when prop right', async () => {
+  it('child ul has class dropdown-menu-end when prop right', async () => {
     const wrapper = mount(BDropdown, {
       props: {right: true},
     })
     const $ul = wrapper.get('ul')
-    expect($ul.classes()).toContain('dropdown-menu-right')
+    expect($ul.classes()).toContain('dropdown-menu-end')
     await wrapper.setProps({right: false})
-    expect($ul.classes()).not.toContain('dropdown-menu-right')
+    expect($ul.classes()).not.toContain('dropdown-menu-end')
   })
 
   it('child ul renders default slot', () => {


### PR DESCRIPTION
# Describe the PR

Dropdown **right** property was not working, because attaching the old utility CSS class: `dropdown-menu-right` instead of the new `dropdown-menu-end`.  Throughout the docs I also renamed the old utility CSS classes. 


## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(BDropdown)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type**
