### PR TITLE
fix(BToggle): console error when vBToggle directive unmounted

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/BPopover/index.ts
+++ b/packages/bootstrap-vue-next/src/directives/BPopover/index.ts
@@ -1,4 +1,4 @@
-import {type Directive, type Ref} from 'vue'
+import {type Directive} from 'vue'
 import {
   bind,
   type ElementWithPopper,
@@ -8,11 +8,11 @@ import {
   unbind,
 } from '../../utils/floatingUi'
 import {defaultsKey} from '../../utils/keys'
-import {findProvides} from '../utils'
+import {injectWithinDirective} from '../utils'
 
 export const vBPopover: Directive<ElementWithPopper> = {
-  mounted(el, binding, vnode) {
-    const defaults = (findProvides(binding, vnode) as Record<symbol, Ref>)[defaultsKey]?.value
+  mounted(el, binding) {
+    const defaults = injectWithinDirective(binding, defaultsKey)?.value
     const isActive = resolveActiveStatus(binding.value)
     if (!isActive) return
 
@@ -21,13 +21,13 @@ export const vBPopover: Directive<ElementWithPopper> = {
     if (!text.body && !text.title) return
     el.$__binding = JSON.stringify([binding.modifiers, binding.value])
     bind(el, binding, {
-      ...(defaults['BPopover'] || undefined),
+      ...(defaults?.['BPopover'] || undefined),
       ...resolveDirectiveProps(binding, el),
       ...text,
     })
   },
-  updated(el, binding, vnode) {
-    const defaults = (findProvides(binding, vnode) as Record<symbol, Ref>)[defaultsKey]?.value
+  updated(el, binding) {
+    const defaults = injectWithinDirective(binding, defaultsKey)?.value
 
     const isActive = resolveActiveStatus(binding.value)
     if (!isActive) return
@@ -39,7 +39,7 @@ export const vBPopover: Directive<ElementWithPopper> = {
     if (el.$__binding === JSON.stringify([binding.modifiers, binding.value])) return
     unbind(el)
     bind(el, binding, {
-      ...(defaults['BPopover'] || undefined),
+      ...(defaults?.['BPopover'] || undefined),
       ...resolveDirectiveProps(binding, el),
       ...text,
     })

--- a/packages/bootstrap-vue-next/src/directives/BToggle/index.ts
+++ b/packages/bootstrap-vue-next/src/directives/BToggle/index.ts
@@ -1,7 +1,7 @@
 import {RX_HASH, RX_HASH_ID, RX_SPACE_SPLIT} from '../../utils/constants'
-import {type Directive, type DirectiveBinding, toValue, type VNode} from 'vue'
-import {findProvides} from '../utils'
-import {type RegisterShowHideValue, showHideRegistryKey} from '../../utils/keys'
+import {type Directive, type DirectiveBinding, toValue} from 'vue'
+import {injectWithinDirective} from '../utils'
+import {showHideRegistryKey} from '../../utils/keys'
 
 const getTargets = (
   binding: DirectiveBinding<string | readonly string[] | undefined>,
@@ -35,16 +35,13 @@ const getTargets = (
 
 const handleUpdate = (
   el: Element,
-  binding: DirectiveBinding<string | readonly string[] | undefined>,
-  vnode: VNode
+  binding: DirectiveBinding<string | readonly string[] | undefined>
 ) => {
   // Determine targets
   const targets = getTargets(binding, el)
   if (targets.length === 0) return
 
-  const provides = findProvides(binding, vnode)
-  const showHideMap = (provides as Record<symbol, RegisterShowHideValue>)[showHideRegistryKey]
-    ?.values
+  const showHideMap = injectWithinDirective(binding, showHideRegistryKey)?.values
   if ((el as HTMLElement).dataset.bvtoggle) {
     const oldTargets = ((el as HTMLElement).dataset.bvtoggle || '').split(' ')
     if (oldTargets.length === 0) return
@@ -85,15 +82,12 @@ const handleUpdate = (
 }
 const handleUnmount = (
   el: Element,
-  binding: DirectiveBinding<string | readonly string[] | undefined>,
-  vnode: VNode
+  binding: DirectiveBinding<string | readonly string[] | undefined>
 ) => {
   // Determine targets
   const targets = getTargets(binding, el)
   if (targets.length === 0) return
-  const provides = findProvides(binding, vnode)
-  const showHideMap = (provides as Record<symbol, RegisterShowHideValue>)[showHideRegistryKey]
-    ?.values
+  const showHideMap = injectWithinDirective(binding, showHideRegistryKey)?.values
 
   targets.forEach((targetId) => {
     const showHide = showHideMap?.value.get(targetId)

--- a/packages/bootstrap-vue-next/src/directives/BTooltip/index.ts
+++ b/packages/bootstrap-vue-next/src/directives/BTooltip/index.ts
@@ -1,4 +1,4 @@
-import {type Directive, type Ref} from 'vue'
+import {type Directive} from 'vue'
 import {
   bind,
   type ElementWithPopper,
@@ -8,11 +8,11 @@ import {
   unbind,
 } from '../../utils/floatingUi'
 import {defaultsKey} from '../../utils/keys'
-import {findProvides} from '../utils'
+import {injectWithinDirective} from '../utils'
 
 export const vBTooltip: Directive<ElementWithPopper> = {
-  mounted(el, binding, vnode) {
-    const defaults = (findProvides(binding, vnode) as Record<symbol, Ref>)[defaultsKey]?.value
+  mounted(el, binding) {
+    const defaults = injectWithinDirective(binding, defaultsKey)?.value
     const isActive = resolveActiveStatus(binding.value)
     if (!isActive) return
 
@@ -22,14 +22,14 @@ export const vBTooltip: Directive<ElementWithPopper> = {
     el.$__binding = JSON.stringify([binding.modifiers, binding.value])
     bind(el, binding, {
       noninteractive: true,
-      ...(defaults['BTooltip'] || undefined),
+      ...(defaults?.['BTooltip'] || undefined),
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.body ?? '',
       tooltip: isActive,
     })
   },
-  updated(el, binding, vnode) {
-    const defaults = (findProvides(binding, vnode) as Record<symbol, Ref>)[defaultsKey]?.value
+  updated(el, binding) {
+    const defaults = injectWithinDirective(binding, defaultsKey)?.value
 
     const isActive = resolveActiveStatus(binding.value)
     if (!isActive) return
@@ -42,7 +42,7 @@ export const vBTooltip: Directive<ElementWithPopper> = {
     unbind(el)
     bind(el, binding, {
       noninteractive: true,
-      ...(defaults['BTooltip'] || undefined),
+      ...(defaults?.['BTooltip'] || undefined),
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.body ?? '',
       tooltip: isActive,

--- a/packages/bootstrap-vue-next/src/directives/utils.spec.ts
+++ b/packages/bootstrap-vue-next/src/directives/utils.spec.ts
@@ -1,0 +1,72 @@
+import {afterAll, describe, expect, it, vi} from 'vitest'
+import {type Component, provide} from 'vue'
+import {injectWithinDirective} from './utils'
+import {mount} from '@vue/test-utils'
+
+describe('injectWithinDirective', () => {
+  const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  afterAll(() => {
+    consoleErrorMock.mockReset()
+  })
+
+  it('nested providers', async () => {
+    let unmountedFoo: unknown = null
+
+    const ProviderTwo: Component = {
+      directives: {
+        test: {
+          mounted(el, binding) {
+            const foo = injectWithinDirective(binding, 'foo')
+            const bar = injectWithinDirective(binding, 'bar')
+            const baz = injectWithinDirective(binding, 'baz')
+            el.textContent = [foo, bar, baz].join(',')
+          },
+          unmounted(el, binding) {
+            unmountedFoo = injectWithinDirective(binding, 'foo')
+          },
+        },
+      },
+      props: {
+        show: {
+          type: Boolean,
+          default: true,
+        },
+      },
+      setup() {
+        // override parent value
+        provide('foo', 'fooOverride')
+        provide('baz', 'baz')
+      },
+      template: `<div v-if="show" v-test></div>`,
+    }
+
+    const ProviderOne = {
+      components: {ProviderTwo},
+      props: {
+        show: {
+          type: Boolean,
+          default: true,
+        },
+      },
+      setup() {
+        provide('foo', 'foo')
+        provide('bar', 'bar')
+      },
+      template: `<ProviderTwo :show="show" />`,
+    }
+
+    const wrapper = mount(ProviderOne)
+
+    // Should find all 3 injections
+    expect(wrapper.html()).toBe('<div>fooOverride,bar,baz</div>')
+
+    // Should not error when used during unmounted hook
+    await wrapper.setProps({show: false})
+    expect(wrapper.html()).toBe('<!--v-if-->')
+    expect(unmountedFoo).toBe('fooOverride')
+    expect(consoleErrorMock).toHaveBeenCalledTimes(0)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
# Describe the PR

Fixes #2856 by changing injection logic used in directive hooks. I ended up greatly simplifying the logic by looking at what Vue's inject method does behind the scenes and matching it. I don't know the background of the original logic here and why it was so complex, but as far as I can tell the complexity wasn't needed. All unit tests are passing, though coverage in this area appears somewhat low.

Main downside of this approach is the use of an internal API, however the previous solution was using even more internal APIs so that seems to be considered acceptable.

Ideally we would simply use `inject`, however until https://github.com/vuejs/core/issues/5002 is resolved we won't be able to.

## Small replication

See repro on #2856 as well as added unit test.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified directive internals for Popover, Tooltip, and Toggle to use a direct injection approach and remove vnode dependence, reducing complexity and improving reliability.

* **Bug Fixes**
  * Safer handling when defaults are absent to prevent potential runtime errors in Popover and Tooltip.

* **Tests**
  * Added comprehensive tests validating directive-based injections and override behavior across nested providers, ensuring correct lifecycle handling and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->