### PR TITLE
docs(BModal): fix attribute to hide footer

### DIFF
--- a/apps/docs/src/docs/components/demo/ModalExposed.vue
+++ b/apps/docs/src/docs/components/demo/ModalExposed.vue
@@ -14,7 +14,7 @@
     </div>
     <BModal
       ref="my-modal"
-      hide-footer
+      no-footer
       title="Using Component Methods"
     >
       <div class="d-block text-center">


### PR DESCRIPTION
# Describe the PR

The example used the old `bootstrap-vue` attribute `hide-footer` instead of the new `no-footer` attribute.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated modal component demonstration in the documentation to reflect current control options for footer visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->