### PR TITLE
feat(BAspect): Create BAspect component

### DIFF
--- a/apps/docs/src/data/components/aspect.data.ts
+++ b/apps/docs/src/data/components/aspect.data.ts
@@ -18,7 +18,7 @@ export default {
         ),
         aspect: {
           type: 'string | number',
-          default: undefined,
+          default: '1:1',
           description: 'Aspect ratio of the container, eg: 16/9, 16:9, 16x9, 1.77',
         },
       } satisfies PropRecord<keyof BAspectProps>,

--- a/apps/docs/src/data/components/aspect.data.ts
+++ b/apps/docs/src/data/components/aspect.data.ts
@@ -1,0 +1,33 @@
+import type { BAspectProps, BAspectSlots } from 'bootstrap-vue-next'
+import { type ComponentReference, type PropRecord, type SlotRecord, StyleKind } from '../../types'
+import { pick } from '../../utils/objectUtils'
+import { buildCommonProps } from '../../utils/commonProps'
+
+export default {
+  load: (): ComponentReference => ({
+    BAspect: {
+      styleSpec: { kind: StyleKind.BsvnClass },
+      props: {
+        ...pick(
+          buildCommonProps({
+            tag: {
+              default: 'div',
+            },
+          }),
+          ['tag'],
+        ),
+        aspect: {
+          type: 'string | number',
+          default: undefined,
+          description: 'Aspect ratio of the container, eg: 16/9, 16:9, 16x9, 1.77',
+        },
+      } satisfies PropRecord<keyof BAspectProps>,
+      emits: {},
+      slots: {
+        default: {
+          description: 'Content to place in the aspect container.',
+        },
+      } satisfies SlotRecord<keyof BAspectSlots>,
+    },
+  }),
+}

--- a/apps/docs/src/docs/components/aspect.md
+++ b/apps/docs/src/docs/components/aspect.md
@@ -4,6 +4,7 @@ description: >
 ---
 
 ## Overview
+
 The default aspect ratio is 1:1 (ratio of 1), which makes the height always be at least the same as the width. 
 The aspect prop can be used to specify an arbitrary aspect ratio (i.e. 1.5) or a ratio as a string such as '16:9' or '4:3'.
 

--- a/apps/docs/src/docs/components/aspect.md
+++ b/apps/docs/src/docs/components/aspect.md
@@ -1,0 +1,12 @@
+---
+description: >
+  The <BAspect> component can be used to maintain a minimum responsive aspect ratio for content. When the content is longer than the available height, then the component will expand vertically to fit all content. If the content is shorter than the computed aspect height, the component will ensure a minimum height is maintained.
+---
+
+## Overview
+The default aspect ratio is 1:1 (ratio of 1), which makes the height always be at least the same as the width. 
+The aspect prop can be used to specify an arbitrary aspect ratio (i.e. 1.5) or a ratio as a string such as '16:9' or '4:3'.
+
+The width will always be 100% of the available width in the parent element/component.
+
+<<< DEMO ./demo/AspectOverview.vue#template{vue-html}

--- a/apps/docs/src/docs/components/demo/AspectOverview.vue
+++ b/apps/docs/src/docs/components/demo/AspectOverview.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BAspect aspect="16:9">
+    <div class="bg-secondary d-flex align-items-center justify-content-center text-white h-100">
+      Content placed in a 16:9 container
+    </div>
+  </BAspect>
+  <!-- #endregion template -->
+</template>

--- a/packages/bootstrap-vue-next/src/components/BAspect/BAspect.vue
+++ b/packages/bootstrap-vue-next/src/components/BAspect/BAspect.vue
@@ -1,0 +1,32 @@
+<template>
+  <component :is="props.tag" class="b-aspect d-flex">
+    <div :style="{paddingBottom: computedPadding, height: 0}" class="b-aspect-sizer flex-grow-1" />
+    <div class="b-aspect-content flex-grow-1 w-100 mw-100" style="margin-left: -100%">
+      <slot />
+    </div>
+  </component>
+</template>
+
+<script setup lang="ts">
+import {computed} from 'vue'
+import type {BAspectProps} from '../../types/ComponentProps'
+import {useDefaults} from '../../composables/useDefaults'
+
+const _props = withDefaults(defineProps<BAspectProps>(), {
+  tag: 'div',
+  aspect: '1:1',
+})
+const props = useDefaults(_props, 'BAspect')
+
+const computedPadding = computed(() => {
+  const aspect = String(props.aspect)
+  let ratio
+  if (/^\d+(\.\d*)?[/:x]\d+(\.\d*)?$/.test(aspect)) {
+    const [width = 1, height = 1] = aspect.split(/[/:x]/).map((v) => Number.parseFloat(v) || 1)
+    ratio = width / height
+  } else {
+    ratio = Number.parseFloat(aspect) || 1
+  }
+  return `${100 / Math.abs(ratio)}%`
+})
+</script>

