### PR TITLE
add support for "formatter" on b-table

### DIFF
--- a/apps/playground/src/components/Comps/TTable.vue
+++ b/apps/playground/src/components/Comps/TTable.vue
@@ -106,7 +106,7 @@ import {TableField, TableItem} from 'bootstrap-vue-3'
 
 const stringTableDefinitions = ref(['last_name', 'first_name', 'age'])
 const objectTableDefinitions: Ref<Array<TableField>> = ref([
-  {key: 'last_name', label: 'Family name'},
+  {key: 'last_name', label: 'Family name', formatter: (value: string) => value.toUpperCase()},
   {key: 'first_name', label: 'Given name'},
 ])
 const items: Array<TableItem> = [

--- a/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-3/src/components/BTable/BTable.vue
@@ -112,7 +112,7 @@
               :toggle-details="() => toggleRowDetails(item)"
               :details-showing="item._showDetails"
             />
-            <template v-else>{{ item[field.key] }}</template>
+            <template v-else>{{ itemHelper.formatItem(item, field) }}</template>
           </td>
         </tr>
 

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -125,6 +125,14 @@ export default () => {
     }
   }
 
+  const formatItem = (item: TableItem, fields: TableFieldObject) => {
+    const value = item[fields.key]
+    if (typeof value === 'string' && fields.formatter && typeof fields.formatter === 'function') {
+      return fields.formatter(value, fields.key, item)
+    }
+    return item[fields.key]
+  }
+
   return {
     normaliseFields,
     mapItems,
@@ -132,5 +140,6 @@ export default () => {
     updateInternalItems,
     filterEvent,
     notifyFilteredItems,
+    formatItem,
   }
 }


### PR DESCRIPTION
# Describe the PR

Support a formatter function on b-table

partial implementation of #769

## Small replication

As the new playground shows, using a formatter function will now work.
The Type also defines a string as valid argument - but i'm not entirely certain what string content would cause what behavior.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or have an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
