### PR TITLE
fix: synchronize input visual value with formatted model value

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormInput/form-input.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/form-input.spec.ts
@@ -446,6 +446,30 @@ describe('form-input', () => {
       await wrapper.trigger('input')
       expect(formatter).toHaveBeenCalledWith('test', expect.any(Event))
     })
+    
+    it('keeps input display value in sync with formatted value when formatted equals previous model', async () => {
+      // Reproduces: typing disallowed chars when formatter strips them and formatted == previous model
+      // e.g. model is "1", user types "a" making raw value "1a", formatter returns "1"
+      // Since model stays "1" (no change), Vue won't re-render, so the input must be updated directly
+      const digitsOnly = (val: string) => val.replace(/\D/g, '')
+      const wrapper = mount(BFormInput, {props: {modelValue: '1', formatter: digitsOnly}})
+      // Simulate the user having typed "1a" into the field
+      wrapper.element.value = '1a'
+      await wrapper.trigger('input')
+      // The model should remain "1" (no new emission since value is unchanged)
+      // The displayed input value must also be "1" (not "1a")
+      expect(wrapper.element.value).toBe('1')
+    })
+
+    it('updates input display value to formatted value when formatter strips characters', async () => {
+      // Formatter only allows digits
+      const digitsOnly = (val: string) => val.replace(/\D/g, '')
+      const wrapper = mount(BFormInput, {props: {modelValue: '', formatter: digitsOnly}})
+      // User types "a" — formatter returns "" which equals previous model ""
+      wrapper.element.value = 'a'
+      await wrapper.trigger('input')
+      expect(wrapper.element.value).toBe('')
+    })
   })
 
   describe('formGroupKey injection', () => {

--- a/packages/bootstrap-vue-next/src/composables/useFormInput.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormInput.ts
@@ -81,6 +81,13 @@ export const useFormInput = (
     const nextModel = formattedValue
 
     updateModelValue(nextModel)
+     // If the formatter changed the value, directly update the input's visual value
+    // to keep the displayed text in sync with the model. Without this, if the
+    // formatted value equals the previous model value, Vue's reactivity won't
+    // re-render the input and the raw (unformatted) text remains visible.
+    if (formattedValue !== value && input.value) {
+      ;(input.value as HTMLInputElement | HTMLTextAreaElement).value = formattedValue
+    }
   }
 
   const onChange = (evt: Readonly<Event>) => {


### PR DESCRIPTION
fix #2826
This change ensures that when the formatter alters the input value, the displayed value in the input field is updated immediately.
Previously, if the formatted value happened to be equal to the previous model value, Vue’s reactivity system would not trigger a re-render. As a result, the raw (unformatted) text could remain visible in the input field.
With this update, the input’s visual value is explicitly updated whenever the formatter changes the value, ensuring that the displayed text always stays consistent with the model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form input display synchronization when the formatter modifies the user input, ensuring the visible text always reflects the formatted value.

* **Tests**
  * Added unit tests to verify form input formatter behavior with character stripping and value consistency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->