### PR TITLE
fix: prevent BFormSelect from treating non-array options as groups

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormSelect/form-select-base.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormSelect/form-select-base.spec.ts
@@ -423,6 +423,36 @@ describe('form-select-base', () => {
     expect(options).toHaveLength(3)
   })
 
+  it('does not treat options with label field as option groups', () => {
+    const wrapper = mount(BFormSelectBase, {
+      props: {
+        options: [
+          {value: 'a', text: 'Option A', label: 'Label A'},
+          {value: 'b', text: 'Option B', label: 'Label B'},
+        ],
+      },
+    })
+    const optgroups = wrapper.findAll('optgroup')
+    expect(optgroups).toHaveLength(0)
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(2)
+  })
+
+  it('does not treat option with non-array options field as a group', () => {
+    const wrapper = mount(BFormSelectBase, {
+      props: {
+        options: [
+          {value: 'a', text: 'Option A', options: 'not an array'},
+          {value: 'b', text: 'Option B'},
+        ],
+      },
+    })
+    const optgroups = wrapper.findAll('optgroup')
+    expect(optgroups).toHaveLength(0)
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(2)
+  })
+
   it('renders empty when options is empty array', () => {
     const wrapper = mount(BFormSelectBase, {
       props: {options: []},

--- a/packages/bootstrap-vue-next/src/components/BFormSelect/form-select-base.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormSelect/form-select-base.spec.ts
@@ -453,6 +453,54 @@ describe('form-select-base', () => {
     expect(options).toHaveLength(2)
   })
 
+  it('does not treat option with null options field as a group', () => {
+    const wrapper = mount(BFormSelectBase, {
+      props: {
+        options: [
+          {value: 'a', text: 'Option A', options: null},
+          {value: 'b', text: 'Option B'},
+        ],
+      },
+    })
+    const optgroups = wrapper.findAll('optgroup')
+    expect(optgroups).toHaveLength(0)
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(2)
+  })
+
+  it('does not treat option with empty object options field as a group', () => {
+    const wrapper = mount(BFormSelectBase, {
+      props: {
+        options: [
+          {value: 'a', text: 'Option A', options: {}},
+        ],
+      },
+    })
+    const optgroups = wrapper.findAll('optgroup')
+    expect(optgroups).toHaveLength(0)
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(1)
+  })
+
+  it('still renders valid option groups with array options', () => {
+    const wrapper = mount(BFormSelectBase, {
+      props: {
+        options: [
+          {value: 'solo', text: 'Solo option'},
+          {
+            label: 'Group',
+            options: [{value: 'a', text: 'A'}, {value: 'b', text: 'B'}],
+          },
+        ],
+      },
+    })
+    const optgroups = wrapper.findAll('optgroup')
+    expect(optgroups).toHaveLength(1)
+    expect(optgroups[0].attributes('label')).toBe('Group')
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(3) // 1 solo + 2 in group
+  })
+
   it('renders empty when options is empty array', () => {
     const wrapper = mount(BFormSelectBase, {
       props: {options: []},

--- a/packages/bootstrap-vue-next/src/composables/useFormSelect.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormSelect.ts
@@ -7,7 +7,10 @@ export const useFormSelect = (
   props: MaybeRefOrGetter<Record<string, unknown>>
 ) => {
   const isComplex = (option: unknown): option is ComplexSelectOptionRaw =>
-    typeof option === 'object' && option !== null && 'options' in option
+    typeof option === 'object' &&
+    option !== null &&
+    'options' in option &&
+    Array.isArray((option as Record<string, unknown>).options)
 
   const normalizeOption = (option: unknown): ComplexSelectOptionRaw | SelectOption => {
     const propsValue = toValue(props)
@@ -30,7 +33,7 @@ export const useFormSelect = (
       ? get(option, propsValue.optionsField as string)
       : undefined
 
-    if (opts !== undefined) {
+    if (opts !== undefined && Array.isArray(opts)) {
       return {
         label: get(option, propsValue.labelField as string) || text,
         options: opts,


### PR DESCRIPTION
## What it does

Fixes a bug where `BFormSelect` would incorrectly render options as `<optgroup>` elements when the option object happened to have a property named `options` that wasn't an array (e.g. a string, null, or object).

Added `Array.isArray` checks in both `isComplex` and `normalizeOption` inside `useFormSelect.ts` so only actual arrays trigger group rendering.

## Tests added

- Options with `label` field → renders as normal `<option>`
- Options with string/null/object `options` field → renders as normal `<option>`  
- Mixed solo options + valid array groups → both render correctly
- Existing option group tests still pass

Closes #2661

**What kind of change does this PR introduce?**

- [x] Bugfix :bug: - `fix(...)`

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form select option group detection to correctly identify and render option groups, preventing items with non-array option fields from being incorrectly processed.

* **Tests**
  * Enhanced test coverage for option group rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->