### PR TITLE
fix(BTable): [#742] BTable with provider never hides the busy loader

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -487,7 +487,7 @@ const callItemsProvider = async () => {
       const internalItems = await itemHelper.updateInternalItems(items)
       return internalItems
     } finally {
-      if (!internalBusyFlag.value) {
+      if (internalBusyFlag.value) {
         internalBusyFlag.value = false
       }
     }


### PR DESCRIPTION
# Describe the PR

BTable with provider never hides the busy loader

## PR checklist

- [X] Bugfix :bug: - `fix(#742 )`