### PR TITLE
A few fixes to table componeted, new stacked label prop 

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -98,7 +98,7 @@
             v-bind="field.tdAttr"
             :class="getFieldRowClasses(field, item)"
           >
-            <label v-if="stacked" class="b-table-stacked-label">{{
+            <label v-if="stacked && labelStackedBoolean" class="b-table-stacked-label">{{
               getFieldHeadLabel(field)
             }}</label>
             <slot

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -98,6 +98,9 @@
             v-bind="field.tdAttr"
             :class="getFieldRowClasses(field, item)"
           >
+            <label v-if="stacked" class="b-table-stacked-label">{{
+              getFieldHeadLabel(field)
+            }}</label>
             <slot
               v-if="$slots['cell(' + field.key + ')'] || $slots['cell()']"
               :name="$slots['cell(' + field.key + ')'] ? 'cell(' + field.key + ')' : 'cell()'"
@@ -222,6 +225,8 @@ interface BTableProps {
   responsive?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
   small?: Booleanish
   striped?: Booleanish
+  stacked?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' // boolean | Breakpoint
+  labelStacked?: boolean
   variant?: ColorVariant
   sortBy?: string
   sortDesc?: Booleanish
@@ -254,6 +259,8 @@ const props = withDefaults(defineProps<BTableProps>(), {
   responsive: false,
   small: false,
   striped: false,
+  labelStacked: false,
+  stacked: false,
   sortDesc: false,
   sortInternal: true,
   selectable: false,
@@ -312,11 +319,12 @@ const sortDescBoolean = useBooleanish(toRef(props, 'sortDesc'))
 const sortInternalBoolean = useBooleanish(toRef(props, 'sortInternal'))
 const selectableBoolean = useBooleanish(toRef(props, 'selectable'))
 const stickySelectBoolean = useBooleanish(toRef(props, 'stickySelect'))
+const labelStackedBoolean = useBooleanish(toRef(props, 'labelStacked'))
 const busyBoolean = useBooleanish(toRef(props, 'busy'))
 const showEmptyBoolean = useBooleanish(toRef(props, 'showEmpty'))
-const noProviderPagingBoolean = useBooleanish(toRef(props, 'showEmpty'))
-const noProviderSortingBoolean = useBooleanish(toRef(props, 'showEmpty'))
-const noProviderFilteringBoolean = useBooleanish(toRef(props, 'showEmpty'))
+const noProviderPagingBoolean = useBooleanish(toRef(props, 'noProviderPaging'))
+const noProviderSortingBoolean = useBooleanish(toRef(props, 'noProviderSorting'))
+const noProviderFilteringBoolean = useBooleanish(toRef(props, 'noProviderFiltering'))
 
 const internalBusyFlag = ref(busyBoolean.value)
 itemHelper.filterEvent.value = async (items) => {
@@ -351,6 +359,7 @@ const containerAttrs = computed(() => ({
   hover: props.hover,
   responsive: props.responsive,
   striped: props.striped,
+  stacked: props.stacked,
   small: props.small,
   tableClass: tableClasses.value,
   tableVariant: props.variant,

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -1,54 +1,65 @@
-.table.b-table.b-table-stacked {
-  display: block;
-  width: 100%;
-}
-
-.table.b-table.b-table-stacked > tfoot,
-.table.b-table.b-table-stacked > tfoot > tr.b-table-bottom-row,
-.table.b-table.b-table-stacked > tfoot > tr.b-table-top-row,
-.table.b-table.b-table-stacked > thead,
-.table.b-table.b-table-stacked > thead > tr.b-table-bottom-row,
-.table.b-table.b-table-stacked > thead > tr.b-table-top-row {
+.b-table-stacked-label {
   display: none;
 }
 
-.table.b-table.b-table-stacked > caption,
-.table.b-table.b-table-stacked > tbody,
-.table.b-table.b-table-stacked > tbody > tr,
-.table.b-table.b-table-stacked > tbody > tr > td,
-.table.b-table.b-table-stacked > tbody > tr > th {
-  display: block;
-}
+@each $breakpoint in map-keys($grid-breakpoints) {
+  $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-.table.b-table.b-table-stacked > tbody > tr > :first-child,
-.table.b-table.b-table-stacked > tbody > tr > [rowspan] + td,
-.table.b-table.b-table-stacked > tbody > tr > [rowspan] + th {
-  border-top-width: 3px;
-}
+  @include media-breakpoint-down($breakpoint, $grid-breakpoints) {
+    .table.b-table.b-table-stacked#{$infix} {
+      display: block;
+      width: 100%;
+    }
 
-.table.b-table.b-table-stacked > tbody > tr > [data-label]::before {
-  content: attr(data-label);
-  width: 40%;
-  float: left;
-  text-align: right;
-  word-wrap: break-word;
-  font-weight: 700;
-  font-style: normal;
-  padding: 0 0.5rem 0 0;
-  margin: 0;
-}
+    .table.b-table.b-table-stacked#{$infix} > tfoot,
+    .table.b-table.b-table-stacked#{$infix} > tfoot > tr.b-table-bottom-row,
+    .table.b-table.b-table-stacked#{$infix} > tfoot > tr.b-table-top-row,
+    .table.b-table.b-table-stacked#{$infix} > thead,
+    .table.b-table.b-table-stacked#{$infix} > thead > tr.b-table-bottom-row,
+    .table.b-table.b-table-stacked#{$infix} > thead > tr.b-table-top-row {
+      display: none;
+    }
 
-.table.b-table.b-table-stacked > tbody > tr > [data-label]::after {
-  display: block;
-  clear: both;
-  content: "";
-}
+    .table.b-table.b-table-stacked#{$infix} > caption,
+    .table.b-table.b-table-stacked#{$infix} > tbody,
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr,
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > td,
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > td > .b-table-stacked-label,
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > th {
+      display: block;
+    }
 
-.table.b-table.b-table-stacked > tbody > tr > [data-label] > div {
-  display: inline-block;
-  width: 60%;
-  padding: 0 0 0 0.5rem;
-  margin: 0;
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > :first-child,
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > [rowspan] + td,
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > [rowspan] + th {
+      border-top-width: 3px;
+    }
+
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > [data-label]::before {
+      content: attr(data-label);
+      width: 40%;
+      float: left;
+      text-align: right;
+      word-wrap: break-word;
+      font-weight: 700;
+      font-style: normal;
+      padding: 0 0.5rem 0 0;
+      margin: 0;
+    }
+
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > [data-label]::after {
+      display: block;
+      clear: both;
+      content: "";
+    }
+
+    .table.b-table.b-table-stacked#{$infix} > tbody > tr > [data-label] > div {
+      display: inline-block;
+      width: 60%;
+      padding: 0 0 0 0.5rem;
+      margin: 0;
+    }
+  }
 }
 
 .b-table-sticky-header,

--- a/packages/bootstrap-vue-3/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-3/src/components/BTable/_table.scss
@@ -1,5 +1,6 @@
 .b-table-stacked-label {
   display: none;
+  font-weight: bold;
 }
 
 @each $breakpoint in map-keys($grid-breakpoints) {

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -38,9 +38,9 @@ const useItemHelper = () => {
     internalItems.value = cloneDeep(items)
     if ('isFilterableTable' in flags && flags.isFilterableTable.value === true && props.filter) {
       internalItems.value = filterItems(internalItems.value, props.filter, props.filterable)
-      if (filterEvent.value) {
-        filterEvent.value(internalItems.value)
-      }
+      // if (filterEvent.value) {
+      //   filterEvent.value(internalItems.value)
+      // }
     }
     if ('isSortable' in flags && flags.isSortable.value === true) {
       internalItems.value = sortItems(
@@ -53,10 +53,10 @@ const useItemHelper = () => {
         props.sortCompare
       )
     }
-    if (props.perPage !== undefined) {
-      const startIndex = (props.currentPage - 1) * props.perPage
-      internalItems.value = internalItems.value.splice(startIndex, props.perPage)
-    }
+    // if (props.perPage !== undefined) {
+    //   const startIndex = (props.currentPage - 1) * props.perPage
+    //   internalItems.value = internalItems.value.splice(startIndex, props.perPage)
+    // }
     return internalItems.value
   }
 
@@ -119,12 +119,19 @@ const useItemHelper = () => {
     }
   }
 
+  const notifyFilteredItems = () => {
+    if (filterEvent.value) {
+      filterEvent.value(internalItems.value)
+    }
+  }
+
   return {
     normaliseFields,
     mapItems,
     internalItems,
     updateInternalItems,
     filterEvent,
+    notifyFilteredItems,
   }
 }
 

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -96,7 +96,8 @@ const useItemHelper = () => {
       (item) =>
         Object.entries(item).filter((item) => {
           const [key, val] = item
-          if (key[0] === '_' || (filterable.length > 0 && !filterable.includes(key))) return false
+          if (!val || key[0] === '_' || (filterable.length > 0 && !filterable.includes(key)))
+            return false
           const itemValue: string =
             typeof val === 'object'
               ? JSON.stringify(Object.values(val))


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(BTable): fixed filtering undefined table item values (more details: https://github.com/cdmoro/bootstrap-vue-3/issues/770).
fix(BTable): fixed ``filtered`` event being emitted when using pagination (more details: https://github.com/cdmoro/bootstrap-vue-3/issues/768).
fix(BTable): provided typescript hints for a stacked prop.
fix(BTable, BTableSimple): Added the needed CSS to make the ``stacked`` prop take effect from a specific screen-size breakpoint.
feature(BTable): added ``label-stacked`` prop to label the stacked rows with the field's label
END_COMMIT_OVERRIDE

### stacked & label-stacked props preview

code example:
```vue
<template>
  <b-container fluid class="py-5">
    <div class="row">
      <div class="col-6">
        <h4 class="mb-3">Stacked table</h4>
        <b-table :items="items" :fields="fields" responsive stacked label-stacked></b-table>
      </div>
      <div class="col-6">
        <h4 class="mb-3">Normal table</h4>
        <b-table :items="items" :fields="fields" responsive></b-table>
        <h4 class="mb-3">Stacked table with a breakpoint</h4>
        <b-table :items="items" :fields="fields" responsive stacked="lg" ></b-table>
      </div>
    </div>
  </b-container>
</template>

<script  lang="ts">
import { defineComponent } from "vue";

export default defineComponent({
  data() {
    return {
      fields: [
        { key: 'last_name', },
        { key: 'first_name', },
        { key: 'age', },
      ],
      items: [
        { isActive: true, age: 40, first_name: 'Dickerson', last_name: 'Macdonald' },
        { isActive: false, age: 21, first_name: 'Larsen', last_name: 'Shaw' },
        { isActive: false, age: 89, first_name: 'Geneva', last_name: 'Wilson' },
        { isActive: true, age: 38, first_name: 'Jami', last_name: 'Carney' }
      ]
    }
  }
});
</script>
```

demo:
![image](https://user-images.githubusercontent.com/58523735/198848837-48ebd38c-b8df-4b9b-971a-b408b49266ca.png)
