### PR TITLE
docs(Type Introspection): Generate temp file to pull type info from

### DIFF
--- a/apps/docs/docs/.vuepress/PluginComponentReference/index.ts
+++ b/apps/docs/docs/.vuepress/PluginComponentReference/index.ts
@@ -1,18 +1,24 @@
-import {fs} from '@vuepress/utils'
+import {fs,info, error} from '@vuepress/utils'
 // import type {Page, Plugin, App, PageData} from '@vuepress/core'
 import type { Plugin, App, PageData, Page } from 'vuepress'
 import {path} from '@vuepress/utils'
+import {  getComponentsFromDir,  RegisterComponentsPluginOptions } from '@vuepress/plugin-register-components'
+import {createComponentMetaChecker, MetaCheckerOptions, createComponentMetaCheckerByJsonConfig} from 'vue-component-meta'
+
+
+export type ComponentPropsOptions  = Omit<RegisterComponentsPluginOptions, 'components'> & 
+{metaCheckerOptions? : MetaCheckerOptions, rootPath?: string } 
 
 export interface ComponentReferenceOptions {
-  baseDir: string
-}
+  baseDir?: string,
+  extendsProps? : (app : App, page : Page, componentReference : any | null) => any,
+} 
 
-function resolvePageComponentReferencePath(baseDir: string, page, app: App): {filePath: string} {
+
+function resolvePageComponentReferencePath(baseDir: string, page, app: App): {filePath: string } {
   const filePath = path.resolve(app.dir.source(), baseDir, path.addExt(page.slug, '.json'))
   if (!filePath) {
-    return {
-      filePath: null,
-    }
+    throw new Error('Cannot resolve Component Reference Path')
   }
 
   return {
@@ -20,17 +26,91 @@ function resolvePageComponentReferencePath(baseDir: string, page, app: App): {fi
   }
 }
 
-export const componentReference: Plugin<ComponentReferenceOptions> = ({
-  baseDir = 'component-references',
-}) => ({
+export const componentReference  = ({
+  baseDir = "component-references",
+  extendsProps,
+   
+} : ComponentReferenceOptions = {baseDir : "component-references"
+
+}, {
+  metaCheckerOptions = undefined,
+  componentsDir = null,
+  rootPath,
+  componentsPatterns = ['**/*.vue', '!App.vue'],
+  getComponentName = (filename) =>
+    path.basename(filename, ".vue"),
+} : ComponentPropsOptions = {}) : Plugin => ({
   name: 'plugin-object',
   clientConfigFile: path.resolve(__dirname, './client.ts'),
+  onPrepared : async (app) => {
+    info("ComponentProps Gathering Prop Defintions")
+    
+    if(componentsDir){
+
+    let componentMetaMap = {}
+    if(fs.pathExistsSync(app.dir.temp('componentMeta.json'))){
+        info("Skip Checker")  
+        return
+    }
+    let componentsMap =  await getComponentsFromDir({componentsDir, componentsPatterns, getComponentName})
+    // Our component directory and tsconfig must share a simliar path
+    let checker = createComponentMetaCheckerByJsonConfig(path.resolve(componentsDir),
+      {
+        "include": [
+          "**/*",
+        ],
+      },
+      metaCheckerOptions)
+      
+    info("Established Checker")
+   
+      async function meta(component, filepath){
+        try{
+               let {props, events, exposed ,slots} =  checker.getComponentMeta(path.resolve(filepath))
+               componentMetaMap[component] = {props: props, events: events ,  exposed: exposed,  slots: slots}
+             }catch(erroy :any){
+              error(`Parsing Failed`, error)
+             }
+      }
+
+     await  Promise.all(Object.entries(componentsMap).map((attributes)=> meta(attributes[0], attributes[1])))
+    
+    app.writeTemp("componentMeta.json", JSON.stringify(componentMetaMap))
+    }
+  }, 
   extendsPage(page, app: App) {
     const {filePath} = resolvePageComponentReferencePath(baseDir, page, app)
     let componentReference = null
     if (fs.existsSync(filePath)) {
-      componentReference = require(filePath)
+      componentReference = require(filePath) 
+      // see if componentMeta exists to augment existing user defined types
+      if (fs.existsSync( path.resolve(path.join(app.dir.temp(), 'componentMeta.json')))) {
+         let componentMeta = require( path.resolve(path.join(app.dir.temp(), 'componentMeta')))
+
+         if(componentReference){
+         componentReference.meta.components.forEach(({component, props}, index) => {
+
+          if (props && componentMeta[component]){
+            props.forEach((prop, propindex)=>{
+              let propDefiniton = componentMeta[component].props.find((propMeta) => {
+                if (propMeta.name === prop.prop){
+                  return propMeta
+                }
+              })
+
+              if (propDefiniton){
+                prop.type = propDefiniton.type
+              }
+            })
+          }
+        });
+      }}
     }
+
+    if (extendsProps){
+      extendsProps(app, page, componentReference)
+    }
+
     page.data.componentReference = componentReference
   },
 })

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -2,7 +2,6 @@
 // import {defaultTheme} from '@vuepress/theme-default'
 import {searchPlugin} from '@vuepress/plugin-search'
 import {componentReference} from './PluginComponentReference'
-import {componentPropsPlugin} from './PluginComponentProps'
 import {path} from '@vuepress/utils'
 import {defineUserConfig, defaultTheme, viteBundler} from 'vuepress'
 

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -2,6 +2,8 @@
 // import {defaultTheme} from '@vuepress/theme-default'
 import {searchPlugin} from '@vuepress/plugin-search'
 import {componentReference} from './PluginComponentReference'
+import {componentPropsPlugin} from './PluginComponentProps'
+import {path} from '@vuepress/utils'
 import {defineUserConfig, defaultTheme, viteBundler} from 'vuepress'
 
 export default defineUserConfig({
@@ -17,7 +19,13 @@ export default defineUserConfig({
         },
       },
     }),
-    componentReference,
+    componentReference({},
+    { rootPath : "../../packages/bootstrap-vue-3", 
+      componentsDir: '../../packages/bootstrap-vue-3/src' , 
+      metaCheckerOptions : {forceUseTs: true,
+      schema: { ignore: ['MyIgnoredNestedProps'] },
+      printer: { newLine: 1 },}
+    }),
   ],
   bundler: viteBundler(),
   theme: defaultTheme({


### PR DESCRIPTION
# Describe the PR

First version of pulling type information from project

Creates a temp componentMeta.json on first project start up. In order to rebuild the meta the docs cache will need to be cleared


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or have an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
