### PR TITLE
fix(#828): BButtonGroup missing btn-group class when prop size

### DIFF
--- a/packages/bootstrap-vue-3/src/components/BButton/BButtonGroup.vue
+++ b/packages/bootstrap-vue-3/src/components/BButton/BButtonGroup.vue
@@ -26,7 +26,7 @@ const props = withDefaults(defineProps<BButtonGroupProps>(), {
 const verticalBoolean = useBooleanish(toRef(props, 'vertical'))
 
 const computedClasses = computed(() => ({
-  'btn-group': !verticalBoolean.value && props.size === undefined,
+  'btn-group': !verticalBoolean.value,
   [`btn-group-${props.size}`]: props.size !== undefined,
   'btn-group-vertical': verticalBoolean.value,
 }))

--- a/packages/bootstrap-vue-3/src/components/BButton/button-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BButton/button-group.spec.ts
@@ -22,12 +22,15 @@ describe('button-group', () => {
     expect(wrapper.attributes('role')).toBe('group')
   })
 
-  it('has attr aria-label as prop ariaLabel', async () => {
+  it('has attr aria-label as prop ariaLabel', () => {
     const wrapper = mount(BButtonGroup, {
       props: {ariaLabel: 'foobar'},
     })
     expect(wrapper.attributes('aria-label')).toBe('foobar')
-    await wrapper.setProps({ariaLabel: undefined})
+  })
+
+  it('has attr aria-label to be Group by default', () => {
+    const wrapper = mount(BButtonGroup)
     expect(wrapper.attributes('aria-label')).toBe('Group')
   })
 
@@ -38,29 +41,45 @@ describe('button-group', () => {
     expect(wrapper.text()).toBe('foobar')
   })
 
-  it('has class btn-group-vertical prop vertical', () => {
+  it('has class btn-group when not prop vertical', () => {
+    const wrapper = mount(BButtonGroup, {
+      props: {vertical: false},
+    })
+    expect(wrapper.classes()).toContain('btn-group')
+  })
+
+  it('does not have class btn-group when prop vertical', () => {
+    const wrapper = mount(BButtonGroup, {
+      props: {vertical: true},
+    })
+    expect(wrapper.classes()).not.toContain('btn-group')
+  })
+
+  it('has class btn-group-{type} when prop size', () => {
+    const wrapper = mount(BButtonGroup, {
+      props: {size: 'lg'},
+    })
+    expect(wrapper.classes()).toContain('btn-group-lg')
+  })
+
+  it('does not have class btn-group-{type} when prop size is undefined', () => {
+    const wrapper = mount(BButtonGroup, {
+      props: {vertical: undefined},
+    })
+    expect(wrapper.classes()).not.toContain('btn-group-undefined')
+  })
+
+  it('does not have class btn-group-vertical when not prop vertical', () => {
+    const wrapper = mount(BButtonGroup, {
+      props: {vertical: false},
+    })
+    expect(wrapper.classes()).not.toContain('btn-group-vertical')
+  })
+
+  it('has class btn-group-vertical when prop vertical', () => {
     const wrapper = mount(BButtonGroup, {
       props: {vertical: true},
     })
     expect(wrapper.classes()).toContain('btn-group-vertical')
-  })
-
-  it('has class btn-group when not prop vertical', () => {
-    const wrapper = mount(BButtonGroup)
-    expect(wrapper.classes()).toContain('btn-group')
-  })
-
-  it('has class btn-group-{type} prop size', async () => {
-    const wrapper = mount(BButtonGroup, {
-      props: {size: 'sm'},
-    })
-    expect(wrapper.classes()).toContain('btn-group-sm')
-    await wrapper.setProps({size: undefined})
-    expect(wrapper.classes()).not.toContain('btn-group-sm')
-  })
-
-  it('has class btn-group when prop size is undefined', () => {
-    const wrapper = mount(BButtonGroup, {props: {size: undefined}})
-    expect(wrapper.classes()).toContain('btn-group')
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BButton/button-group.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BButton/button-group.spec.ts
@@ -64,7 +64,7 @@ describe('button-group', () => {
 
   it('does not have class btn-group-{type} when prop size is undefined', () => {
     const wrapper = mount(BButtonGroup, {
-      props: {vertical: undefined},
+      props: {size: undefined},
     })
     expect(wrapper.classes()).not.toContain('btn-group-undefined')
   })


### PR DESCRIPTION
# Describe the PR

A clear and concise description of what the pull request does.

Fixes #828

## Small replication

```html
<b-card>
  <div>
    <b-button-group>
      <b-button>Button 1</b-button>
      <b-button>Button 2</b-button>
      <b-button>Button 3</b-button>
    </b-button-group>
  </div>
  <div class="mt-3">
    <b-button-group size="sm">
      <b-button>Left</b-button>
      <b-button>Middle</b-button>
      <b-button>Right</b-button>
    </b-button-group>
  </div>
  <div class="mt-3">
    <b-button-group size="lg">
      <b-button>Left</b-button>
      <b-button>Middle</b-button>
      <b-button>Right</b-button>
    </b-button-group>
  </div>
</b-card>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or have an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
