### PR TITLE
fix(BTable): events are no longer dispatched when emitted from inside TRs and THs (regression of version 0.40.2)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -470,7 +470,9 @@ const shouldRowBeFocusable = computed(
 )
 
 const handleHeaderKeydown = (field: TableField<Items>, event: KeyboardEvent, isFooter = false) => {
-  const {code} = event
+  const {target, code} = event
+
+  if (target && (target as Element).tagName !== 'TH' && document.activeElement === target) return
 
   if (code === 'Enter' || code === 'Space') {
     stopEvent(event)
@@ -479,7 +481,9 @@ const handleHeaderKeydown = (field: TableField<Items>, event: KeyboardEvent, isF
 }
 
 const handleRowKeydown = (item: Items, itemIndex: number, event: KeyboardEvent) => {
-  const {code, shiftKey} = event
+  const {target, code, shiftKey} = event
+
+  if (target && (target as Element).tagName !== 'TR' && document.activeElement === target) return
 
   if (code === 'Enter' || code === 'Space') {
     stopEvent(event)


### PR DESCRIPTION
Hello,
patch #2834 implemented keyboard navigation for BTable components, but unfortunately broke basic navigation (which previously worked).
Previously, it was possible to use the Tab key to focus elements (like buttons) in a BTable, and to use the spacebar or Enter key to activate these elements.
Now, when you use the spacebar or Enter key on these elements, either nothing happens or the TH/TR parent is incorrectly selected (when BTable has the "selectable" property).
This bug is caused by the fact that all keydown events are now handled by the BTr or BTh components and are systematically canceled, even though some keydown events should be handled by "internal" table elements.

My patch proposal is based on my own keyboard navigation implementation that I made some time ago (for my own use) and discussed [here](https://github.com/bootstrap-vue-next/bootstrap-vue-next/pull/2834#issuecomment-3262409906): https://stackblitz.com/edit/github-rzxbjv-nralwm3b

Maybe using `document.activeElement` wouldn't even be necessary, but this patch works perfectly as is in my case.

## Small replication
I made 3 demos (each with the same 2 tables inside) so you can compare the results between different versions of boostrap-vue-next.
- Basic navigation (using tab, enter and space keys) working correctly with v0.40.1: https://stackblitz.com/edit/github-huqpsoqb-uieuscdr
- space and enter keys **not working** on buttons and custom table headers with v0.40.2: https://stackblitz.com/edit/github-huqpsoqb-zaebhjhp
- space and enter keys **working** on buttons and custom table headers with v0.40.2 (using a patched version): https://stackblitz.com/edit/github-huqpsoqb-aaupkmx9

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in tables: key actions now trigger only when focus is on header cells or rows, preventing unintended behavior when interacting with inputs or links inside the table.
  * Maintains expected Enter/Space and Arrow/Home/End behavior in the correct context, reducing accidental activations and enhancing accessibility and predictability for keyboard-only users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->