### PR TITLE
BTable sort-compare prop but simpler

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -182,7 +182,6 @@ import {cloneDeepAsync} from '../../utils/object'
 import {titleCase} from '../../utils/stringUtils'
 import BSpinner from '../BSpinner.vue'
 
-import {BTableSortCompare} from 'src/types/components/BTable/BTable'
 import type {
   Booleanish,
   ColorVariant,
@@ -191,7 +190,7 @@ import type {
   TableItem,
   VerticalAlign,
 } from '../../types'
-import type {BTableProvider} from '../../types/components'
+import {type BTableProvider, type BTableSortCompare} from '../../types/components'
 import BTableSimple from './BTableSimple.vue'
 import useItemHelper from './itemHelper'
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -209,6 +209,7 @@ interface BTableProps {
   hover?: Booleanish
   items?: Array<TableItem>
   provider?: BTableProvider
+  sortCompare?: (aRow: TableItem, bRow: TableItem, fieldKey: string, sortDesc: boolean) => number
   noProvider?: Array<NoProviderTypes>
   noProviderPaging?: Booleanish
   noProviderSorting?: Booleanish

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -190,7 +190,7 @@ import type {
   TableItem,
   VerticalAlign,
 } from '../../types'
-import {type BTableProvider, type BTableSortCompare} from '../../types/components'
+import type {BTableProvider, BTableSortCompare} from '../../types/components'
 import BTableSimple from './BTableSimple.vue'
 import useItemHelper from './itemHelper'
 

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -182,6 +182,7 @@ import {cloneDeepAsync} from '../../utils/object'
 import {titleCase} from '../../utils/stringUtils'
 import BSpinner from '../BSpinner.vue'
 
+import {BTableSortCompare} from 'src/types/components/BTable/BTable'
 import type {
   Booleanish,
   ColorVariant,
@@ -209,7 +210,7 @@ interface BTableProps {
   hover?: Booleanish
   items?: Array<TableItem>
   provider?: BTableProvider
-  sortCompare?: (aRow: TableItem, bRow: TableItem, fieldKey: string, sortDesc: boolean) => number
+  sortCompare?: BTableSortCompare
   noProvider?: Array<NoProviderTypes>
   noProviderPaging?: Booleanish
   noProviderSorting?: Booleanish

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -1,7 +1,7 @@
 import {ref, Ref} from 'vue'
 import type {TableField, TableFieldObject, TableItem} from '../../types'
 import {isObject, startCase} from '../../utils'
-import {BTableSortCompare} from './../../types/components/BTable/BTable.d'
+import {BTableSortCompare} from './../../types/components'
 import {cloneDeep, cloneDeepAsync} from './../../utils/object'
 
 const useItemHelper = () => {

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -42,10 +42,15 @@ const useItemHelper = () => {
       }
     }
     if ('isSortable' in flags && flags.isSortable.value === true) {
-      internalItems.value = sortItems(fields, internalItems.value, {
-        key: props.sortBy,
-        desc: flags.sortDescBoolean.value,
-      })
+      internalItems.value = sortItems(
+        fields,
+        internalItems.value,
+        {
+          key: props.sortBy,
+          desc: flags.sortDescBoolean.value,
+        },
+        props.sortCompare
+      )
     }
     if (props.perPage !== undefined) {
       const startIndex = (props.currentPage - 1) * props.perPage
@@ -59,11 +64,15 @@ const useItemHelper = () => {
   const sortItems = (
     fields: TableField[],
     items: TableItem<Record<string, any>>[],
-    sort?: {key?: string; desc?: boolean}
+    sort?: {key?: string; desc?: boolean},
+    sorter?: (...p: any) => number
   ) => {
     if (!sort || !sort.key) return items
     const sortKey = sort.key
     return items.sort((a, b) => {
+      if (sorter !== undefined) {
+        return sorter(a, b, sort.key, sort.desc)
+      }
       const realVal = (ob: any) => (typeof ob === 'object' ? JSON.stringify(ob) : ob)
       const aHigher = realVal(a[sortKey]) > realVal(b[sortKey])
       if (aHigher) {

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -1,6 +1,7 @@
 import {ref, Ref} from 'vue'
 import type {TableField, TableFieldObject, TableItem} from '../../types'
 import {isObject, startCase} from '../../utils'
+import {BTableSortCompare} from './../../types/components/BTable/BTable.d'
 import {cloneDeep, cloneDeepAsync} from './../../utils/object'
 
 const useItemHelper = () => {
@@ -64,8 +65,8 @@ const useItemHelper = () => {
   const sortItems = (
     fields: TableField[],
     items: TableItem<Record<string, any>>[],
-    sort?: {key?: string; desc?: boolean},
-    sorter?: (...p: any) => number
+    sort: {key: string; desc: boolean},
+    sorter?: BTableSortCompare
   ) => {
     if (!sort || !sort.key) return items
     const sortKey = sort.key

--- a/packages/bootstrap-vue-3/src/types/components/BTable/BTable.d.ts
+++ b/packages/bootstrap-vue-3/src/types/components/BTable/BTable.d.ts
@@ -34,3 +34,10 @@ export type BTableProvider = (
   context: BTableProviderContext,
   provide: (items: Array<TableItem>) => Promise<TableItem[] | undefined>
 ) => Promise<Array<TableItem> | undefined> | Array<TableItem> | undefined
+
+export type BTableSortCompare = (
+  aRow: TableItem,
+  bRow: TableItem,
+  fieldKey: string,
+  sortDesc: boolean
+) => number

--- a/packages/bootstrap-vue-3/src/types/components/index.ts
+++ b/packages/bootstrap-vue-3/src/types/components/index.ts
@@ -134,7 +134,12 @@ export type {Props as BSkeletonTableProps} from './BSkeleton/BSkeletonTable'
 export type {Props as BSkeletonWrapperProps} from './BSkeleton/BSkeletonWrapper'
 export type {Props as BSpinnerProps} from './BSpinner'
 // BTable
-export type {BTableProvider, BTableProviderContext, Props as BTableProps} from './BTable/BTable'
+export type {
+  BTableProvider,
+  BTableProviderContext,
+  BTableSortCompare,
+  Props as BTableProps,
+} from './BTable/BTable'
 export type {Props as BTableSimpleProps} from './BTable/BTableSimple'
 export type {Props as BTBodyProps} from './BTable/BTbody'
 export type {Props as BTdProps} from './BTable/BTd'


### PR DESCRIPTION
Solves https://github.com/cdmoro/bootstrap-vue-3/issues/694,

Notes:
The compare function has fewer arguments than what BSV2's has

SortCompare function example:
```ts
const sortCompare: BTableSortCompare = (aRow, bRow, key, sortDesc): number => {
  const a = aRow[key] // or use Lodash `_.get()`
  const b = bRow[key]
  if (
    (typeof a === 'number' && typeof b === 'number') ||
    (a instanceof Date && b instanceof Date)
  ) {
    // If both compared fields are native numbers or both are native dates
    return a < b ? (sortDesc ? -1 : 1) : a > b ? (sortDesc ? 1 : -1) : 0
  } else {
    // Otherwise stringify the field data and use String.prototype.localeCompare
    return JSON.stringify(a).localeCompare(JSON.stringify(b))
  }
}
```
