### PR TITLE
fix(BTable): always allow text selection when properties "selectable" and "no-select-on-click" are used together

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -387,7 +387,7 @@ const computedFields = computed<TableField<Items>[]>(() =>
 const tableClasses = computed(() => ({
   'b-table-busy': busyModel.value,
   'b-table-selectable': props.selectable,
-  'user-select-none': props.selectable && isSelecting.value,
+  'user-select-none': props.selectable && !props.noSelectOnClick && isSelecting.value,
   'b-table-fixed': props.fixed,
   'b-table-no-border-collapse': props.noBorderCollapse,
   'b-table-no-sort-icon': props.noSortableIcon,


### PR DESCRIPTION
Hello,
there's a specific case where text selection with the mouse is impossible in a b-table.

I have b-tables where I simultaneously use the "selectable" and "no-select-on-click" properties because I manage row selection myself using the `unselectRow()` and `selectRow()` methods.

Using the properties "selectable" and "no-select-on-click" doesn't need to disable text selection when a table row is selected, so let's fix that (and let make my users happy again).

Btw, the condition `props.selectable && !props.noSelectOnClick` is already used elsewhere in the bootstrap-vue-next code.

## Small replication

I created 2 demos (each with the same table inside) so you can compare the results with and without this fix by trying to select text in the b-table before and after clicking some of the "Select/Deselect" buttons:

- "buggy" version (text selection doesn't work in the b-table when a row is selected) : https://stackblitz.com/edit/github-huqpsoqb-sbg3hjra
- patched version allowing text selection when a row is selected: https://stackblitz.com/edit/github-huqpsoqb-bogxgahy

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed BTable component to properly respect the `noSelectOnClick` property during item selection. When enabled, the table now correctly manages text-selection behavior, delivering more predictable user interactions with selectable tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->