### PR TITLE
docs(bmodal): mark header-tag and footer-tag as deprecated

### DIFF
--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -608,7 +608,7 @@ flex utility classes. See their [documentation](https://getbootstrap.com/docs/5.
 ### BModal
 
 `footer-tag` and `header-tag` are deprecated, use the `footer` and `title` slots instead. See the
-[modal documentation](/docs/components/modal/#custom-rendering-with-slots) for details.
+[modal documentation](/docs/components/modal#custom-rendering-with-slots) for details.
 
 #### Removed Global Modal Management
 
@@ -701,7 +701,7 @@ See the [v-html](#v-html) section for information on deprecation of the `cancel-
 
 #### Modal Slot changes
 
-[BootstrapVue](https://bootstrap-vue.github.io/bootstrap-vue/docs/components/modal#custom-rendering-with-slots) provides different slots to configure some pieces of the modal component. These slots are slightly different in [BootstrapVueNext](/docs/components/modal.html#comp-reference-bmodal-slots):
+[BootstrapVue](https://bootstrap-vue.github.io/bootstrap-vue/docs/components/modal#custom-rendering-with-slots) provides different slots to configure some pieces of the modal component. These slots are slightly different in [BootstrapVueNext](/docs/components/modal#comp-reference-bmodal-slots):
 
 | BootstrapVue       | BootstrapVueNext |
 | ------------------ | ---------------- |


### PR DESCRIPTION
# Describe the PR

resolves #2867

- Add note and workaround to the migration guide
- Update parity spreadsheet

## Small replication

N/A

## PR checklist

<!-- (Update “[ ]“ to “[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide for BModal: clarified that footer-tag and header-tag are deprecated and recommends using the footer and title slots for custom rendering.
  * Fixed and updated the slot reference link/anchor in the Modal Slot changes section to point to the correct slot-based rendering documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->