--- a/packages/bootstrap-vue-next/src/components/BAspect/aspect.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAspect/aspect.spec.ts
@@ -1,0 +1,132 @@
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
+import BAspect from './BAspect.vue'
+
+describe('aspect', () => {
+  enableAutoUnmount(afterEach)
+
+  it('tag is div by default', () => {
+    const wrapper = mount(BAspect)
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('tag is tag prop', () => {
+    const wrapper = mount(BAspect, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+  })
+
+  it('tag is reactive', async () => {
+    const wrapper = mount(BAspect, {
+      props: {tag: 'span'},
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
+    await wrapper.setProps({tag: 'div'})
+    expect(wrapper.element.tagName).toBe('DIV')
+  })
+
+  it('should have expected structure when aspect is set to "4:3"', async () => {
+    const wrapper = mount(BAspect, {
+      props: {aspect: '4:3'},
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.classes()).toContain('b-aspect')
+    expect(wrapper.classes()).toContain('d-flex')
+    expect(wrapper.classes().length).toBe(2)
+
+    const $sizer = wrapper.find('.b-aspect-sizer')
+    expect($sizer.exists()).toBe(true)
+    expect($sizer.element.tagName).toBe('DIV')
+    expect($sizer.classes()).toContain('flex-grow-1')
+    expect($sizer.attributes('style')).toContain('padding-bottom: 75%;')
+
+    const $content = wrapper.find('.b-aspect-content')
+    expect($content.exists()).toBe(true)
+    expect($content.element.tagName).toBe('DIV')
+    expect($content.classes()).toContain('flex-grow-1')
+    expect($content.classes()).toContain('w-100')
+    expect($content.classes()).toContain('mw-100')
+    expect($content.attributes('style')).toContain('margin-left: -100%;')
+  })
+
+  it('should have expected structure when aspect is set to `16/9`', async () => {
+    const wrapper = mount(BAspect, {
+      props: {aspect: 16 / 9},
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.classes()).toContain('b-aspect')
+    expect(wrapper.classes()).toContain('d-flex')
+    expect(wrapper.classes().length).toBe(2)
+
+    const $sizer = wrapper.find('.b-aspect-sizer')
+    expect($sizer.exists()).toBe(true)
+    expect($sizer.element.tagName).toBe('DIV')
+    expect($sizer.classes()).toContain('flex-grow-1')
+    expect($sizer.attributes('style')).toContain('padding-bottom: 56.25%;')
+
+    const $content = wrapper.find('.b-aspect-content')
+    expect($content.exists()).toBe(true)
+    expect($content.element.tagName).toBe('DIV')
+    expect($content.classes()).toContain('flex-grow-1')
+    expect($content.classes()).toContain('w-100')
+    expect($content.classes()).toContain('mw-100')
+    expect($content.attributes('style')).toContain('margin-left: -100%;')
+  })
+
+  it('should have expected structure when aspect is set to `16x9`', async () => {
+    const wrapper = mount(BAspect, {
+      props: {aspect: '16x9'},
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.classes()).toContain('b-aspect')
+    expect(wrapper.classes()).toContain('d-flex')
+    expect(wrapper.classes().length).toBe(2)
+
+    const $sizer = wrapper.find('.b-aspect-sizer')
+    expect($sizer.exists()).toBe(true)
+    expect($sizer.element.tagName).toBe('DIV')
+    expect($sizer.classes()).toContain('flex-grow-1')
+    expect($sizer.attributes('style')).toContain('padding-bottom: 56.25%;')
+
+    const $content = wrapper.find('.b-aspect-content')
+    expect($content.exists()).toBe(true)
+    expect($content.element.tagName).toBe('DIV')
+    expect($content.classes()).toContain('flex-grow-1')
+    expect($content.classes()).toContain('w-100')
+    expect($content.classes()).toContain('mw-100')
+    expect($content.attributes('style')).toContain('margin-left: -100%;')
+  })
+
+  it('should have expected structure when aspect is set to `1.5`', async () => {
+    const wrapper = mount(BAspect, {
+      props: {aspect: 1.5},
+    })
+
+    expect(wrapper.vm).toBeDefined()
+    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.classes()).toContain('b-aspect')
+    expect(wrapper.classes()).toContain('d-flex')
+    expect(wrapper.classes().length).toBe(2)
+
+    const $sizer = wrapper.find('.b-aspect-sizer')
+    expect($sizer.exists()).toBe(true)
+    expect($sizer.element.tagName).toBe('DIV')
+    expect($sizer.classes()).toContain('flex-grow-1')
+    expect($sizer.attributes('style')).toContain('padding-bottom: 66.66666666666667%;')
+
+    const $content = wrapper.find('.b-aspect-content')
+    expect($content.exists()).toBe(true)
+    expect($content.element.tagName).toBe('DIV')
+    expect($content.classes()).toContain('flex-grow-1')
+    expect($content.classes()).toContain('w-100')
+    expect($content.classes()).toContain('mw-100')
+    expect($content.attributes('style')).toContain('margin-left: -100%;')
+  })
+})

--- a/packages/bootstrap-vue-next/src/components/BAspect/index.ts
+++ b/packages/bootstrap-vue-next/src/components/BAspect/index.ts
@@ -1,0 +1,1 @@
+export {default as BAspect} from './BAspect.vue'

--- a/packages/bootstrap-vue-next/src/components/index.ts
+++ b/packages/bootstrap-vue-next/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './BAspect'
 export * from './BAccordion'
 export * from './BAlert'
 export * from './BApp'

--- a/packages/bootstrap-vue-next/src/types/BootstrapVueOptions.ts
+++ b/packages/bootstrap-vue-next/src/types/BootstrapVueOptions.ts
@@ -14,6 +14,7 @@ export type BvnComponents = {
 }
 
 export const componentsWithExternalPath = {
+  BAspect: '/components/BAspect',
   BAccordion: '/components/BAccordion',
   BAccordionItem: '/components/BAccordion',
   BAlert: '/components/BAlert',
@@ -199,6 +200,7 @@ export interface BootstrapVueOptions {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UnmappedComponentProps<BFormSelectOption = any, BTableLite = any, BTable = any> = {
+  BAspect: ComponentProps.BAspectProps
   BLink: ComponentProps.BLinkProps
   BAccordion: ComponentProps.BAccordionProps
   BApp: ComponentProps.BAppProps

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -120,6 +120,11 @@ export interface BAppProps {
       }
 }
 
+export interface BAspectProps {
+  tag?: string
+  aspect?: string | number
+}
+
 export interface BOrchestratorProps {
   noPopovers?: boolean
   noToasts?: boolean

--- a/packages/bootstrap-vue-next/src/types/ComponentSlots.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentSlots.ts
@@ -21,6 +21,10 @@ export interface ShowHideSlotsData {
   visible: boolean
 }
 
+export type BAspectSlots = {
+  default?: (props: Record<string, never>) => any
+}
+
 export interface BCollapseSlots {
   default?: (props: ShowHideSlotsData) => any
   footer?: (props: ShowHideSlotsData) => any


### PR DESCRIPTION
# Describe the PR

This pull request migrates the BAspect component from BootstrapVue keeping the properties (aspect, tag) and slot (default).
In Bootstrap 5 ratios are specified using "16x9" instead of "16:9", so I've added this possiblity keeping the old.

## Small replication

A demo has been added to the documentation.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BAspect component for responsive aspect-ratio containers (accepts numeric or string ratios like 16:9, 4:3, 1.5); renders at 100% width.

* **Documentation**
  * Added component docs with overview, behavior details, usage examples, and an interactive demo showing default 1:1 and 16:9.

* **Tests**
  * Added tests covering tag rendering, reactivity, structure, and multiple aspect formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->