### PR TITLE
fix: BFormRadioGroup - prevent forwarding option attrs that override input id

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
@@ -90,18 +90,29 @@ const normalizeOptions = computed<
     [key: string]: unknown
   }[]
 >(() =>
-  props.options.map((el) =>
+  props.options.map((el, index) =>
     typeof el === 'string' || typeof el === 'number'
       ? {
+          id: `${computedId.value}__${index}`,
           value: el,
           disabled: props.disabled,
           text: el.toString(),
         }
       : {
-          ...el,
-          value: el[props.valueField],
-          disabled: el[props.disabledField] as boolean | undefined,
-          text: el[props.textField] as string | undefined,
+          // Only include a small set of well-known properties on the
+          // normalized option object. We deliberately DO NOT spread the
+          // original `el` object because arbitrary keys (for example a key
+          // named `Id`) would be forwarded as attributes ($attrs) to the
+          // child `BFormRadio` and then bound onto the native <input>, which
+          // can inadvertently override the input `id` (case-insensitive in
+          // HTML) and break the label `for` association. By building a
+          // clean object we avoid such accidental attribute collisions.
+          id: (el as Record<string, unknown>).id ?? `${computedId.value}__${index}`,
+          value: (el as Record<string, unknown>)[props.valueField] as unknown,
+          disabled: (el as Record<string, unknown>)[props.disabledField] as
+            | boolean
+            | undefined,
+          text: (el as Record<string, unknown>)[props.textField] as string | undefined,
         }
   )
 )

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts
@@ -200,5 +200,38 @@ describe('form-radio-group', () => {
       expect(radios[1].text()).toBe('foo')
       expect(radios[2].text()).toBe('foo')
     })
+
+    it('clicking label toggles selection when using custom valueField Id and buttons', async () => {
+      const options = [
+        { Id: 1, Label: 'Radio 1' },
+        { Id: 2, Label: 'Radio 2' },
+        { Id: 3, Label: 'Radio 3' },
+      ]
+
+      const wrapper = mount(BFormRadioGroup, {
+        props: {
+          options,
+          // use capitalized keys to reproduce the reported issue
+          valueField: 'Id',
+          textField: 'Label',
+          buttons: true,
+          modelValue: null,
+          name: 'test-radios',
+        },
+      })
+
+  // Ensure label `for` matches input `id` (this is the key fix)
+  const labels = wrapper.findAll('label')
+  const inputs = wrapper.findAll('input')
+  expect(labels.length).toBeGreaterThan(0)
+  expect(inputs.length).toBeGreaterThan(0)
+  const labelFor = labels[0].attributes('for')
+  const inputId = inputs[0].attributes('id')
+  expect(labelFor).toBe(inputId)
+
+  // Clicking the input should toggle selection (input becomes checked)
+  await inputs[0].trigger('click')
+  expect((inputs[0].element as HTMLInputElement).checked).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Fixes #2898

Disclaimer: this fix was coded by Copilot using "Code with agent mode" button.

### Summary

This PR fixes a bug where object option keys (for example `Id`) were forwarded via $attrs onto the native <input> and could override the computed id (HTML attribute names are case-insensitive). That broke the label for association and prevented clicks on labels/buttons from selecting the radio when using textField/valueField and buttons styles.

What I changed:
- Do not spread original option object into normalized option. Build a clean object with only: id, value, text, disabled.
- Generate deterministic id per option (<group-id>__<index>) when not provided.
- Add unit test that reproduces the case where options use capitalized Id as valueField and buttons: true.

Validation:
- Built package and ran tests locally: all unit tests pass and lint has no errors (only minor warnings).

Files changed:
- packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
- packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts

Please review and let me know if you prefer forcing generated ids even when id is provided by options.
