### PR TITLE
BModal fix, Should be merged & published asap

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BModal.vue
+++ b/packages/bootstrap-vue-3/src/components/BModal.vue
@@ -339,13 +339,3 @@ export default {
   inheritAttrs: false,
 }
 </script>
-
-<style lang="scss" scoped>
-.modal {
-  display: block;
-}
-
-.modal-dialog {
-  z-index: 1051;
-}
-</style>

--- a/packages/bootstrap-vue-3/src/styles/styles.scss
+++ b/packages/bootstrap-vue-3/src/styles/styles.scss
@@ -42,3 +42,11 @@
 .bv-no-focus-ring:focus {
   outline: none;
 }
+
+.modal {
+  display: block;
+}
+
+.modal-dialog {
+  z-index: 1051;
+}


### PR DESCRIPTION
### Description
BModal is no longer showing up
For some reason adding CSS to a component's scoped style does not have any effect, The CSS is not being used when serving the library in a project (But works fine in dev env).
However, Moving the CSS to the global styles will fix issues where the modal doesn't show up and the backdrop doesn't appear correctly in some cases.

### What to do until this is published?
add this CSS to your application's global styles
```css
.modal {
  display: block;
}
.modal .modal-dialog {
  z-index: 1051;
}
```