### PR TITLE
fix(docs): Make bootstrap, bootstrap-vue-next and @bootstrap-vue-nextnuxt runtime dependencies in the Nuxt docs section; make @floating-ui/vue, @vueuse/core and vue-router runtime dependencies

### DIFF
--- a/apps/docs/src/docs.md
+++ b/apps/docs/src/docs.md
@@ -214,19 +214,19 @@ In your Nuxt3 application, install the necessary packages for `bootstrap-vue-nex
 ::: code-group
 
 ```bash [PNPM]
-pnpm add bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt -D
+pnpm add bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt
 ```
 
 ```bash [BUN]
-bun add bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt -D
+bun add bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt
 ```
 
 ```bash [YARN]
-yarn add bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt -D
+yarn add bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt
 ```
 
 ```bash [NPM]
-npm i bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt -D
+npm i bootstrap bootstrap-vue-next @bootstrap-vue-next/nuxt
 ```
 
 :::
@@ -296,19 +296,19 @@ This package uses optional peer dependencies to generate type definitions for en
 ::: code-group
 
 ```bash [PNPM]
-pnpm add -D @floating-ui/vue @vueuse/core vue-router
+pnpm add @floating-ui/vue @vueuse/core vue-router
 ```
 
 ```bash [BUN]
-bun add -D @floating-ui/vue @vueuse/core vue-router
+bun add @floating-ui/vue @vueuse/core vue-router
 ```
 
 ```bash [YARN]
-yarn add -D @floating-ui/vue @vueuse/core vue-router
+yarn add @floating-ui/vue @vueuse/core vue-router
 ```
 
 ```bash [NPM]
-npm i -D @floating-ui/vue @vueuse/core vue-router
+npm i @floating-ui/vue @vueuse/core vue-router
 ```
 
 :::


### PR DESCRIPTION
# Describe the PR

The docs in the Vue section indicate that `bootstrap`, `bootstrap-vue-next` and `@bootstrap-vue-next/nuxt` should be installed as runtime dependencies, however in the Nuxt section they are required to be installed as dev dependencies which is not correct.
`@floating-ui/vue`, `@vueuse/core` and `vue-router` should be installed as dependencies as well, according to their respective documentations.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions across package managers (PNPM, BUN, YARN, NPM) to reflect installing the package as a regular dependency instead of a development dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->