### PR TITLE
fix(modal): don't steal focus after shown handler focuses input

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
@@ -319,7 +319,20 @@ const {needsFallback} = useActivatedFocusTrap({
     ref: fallbackFocusElement,
     classSelector: fallbackClassSelector,
   },
-  focus: () => (props.focus === false ? false : (unrefElement(pickFocusItem()) ?? undefined)),
+  focus: () => {
+    if (props.focus === false) {
+      return false
+    }
+
+    if (props.focus === undefined) {
+      const active = getSafeDocument()?.activeElement
+      if (active instanceof HTMLElement && element.value?.contains(active)) {
+        return false
+      }
+    }
+
+    return unrefElement(pickFocusItem()) ?? undefined
+  },
   // () => (typeof focus === 'boolean' ? focus : (unrefElement(focus) ?? undefined)),
 })
 

--- a/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
@@ -454,6 +454,35 @@ describe('modal', () => {
     wrapper.unmount()
   })
 
+  it('keeps focus on an input focused from the shown event', async () => {
+    const wrapper = mount(BModal, {
+      attachTo: document.body,
+      global: {
+        stubs: {teleport: true, transition: false},
+      },
+      props: {
+        modelValue: true,
+        noHeader: true,
+        noFooter: true,
+      },
+      attrs: {
+        onShown: () => {
+          ;(document.getElementById('shown-focus-input') as HTMLInputElement | null)?.focus()
+        },
+      },
+      slots: {
+        default: '<input id="shown-focus-input" />',
+      },
+    })
+
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect((document.activeElement as HTMLElement | null)?.id).toBe('shown-focus-input')
+
+    wrapper.unmount()
+  })
+
   describe('button and event functionality', () => {
     it('header close button triggers modal close and is preventable', async () => {
       let cancelHide = true


### PR DESCRIPTION
Fixes #3141

When no explicit `focus` prop is provided, focus trap activation could still force focus back to the modal root even if a consumer already focused an input in the `shown` handler.

This change keeps existing behavior for explicit `focus` values, but skips forcing initial focus when an element inside the modal is already active. Added a regression test that focuses an input from `onShown` and verifies focus remains there.

Greetings, saschabuehrle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal focus trapping behavior to avoid redirecting focus when the user's focus is already positioned on an element contained within the modal, resulting in a smoother interaction experience with form inputs and other interactive components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->