### PR TITLE
docs(table): fix incorrect list item

### DIFF
--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -451,7 +451,7 @@ scoped slots (even when disabled)
 **Notes:**
 
 - Slot names **cannot** contain spaces, and when using in-browser DOM templates the slot names will _always_
-- be lower cased. To get around this, you can pass the slot name using Vue's
+  be lower cased. To get around this, you can pass the slot name using Vue's
   [dynamic slot names](https://vuejs.org/guide/components/slots.html#dynamic-slot-names)
 
 ### Adding additional rows to the header


### PR DESCRIPTION
# Describe the PR

Remove the extra hyphen `-` that created a new list item

## Small replication

Visit https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/table.html#header-and-footer-custom-rendering-via-scoped-slots (the end of this anchored section):
<img width="840" height="49" alt="image" src="https://github.com/user-attachments/assets/6d777d54-ed1d-4f54-b0a0-2f7932ee6136" />

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [-] Bugfix :bug: - `fix(...)`
- [-] Feature - `feat(...)`
- [-] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [-] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Adjusted indentation/continuation-line formatting in the Table component docs for improved readability and consistency.
  - Text content unchanged; no effect on features, behavior, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->