### PR TITLE
docs(BApp): add some additional details around legacy plugin use

### DIFF
--- a/apps/docs/src/docs.md
+++ b/apps/docs/src/docs.md
@@ -132,7 +132,8 @@ Now, you can begin importing and using components
 
 ::: warning
 
-If you are using individual plugins, please see the [`BApp` documentation](/docs/components/app#backward-compatibility) for additional details.
+If you are using individual plugins such as `modalControllerPlugin`, `toastControllerPlugin`, or
+`popoverControllerPlugin`, please see the [`BApp` documentation](/docs/components/app#backward-compatibility) for additional details.
 
 :::
 
@@ -356,7 +357,7 @@ Below are some pointers on optimizing tree-shaking in the context of BootstrapVu
 
 If you are using one of the preferred installation methods, JS will be tree-shaken by default. The one thing we are not able to do automatically is optimize CSS. Methods like PurgeCSS are not ideal because of a limitation with the dynamic nature of class renderings and Vue (Problematic code like: `[btn-${props.variant}]: props.variant !== undefined`). With that being said, BootstrapVueNext does not handle CSS imports from Bootstrap, we only add some additional CSS ourselves. So, using a method such as [Lean Sass Imports](https://getbootstrap.com/docs/5.3/customize/optimize/#lean-sass-imports) from the Bootstrap documentation is likely the best way to achieve the tiniest possible application size. Though it is not automatic, it should prove the safest bet for minifying your application.
 
-### Tree-shaking
+### Tree-shaking with BApp
 
 When using the **BApp component approach**, you automatically get optimal tree-shaking as only the components and composables you actually use are included in your bundle.
 

--- a/apps/docs/src/docs/components/app.md
+++ b/apps/docs/src/docs/components/app.md
@@ -353,10 +353,15 @@ The `BApp` component is fully backward compatible with existing plugin-based set
 
 ::: warning Migration Note
 
-The plugins will show deprecation warnings but continue to work until removed in a future version.
+Plugins will show deprecation warnings but continue to work until removed in a future version, with
+the following exceptions:
 
-However, the individual plugins `modalControllerPlugin`, `toastControllerPlugin`, and `popoverControllerPlugin`
-are deprecated. Please replace references to these with a reference to `orchestratorPlugin`.
+- `modalControllerPlugin`
+- `toastControllerPlugin`
+- `popoverControllerPlugin`
+
+These plugins have been removed as of **version 0.40.0**.
+Please replace references to these with a reference to `orchestratorPlugin`.
 
 :::
 


### PR DESCRIPTION
# Describe the PR

I think it's worthwhile to be explicit about deprecations - I don't use individual plugins myself generally, but I think this would trip someone up who is upgrading - hopefully this clarifies.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added warning admonitions for backward-compatibility and plugin deprecations; cross-referenced BApp docs.
  * Expanded Automatic Registering of Components with guidance on using an automatic component plugin, installation snippets, config example, and aliasing note.
  * Added a "Tree-shaking with BApp" subsection explaining component vs plugin approaches, size guidance (~20kb gzipped) and migration tips.
  * No code or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->