### PR TITLE
docs(table): fix missing anchor in `BTableLite` and `BTableSimple` links

### DIFF
--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -2,7 +2,7 @@
 
 <PageHeader>
 
-For displaying tabular data, `BTable` supports pagination, filtering, sorting, custom rendering, various style options, events, and asynchronous data. For simple display of tabular data without all the fancy features, BootstrapVueNext provides two lightweight alternative components [`BTableLite`](light-weight-tables) and [`BTableSimple`](simple-tables).
+For displaying tabular data, `BTable` supports pagination, filtering, sorting, custom rendering, various style options, events, and asynchronous data. For simple display of tabular data without all the fancy features, BootstrapVueNext provides two lightweight alternative components [`BTableLite`](#light-weight-tables) and [`BTableSimple`](#simple-tables).
 
 </PageHeader>
 


### PR DESCRIPTION
# Describe the PR

`BTableLite` and `BTableSimple` links are broken on https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/table.html

## Small replication

1. Navigate to https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/table.html
2. Click on the links for `BTableLite` and `BTableSimple`
3. Observe 404

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated internal links in the documentation to correctly reference lightweight table components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->