### PR TITLE
feat(Popover): Allow html modifier in directive

### DIFF
--- a/packages/bootstrap-vue-3/src/directives/BPopover.ts
+++ b/packages/bootstrap-vue-3/src/directives/BPopover.ts
@@ -41,6 +41,7 @@ const BPopover: Directive<HTMLElement> = {
       trigger: trigger.length === 0 ? 'click' : (trigger.join(' ') as Popover.Options['trigger']),
       placement,
       content: binding.value,
+      html: binding.modifiers.html,
     })
   },
   unmounted(el) {


### PR DESCRIPTION
# Describe the PR

Allow html modifier in Popover directive

## Small replication

I am using `v-b-popover.html="'<p>text</p>'"` and it didn't render the HTML but showed the actual HTML tags. 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or have an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
