### PR TITLE
feat(BFormRating): added `icon-clear` slot

### DIFF
--- a/apps/docs/src/data/components/FormRating.data.ts
+++ b/apps/docs/src/data/components/FormRating.data.ts
@@ -84,7 +84,7 @@ export default {
         },
       },
       slots: {
-        default: {
+        'default': {
           description: 'Custom renderer for each star.',
           scope: {
             starIndex: {
@@ -100,6 +100,9 @@ export default {
               description: 'When `true`, the star is half-filled (partially selected)',
             },
           },
+        },
+        'icon-clear': {
+          description: 'Content for the optional clear button',
         },
       } satisfies SlotRecord<keyof BFormRatingSlots>,
     },

--- a/apps/docs/src/docs/components/demo/RatingCustomClear.vue
+++ b/apps/docs/src/docs/components/demo/RatingCustomClear.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <BFormRating
+      v-model="rating"
+      show-clear
+    >
+      <template #icon-clear>
+        <b-button variant="dark"> Clear </b-button>
+      </template>
+    </BFormRating>
+    <p>Current rating: {{ rating }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const rating = ref(2.5)
+</script>

--- a/apps/docs/src/docs/components/form-rating.md
+++ b/apps/docs/src/docs/components/form-rating.md
@@ -114,6 +114,13 @@ Optionally show a clear icon via the `show-clear` prop. The value will be set to
 
 - The clear icon will not be shown when the props `readonly` or `disabled` are set.
 
+#### Custom clear icon
+
+You can replace the default clear icon using the `#icon-clear` slot.  
+This slot is **not scoped** — you can insert any content you like.
+
+<<< DEMO ./demo/RatingCustomClear.vue
+
 ### Icons
 
 By default, `BFormRating` uses built-in star SVG icons:

--- a/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.spec.ts
@@ -219,3 +219,40 @@ describe('rating', () => {
   expect(blockWrapper.classes()).not.toContain('d-inline-block')
   expect(blockWrapper.classes()).toContain('w-100')
 })
+
+it('renders fallback clear icon when showClear is true (no slot provided)', async () => {
+  const wrapper = mount(BFormRating, {
+    props: {modelValue: 3, showClear: true, readonly: false},
+  })
+  const clearArea = wrapper.find('.clear-button-spacing')
+  expect(clearArea.exists()).toBe(true)
+
+  await clearArea.trigger('click')
+  expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+  expect(wrapper.emitted('update:modelValue')![0]).toEqual([0])
+})
+
+it('uses #icon-clear slot content when provided', async () => {
+  const wrapper = mount(BFormRating, {
+    props: {modelValue: 4, showClear: true},
+    slots: {
+      'icon-clear': '<button id="custom-clear" type="button">Clear</button>',
+    },
+  })
+  const clearArea = wrapper.find('.clear-button-spacing')
+  expect(clearArea.exists()).toBe(true)
+  expect(wrapper.find('#custom-clear').exists()).toBe(true)
+
+  await clearArea.trigger('click')
+  expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+  expect(wrapper.emitted('update:modelValue')![0]).toEqual([0])
+})
+
+it('does not render clear when readonly is true', () => {
+  const wrapper = mount(BFormRating, {
+    props: {showClear: true, readonly: true},
+    slots: {'icon-clear': '<span id="slot-should-not-render">X</span>'},
+  })
+  expect(wrapper.find('.clear-button-spacing').exists()).toBe(false)
+  expect(wrapper.find('#slot-should-not-render').exists()).toBe(false)
+})

--- a/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.vue
@@ -15,19 +15,21 @@
       class="clear-button-spacing"
       @click="clearRating"
     >
-      <svg
-        viewBox="0 0 16 16"
-        role="img"
-        aria-label="x"
-        xmlns="http://www.w3.org/2000/svg"
-        class="clear-icon"
-      >
-        <g>
-          <path
-            d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"
-          />
-        </g>
-      </svg>
+      <slot name="icon-clear">
+        <svg
+          viewBox="0 0 16 16"
+          role="img"
+          aria-label="x"
+          xmlns="http://www.w3.org/2000/svg"
+          class="clear-icon"
+        >
+          <g>
+            <path
+              d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"
+            />
+          </g>
+        </svg>
+      </slot>
     </span>
     <span
       v-for="(starIndex, index) in clampedStars"

--- a/packages/bootstrap-vue-next/src/types/ComponentSlots.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentSlots.ts
@@ -281,7 +281,8 @@ export type BFormRadioGroupSlots = {
 }
 
 export type BFormRatingSlots = {
-  default?: (props: {starIndex: number; isFilled: boolean; isHalf: boolean}) => any
+  'icon-clear'?: (props: Record<string, never>) => any
+  'default'?: (props: {starIndex: number; isFilled: boolean; isHalf: boolean}) => any
 }
 
 export type BFormSelectSlots<T> = {


### PR DESCRIPTION
# Describe the PR

Closes #2752

- Added #icon-clear slot to BFormRating for customizing the clear/reset icon.
- Preserved default SVG icon as fallback when no slot is provided.

## Small replication

https://github.com/user-attachments/assets/c4390f9f-d894-43b6-8e39-e9471c9ee7ea

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - BFormRating now supports a customizable clear icon via a new icon-clear slot. Default appearance remains unchanged if not overridden.

- Documentation
  - Added a “Custom clear icon” section with a new demo showcasing how to replace the clear icon.
  - Updated examples to illustrate using the icon-clear slot.

- Tests
  - Added tests covering default clear icon fallback, custom icon-clear slot rendering, click-to-clear behavior, and readonly state not rendering the clear control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->