### PR TITLE
fix(BPopover): Allow focus=false popovers to hide when target is focused (#3113)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
@@ -365,7 +365,8 @@ const tryHide = (e?: Readonly<Event>) => {
       isOutside &&
       triggerIsOutside &&
       !floatingElement.value?.contains(document?.activeElement) &&
-      !triggerElement.value?.contains(document?.activeElement)) ||
+      (!computedTriggers.value.focus ||
+        !triggerElement.value?.contains(document?.activeElement))) ||
     (props.noninteractive && triggerIsOutside)
   ) {
     hide(e?.type)


### PR DESCRIPTION
# Describe the PR

Fixes https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/3113 by skipping the focus check when the `focus` trigger mode is not enabled.

I have manually tested that all the examples in the [linked section of the documentation](https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/popover.html#basic-trigger-configuration) work.

I looked at adding a test to `popover.spec.ts` but struggled to find a good way to pass the (other, issue non-relevant) checks in `tryHide` without adding quite a lot of intrusive mocking. There are no existing tests that check `hide` events being emitted.

## Small replication

See https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/3113

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popover dismissal behavior when focus triggering is disabled, ensuring popovers hide more reliably in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->