### PR TITLE
feat(BFormGroup): add props to apply attrs to label and content wrappers in horizontal mode

### DIFF
--- a/apps/docs/src/data/components/formGroup.data.ts
+++ b/apps/docs/src/data/components/formGroup.data.ts
@@ -41,6 +41,12 @@ export default {
           default: 'undefined',
           description: "Number of columns for the content width 'xl' screens and up",
         },
+        contentWrapperAttrs: {
+          type: 'Readonly<AttrsValue>',
+          default: 'undefined',
+          description:
+            'Additional attributes to apply to the content column wrapper in horizontal layout mode. Useful for adding custom classes or styles to control the width/layout of the content column. Only applies when using label-cols or content-cols props',
+        },
         description: {
           type: 'string',
           default: 'undefined',
@@ -138,6 +144,12 @@ export default {
           default: 'false',
           description:
             'Visually hides the label content, but makes it available to screen reader users',
+        },
+        labelWrapperAttrs: {
+          type: 'Readonly<AttrsValue>',
+          default: 'undefined',
+          description:
+            'Additional attributes to apply to the label column wrapper in horizontal layout mode. Useful for adding custom classes or styles to override the default column width set by label-cols. Only applies when using label-cols or content-cols props',
         },
         validFeedback: {
           type: 'string',

--- a/apps/docs/src/docs/components/demo/FormGroupWrapperAttrsBasic.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupWrapperAttrsBasic.vue
@@ -1,0 +1,15 @@
+<template>
+  <!-- #region template -->
+  <BFormGroup
+    label="My Label:"
+    label-for="my-input"
+    label-cols-md="3"
+    :label-wrapper-attrs="{
+      class: 'custom-label-width',
+      style: 'flex: 0 0 120px; max-width: 120px;',
+    }"
+  >
+    <BFormInput id="my-input" />
+  </BFormGroup>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/FormGroupWrapperAttrsCustom.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupWrapperAttrsCustom.vue
@@ -1,0 +1,25 @@
+<template>
+  <BFormGroup
+    label="Active:"
+    label-for="status"
+    label-align-md="end"
+    label-cols-md="3"
+    :label-wrapper-attrs="{
+      class: 'custom-label-field',
+    }"
+  >
+    <BFormCheckbox
+      id="status"
+      switch
+    />
+  </BFormGroup>
+</template>
+
+<style scoped>
+@media (min-width: 768px) {
+  :deep(.custom-label-field) {
+    flex: 0 0 120px !important;
+    max-width: 120px !important;
+  }
+}
+</style>

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -91,6 +91,26 @@ value via the prop `label-text-align` and/or `label-align-{breakpoint}`.
 
 Alignment has no effect if the `label-visually-hidden` prop is set.
 
+### Customizing wrapper elements in horizontal layout
+
+When using horizontal layout (with `label-cols` or `content-cols` props), the label and content are wrapped in column elements. You can apply additional attributes, classes, or styles to these wrapper elements using the `label-wrapper-attrs` and `content-wrapper-attrs` props.
+
+This is particularly useful when you need to override the default column widths with custom sizing:
+
+<<< DEMO ./demo/FormGroupWrapperAttrsBasic.vue#template{vue-html}
+
+**Important Notes:**
+
+- These props **only apply in horizontal layout mode** (when `label-cols` or `content-cols` is set)
+- `label-wrapper-attrs` applies to the column wrapper around the label element
+- `content-wrapper-attrs` applies to the column wrapper around the content/input
+- Use `label-class` if you need to style the `<label>` or `<legend>` element itself
+- The `class` property in wrapper attrs will be merged with the Bootstrap column classes
+
+**Common use case:** You need more precise control over column widths than Bootstrap's 12-column grid provides. For example, setting a label to exactly 120px wide using flexbox properties:
+
+<<< DEMO ./demo/FormGroupWrapperAttrsCustom.vue{vue}
+
 ## Nested form groups
 
 Feel free to nest `BFormGroup` components to produce advanced form layouts and semantic grouping

--- a/apps/playground/src/components/Comps/TFormGroup.vue
+++ b/apps/playground/src/components/Comps/TFormGroup.vue
@@ -47,6 +47,44 @@
         </BFormGroup>
       </BCol>
     </BRow>
