### PR TITLE
fix(BOffcanvas): Add a footer class

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -59,7 +59,7 @@
           <div class="offcanvas-body" :class="props.bodyClass" v-bind="props.bodyAttrs">
             <slot v-bind="sharedSlots" />
           </div>
-          <div v-if="hasFooterSlot" :class="props.footerClass">
+          <div v-if="hasFooterSlot" class="offcanvas-footer" :class="props.footerClass">
             <slot name="footer" v-bind="sharedSlots" />
           </div>
         </template>


### PR DESCRIPTION
# Describe the PR

title and body have default classes set, but footer has not. Why? It seems inconsistent, so adding one.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved offcanvas footer styling by adding a dedicated CSS class to the footer container when a footer slot is present, preserving any existing footer class bindings for compatibility and consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->