### PR TITLE
improve "formatter" option for table

### DIFF
--- a/apps/playground/src/components/Comps/TTable.vue
+++ b/apps/playground/src/components/Comps/TTable.vue
@@ -106,9 +106,13 @@ import {TableField, TableItem} from 'bootstrap-vue-3'
 
 const stringTableDefinitions = ref(['last_name', 'first_name', 'age'])
 const objectTableDefinitions: Ref<Array<TableField>> = ref([
-  {key: 'last_name', label: 'Family name', formatter: (value: string) => value.toUpperCase()},
+  {
+    key: 'last_name',
+    label: 'Family name',
+    formatter: (value: unknown) => (typeof value === 'string' ? value.toUpperCase() : `${value}`),
+  },
   {key: 'first_name', label: 'Given name'},
-  {key: 'age', label: 'Age', formatter: (value: any) => `${value} years`},
+  {key: 'age', label: 'Age', formatter: (value: unknown) => `${value} years`},
 ])
 const items: Array<TableItem> = [
   {age: 40, first_name: 'Dickerson', last_name: 'Macdonald'},

--- a/apps/playground/src/components/Comps/TTable.vue
+++ b/apps/playground/src/components/Comps/TTable.vue
@@ -108,6 +108,7 @@ const stringTableDefinitions = ref(['last_name', 'first_name', 'age'])
 const objectTableDefinitions: Ref<Array<TableField>> = ref([
   {key: 'last_name', label: 'Family name', formatter: (value: string) => value.toUpperCase()},
   {key: 'first_name', label: 'Given name'},
+  {key: 'age', label: 'Age', formatter: (value: any) => `${value} years`},
 ])
 const items: Array<TableItem> = [
   {age: 40, first_name: 'Dickerson', last_name: 'Macdonald'},

--- a/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/itemHelper.ts
@@ -127,7 +127,7 @@ export default () => {
 
   const formatItem = (item: TableItem, fields: TableFieldObject) => {
     const value = item[fields.key]
-    if (typeof value === 'string' && fields.formatter && typeof fields.formatter === 'function') {
+    if (fields.formatter && typeof fields.formatter === 'function') {
       return fields.formatter(value, fields.key, item)
     }
     return item[fields.key]

--- a/packages/bootstrap-vue-3/src/components/BTable/table.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/table.spec.ts
@@ -1,7 +1,7 @@
 import {enableAutoUnmount, flushPromises, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
 import {ref} from 'vue'
-import {TableField, TableItem} from '../../types'
+import {TableField, TableFieldObject, TableItem} from '../../types'
 import BTable from './BTable.vue'
 import BTableSimple from './BTableSimple.vue'
 
@@ -626,5 +626,30 @@ describe('table', () => {
     const $table = wrapper.get('table')
     expect($table.classes()).toContain('b-table-busy')
     expect($table.find('tr.b-table-busy-slot').exists()).toBe(true)
+  })
+
+  it('has accepts a formatter function', async () => {
+    const fields2: Array<TableFieldObject> = fields.map((field) => {
+      if (typeof field === 'object') {
+        return {
+          key: field.key,
+          formatter: (value: any, key: string, item: any) => value.toUpperCase(),
+        }
+      }
+      return field
+    })
+    const wrapper = mount(BTable, {
+      props: {
+        fields: fields2,
+        items,
+      },
+    })
+
+    await flushPromises()
+
+    const $table = wrapper.get('table')
+    const $firstRow = $table.get('tbody tr td')
+
+    expect($firstRow.text()).toBe('HOSSAM')
   })
 })

--- a/packages/bootstrap-vue-3/src/components/BTable/table.spec.ts
+++ b/packages/bootstrap-vue-3/src/components/BTable/table.spec.ts
@@ -1,7 +1,7 @@
 import {enableAutoUnmount, flushPromises, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
 import {ref} from 'vue'
-import {TableField, TableFieldObject, TableItem} from '../../types'
+import {TableField, TableItem} from '../../types'
 import BTable from './BTable.vue'
 import BTableSimple from './BTableSimple.vue'
 
@@ -629,15 +629,17 @@ describe('table', () => {
   })
 
   it('has accepts a formatter function', async () => {
-    const fields2: Array<TableFieldObject> = fields.map((field) => {
+    const fields2: Array<TableField> = fields.map((field) => {
       if (typeof field === 'object') {
         return {
           key: field.key,
-          formatter: (value: any, key: string, item: any) => value.toUpperCase(),
+          formatter: (value: any, key?: string, item?: any): string =>
+            typeof value === 'string' ? value.toUpperCase() : `${value} years`,
         }
       }
       return field
     })
+
     const wrapper = mount(BTable, {
       props: {
         fields: fields2,
@@ -648,8 +650,11 @@ describe('table', () => {
     await flushPromises()
 
     const $table = wrapper.get('table')
-    const $firstRow = $table.get('tbody tr td')
+    const $firstRow = $table.get('tbody tr')
+    const $firstCell = $firstRow.get('td')
+    const $secondCell = $firstRow.get('td:nth-child(2)')
 
-    expect($firstRow.text()).toBe('HOSSAM')
+    expect($firstCell.text()).toBe('HOSSAM')
+    expect($secondCell.text()).toBe('1 years')
   })
 })

--- a/packages/bootstrap-vue-3/src/types/TableField.d.ts
+++ b/packages/bootstrap-vue-3/src/types/TableField.d.ts
@@ -7,7 +7,7 @@ export interface TableFieldObject<T = Record<string, unknown>> {
   headerTitle?: string
   headerAbbr?: string
   class?: string | string[]
-  formatter?: string | ((value: any, key?: string, item?: T) => string)
+  formatter?: string | ((value: unknown, key?: string, item?: T) => string)
   sortable?: boolean
   sortKey?: string
   sortDirection?: string

--- a/packages/bootstrap-vue-3/src/types/TableField.d.ts
+++ b/packages/bootstrap-vue-3/src/types/TableField.d.ts
@@ -7,7 +7,7 @@ export interface TableFieldObject<T = Record<string, unknown>> {
   headerTitle?: string
   headerAbbr?: string
   class?: string | string[]
-  formatter?: string | ((value: string, key?: string, item?: T) => string)
+  formatter?: string | ((value: any, key?: string, item?: T) => string)
   sortable?: boolean
   sortKey?: string
   sortDirection?: string


### PR DESCRIPTION
# Describe the PR

Builds on top of #844 - adding support for the formatter for all types of values (it's actually more useful on non-string values).
It's also adding a test for the new behavior (also for #844).
This required a change to the type - as the formatter should accept "any" value (whatever the item type is).

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