+    <BRow>
+      <BCol>
+        <h4 class="mt-4 mb-3">Using label-wrapper-attrs prop</h4>
+
+        <BFormGroup
+          label="Aktiv:"
+          label-for="test-active-fixed"
+          label-align-md="end"
+          label-cols-md="3"
+          :label-wrapper-attrs="{class: 'custom-label-field'}"
+          class="align-items-center test-form-group"
+        >
+          <BFormCheckbox id="test-active-fixed" placeholder="" switch />
+        </BFormGroup>
+
+        <BFormGroup
+          label="Standard:"
+          label-for="test-default-fixed"
+          label-align-md="end"
+          label-cols-md="3"
+          :label-wrapper-attrs="{class: 'custom-label-field'}"
+          class="align-items-center test-form-group"
+        >
+          <BFormCheckbox id="test-default-fixed" placeholder="" switch />
+        </BFormGroup>
+
+        <BFormGroup
+          label="Name:"
+          label-for="test-name-fixed"
+          label-align-md="end"
+          label-cols-md="3"
+          :label-wrapper-attrs="{class: 'custom-label-field'}"
+          class="align-items-center test-form-group"
+        >
+          <BFormInput id="test-name-fixed" placeholder="Enter name" />
+        </BFormGroup>
+      </BCol>
+    </BRow>
   </BContainer>
 </template>
 
@@ -69,3 +107,21 @@ const onTagState = (valid: string[], invalid: string[], duplicate: string[]) => 
 
 const name = ref('')
 </script>
+
+<style scoped>
+@media (min-width: 768px) {
+  :deep(.custom-label-field) {
+    flex: 0 0 120px !important;
+    max-width: 120px !important;
+    padding-right: 5px !important;
+    background-color: rgba(255, 0, 0, 0.1); /* Visual indicator to see if it's applied */
+  }
+}
+
+:deep(.test-form-group) {
+  border: 1px solid #dee2e6;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 0.25rem;
+}
+</style>

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
@@ -35,7 +35,11 @@
     </ContentTemplate.define>
     <LabelContentTemplate.define>
       <template v-if="slots.label || props.label || isHorizontal">
-        <BCol v-if="isHorizontal" v-bind="labelColProps" :class="labelAlignClasses">
+        <BCol
+          v-if="isHorizontal"
+          v-bind="{...labelColProps, ...props.labelWrapperAttrs}"
+          :class="labelAlignClasses"
+        >
           <component
             :is="labelTag"
             :id="labelId"
@@ -63,7 +67,7 @@
     <!-- End of definitions -->
     <BFormRow v-if="isHorizontal" :class="rowAttrs.class" :style="rowAttrs.style">
       <LabelContentTemplate.reuse />
-      <BCol v-bind="contentColProps" ref="_content">
+      <BCol v-bind="{...contentColProps, ...props.contentWrapperAttrs}" ref="_content">
         <slot
           :id="computedId"
           :aria-describedby="null"
