### PR TITLE
docs: fix otp for index and reference pages

### DIFF
--- a/apps/docs/src/components/OpenCollectiveMemberDisplay.vue
+++ b/apps/docs/src/components/OpenCollectiveMemberDisplay.vue
@@ -36,8 +36,14 @@
       <BCol>
         <BPopover>
           <template #target>
-            <h3 id="inactive-financial-backers">
-              <div class="text-center">Inactive Financial Backers</div>
+            <h3 id="inactive-financial-backers" class="text-center m-0">
+              <BButton
+                variant="link"
+                class="p-0 text-reset"
+                aria-label="More information about inactive financial backers"
+              >
+                Inactive Financial Backers
+              </BButton>
             </h3>
           </template>
           <div class="mb-2">

--- a/apps/docs/src/components/TableOfContentsCard.vue
+++ b/apps/docs/src/components/TableOfContentsCard.vue
@@ -2,7 +2,7 @@
   <BCard :body-text="description">
     <template #header>
       <BLink :to="route">
-        <h3 :id="toKebabCase(name)" class="m-0">
+        <h3 :id="route" class="m-0">
           {{ name }}
         </h3>
       </BLink>
@@ -16,10 +16,4 @@ defineProps<{
   description: string
   route: string
 }>()
-
-const toKebabCase = (str = '') =>
-  str
-    .replace(/[^a-z]/gi, '-')
-    .replace(/\B([A-Z])/g, '-$1')
-    .toLowerCase()
 </script>


### PR DESCRIPTION
# Describe the PR

These pages were not formatted in a way that the headings correctly mapped for on this page. I'll think a bit more about getting the OTP code to throw an error (hopefully at build time), but for the moment, this fixes the known issues.

## Small replication

Document index and reference page - clicking the OTP links does nothing in some cases.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added anchor links to section headings (Administrators, Contributors, Financial Backers, Inactive Financial Backers, and Table of Contents cards) for easier deep-linking.
  - Simplified Financial Backers display by removing per‑tier header labels.
  - Restructured Inactive Financial Backers popover so its trigger and content use consistent headings and an anchorable ID.

- Style
  - Standardized heading levels to improve readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->