### PR TITLE
feat: export all types

### DIFF
--- a/packages/bootstrap-vue-next/package.json
+++ b/packages/bootstrap-vue-next/package.json
@@ -129,6 +129,14 @@
         "default": "./dist/src/types/index.umd.js"
       }
     },
+    "./types/*": {
+      "import": {
+        "types": "./dist/types/*.d.mts"
+      },
+      "require": {
+        "types": "./dist/types/*.d.ts"
+      }
+    },
     "./dist/bootstrap-vue-next.css": "./dist/bootstrap-vue-next.css",
     "./src/styles/styles.scss": "./src/styles/styles.scss"
   },


### PR DESCRIPTION
# Describe the PR

Expose `bootstrap-vue-next/types/*` as a public subpath export, allowing consumers to import individual or niche types directly:

```ts
import { type Numberish } from "bootstrap-vue-next/types/CommonTypes"
```

This solve a problem for package authors that would like to create wrapper components and re-use (and not duplicate) the types used by BootstrapVueNext internally.

Fixes: #3152 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package exports updated to expose per-file type declarations for both ESM and CommonJS consumers.
  * Added a wildcard types subpath so individual type declaration files can be imported directly.
  * Improved TypeScript tooling and module resolution compatibility for projects consuming the package's types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->