@@ -128,6 +132,7 @@ const _props = withDefaults(defineProps<BFormGroupProps>(), {
   contentColsMd: undefined,
   contentColsSm: undefined,
   contentColsXl: undefined,
+  contentWrapperAttrs: undefined,
   description: undefined,
   disabled: false,
   feedbackAriaLive: 'assertive',
@@ -149,6 +154,7 @@ const _props = withDefaults(defineProps<BFormGroupProps>(), {
   labelFor: undefined,
   labelSize: undefined,
   labelVisuallyHidden: false,
+  labelWrapperAttrs: undefined,
   state: null,
   tooltip: false,
   validFeedback: undefined,

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -512,5 +512,101 @@ describe('form-group', () => {
       const label = wrapper.find('label')
       expect(label.classes()).toContain('text-center')
     })
+
+    it('applies labelWrapperAttrs to label wrapper BCol in horizontal mode', () => {
+      const wrapper = mount(BFormGroup, {
+        props: {
+          label: 'Login:',
+          labelFor: 'loginname',
+          labelColsMd: 3,
+          labelWrapperAttrs: {
+            'class': 'custom-label-wrapper',
+            'data-testid': 'label-wrapper',
+          },
+        },
+        slots: {
+          default: h(BFormInput, {id: 'loginname'}),
+        },
+      })
+      // Find the BCol component that wraps the label
+      const [labelCol] = wrapper
+        .findAll('[class*="col-"]')
+        .filter((el) => el.html().includes('Login:'))
+      expect(labelCol?.classes()).toContain('custom-label-wrapper')
+      expect(labelCol?.attributes('data-testid')).toBe('label-wrapper')
+    })
+
+    it('applies contentWrapperAttrs to content wrapper BCol in horizontal mode', () => {
+      const wrapper = mount(BFormGroup, {
+        props: {
+          label: 'Login:',
+          labelFor: 'loginname',
+          labelColsMd: 3,
+          contentWrapperAttrs: {
+            'class': 'custom-content-wrapper',
+            'data-testid': 'content-wrapper',
+          },
+        },
+        slots: {
+          default: h(BFormInput, {id: 'loginname'}),
+        },
+      })
+      // Find the BCol component that wraps the content (it has data-testid)
+      const contentCol = wrapper.find('[data-testid="content-wrapper"]')
+      expect(contentCol.exists()).toBe(true)
+      expect(contentCol.classes()).toContain('custom-content-wrapper')
+      expect(contentCol.classes()).toContain('col')
+    })
+
+    it('allows labelWrapperAttrs class to override column sizing', () => {
+      const wrapper = mount(BFormGroup, {
+        props: {
+          label: 'Login:',
+          labelFor: 'loginname',
+          labelColsMd: 3,
+          labelWrapperAttrs: {
+            class: 'custom-width-class',
+            style: 'flex: 0 0 120px; max-width: 120px;',
+          },
+        },
+        slots: {
+          default: h(BFormInput, {id: 'loginname'}),
+        },
+      })
+      const [labelCol] = wrapper
+        .findAll('[class*="col-"]')
+        .filter((el) => el.html().includes('Login:'))
+      expect(labelCol?.classes()).toContain('custom-width-class')
+      // Vue normalizes shorthand flex to longhand properties
+      expect(labelCol?.attributes('style')).toContain('flex-basis: 120px')
+      expect(labelCol?.attributes('style')).toContain('max-width: 120px')
+    })
+
+    it('applies both labelWrapperAttrs and contentWrapperAttrs simultaneously', () => {
+      const wrapper = mount(BFormGroup, {
+        props: {
+          label: 'Login:',
+          labelFor: 'loginname',
+          labelColsMd: 3,
+          labelWrapperAttrs: {
+            'class': 'label-custom',
+            'data-testid': 'label-col',
+          },
+          contentWrapperAttrs: {
+            'class': 'content-custom',
+            'data-testid': 'content-col',
+          },
+        },
+        slots: {
+          default: h(BFormInput, {id: 'loginname'}),
+        },
+      })
+      const labelCol = wrapper.find('[data-testid="label-col"]')
+      const contentCol = wrapper.find('[data-testid="content-col"]')
+      expect(labelCol.exists()).toBe(true)
+      expect(contentCol.exists()).toBe(true)
+      expect(labelCol.classes()).toContain('label-custom')
+      expect(contentCol.classes()).toContain('content-custom')
+    })
   })
 })

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1491,6 +1491,7 @@ export interface BFormGroupProps
   labelCols?: boolean | Numberish
   labelAlign?: string
   ariaInvalid?: AriaInvalid
+  contentWrapperAttrs?: Readonly<AttrsValue>
   description?: string
   disabled?: boolean
   feedbackAriaLive?: string
@@ -1502,6 +1503,7 @@ export interface BFormGroupProps
   labelFor?: string
   labelSize?: string
   labelVisuallyHidden?: boolean
+  labelWrapperAttrs?: Readonly<AttrsValue>
   state?: ValidationState
   tooltip?: boolean
   validFeedback?: string


### PR DESCRIPTION
# Describe the PR

Fixes #2950

- Adds `label-wrapper-attrs` and `content-wrapper-attrs` to wrapper divs created in horizontal mode.
- Adds testing for new props
- Adds documentation for new props
-
## Small replication

See the bug

## PR checklist

<!-- (Update “[ ]“ to “[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(…)`
- [ ] Feature - `feat(…)`
- [ ] ARIA accessibility - `fix(…)`
- [x] Documentation update - `docs(…)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable wrapper attributes for BFormGroup in horizontal layouts via new `contentWrapperAttrs` and `labelWrapperAttrs` props, enabling precise column width control and custom styling beyond Bootstrap's default grid.

* **Documentation**
  * Updated form group documentation with examples demonstrating how to customize label and content wrapper attributes.

* **Tests**
  * Added unit tests verifying wrapper attribute functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->