### PR TITLE
fix: Tabs Content will update with reactive components

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BTabs/BTabs.vue
+++ b/packages/bootstrap-vue-3/src/components/BTabs/BTabs.vue
@@ -1,9 +1,10 @@
 <template>
   <component :is="tag" :id="id" class="tabs" :class="computedClasses">
+    <!-- Tab Content Above Tabs -->
     <div v-if="endBoolean" class="tab-content" :class="contentClass">
       <component
-        :is="tab"
-        v-for="({tab, contentId, tabClasses, active}, i) in tabs"
+        :is="tabComponent()"
+        v-for="({tabComponent, contentId, tabClasses, active}, i) in tabs"
         :id="contentId"
         :key="i"
         :class="tabClasses"
@@ -21,6 +22,7 @@
     <div
       :class="[navWrapperClass, {'card-header': cardBoolean, 'ms-auto': vertical && endBoolean}]"
     >
+      <!-- Render Tabs -->
       <ul class="nav" :class="[navTabsClasses, navClass]" role="tablist">
         <slot name="tabs-start" />
         <li
@@ -50,10 +52,11 @@
         <slot name="tabs-end" />
       </ul>
     </div>
+    <!-- Tab Content Below Tabs-->
     <div v-if="!endBoolean" class="tab-content" :class="contentClass">
       <component
-        :is="tab"
-        v-for="({tab, contentId, tabClasses, active}, i) in tabs"
+        :is="tabComponent()"
+        v-for="({tabComponent, contentId, tabClasses, active}, i) in tabs"
         :id="contentId"
         :key="i"
         :class="tabClasses"
@@ -191,7 +194,8 @@ const tabs = computed(() => {
         titleItemClass,
         titleLinkAttributes,
         onClick: tab.props.onClick,
-        tab,
+        tab, //TODO remove this in future since the mapped value does not provide a direct reference to the actual slot component.
+        tabComponent: () => getTabs(slots)[idx],
       }
     })
   }

--- a/packages/bootstrap-vue-3/src/components/BTabs/tabs.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTabs/tabs.spec.ts
@@ -3,6 +3,8 @@ import {h} from 'vue'
 import {afterEach, describe, expect, it} from 'vitest'
 import BTabs from './BTabs.vue'
 import BTab from './BTab.vue'
+import BFormInput from '../BFormInput/BFormInput.vue'
+import BFormGroup from '../BFormGroup/BFormGroup.vue'
 
 describe('tabs', () => {
   enableAutoUnmount(afterEach)
@@ -449,5 +451,52 @@ describe('tabs', () => {
       slots: {'empty': 'empty', 'tabs-start': 'start'},
     })
     expect(wrapper.text()).toBe('startempty')
+  })
+
+  it('renders content passed via ', async () => {
+    const msg = 'foobar'
+
+    const HelloWorld = {
+      template: ` 
+      <b-form-group label="msg">
+        <b-form-input v-model="msg" />
+        <slot :msg="msg"/>      
+      </b-form-group>`,
+      data() {
+        return {
+          msg,
+        }
+      },
+      components: {
+        BFormInput,
+        BFormGroup,
+      },
+    }
+
+    const ComplexComponent = {
+      template: `
+      <HelloWorld v-slot="{msg}" class="mt-3">
+        out of tabs: {{ msg }}
+        <b-tabs>
+         <b-tab title="First" active><p>{{msg}}</p></b-tab>
+        </b-tabs>
+      </HelloWorld>
+      `,
+      data() {
+        return {}
+      },
+      components: {
+        BTab,
+        BTabs,
+        HelloWorld,
+      },
+    }
+
+    const wrapper = mount(ComplexComponent, {})
+    let HelloWorldComponent = wrapper.findComponent({name: 'HelloWorld'})
+
+    await HelloWorldComponent.setData({msg: 'bar'})
+
+    expect(wrapper.findComponent({name: 'b-tab'}).find('p').text()).toBe('bar')
   })
 })


### PR DESCRIPTION
Refs: #778

# Describe the PR

Fixes an issue where tabs content does not update when reactive content is passed. 



## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or have an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
