### PR TITLE
test: add BFormGroup label-for tests with BFormSelect

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -446,6 +446,35 @@ describe('form-group', () => {
       await nextTick()
       expect(textArea.get('label').attributes('for')).toBe('foobar')
     })
+    it('label should automatically inherit BFormSelect id', async () => {
+      const wrapper = mount(BFormGroup, {
+        props: {label: 'foo'},
+        slots: {
+          default: h(BFormSelect, {id: 'select-id'}),
+        },
+      })
+      await nextTick()
+      expect(wrapper.find('label').exists()).toBe(true)
+      expect(wrapper.get('label').attributes('for')).toBe('select-id')
+    })
+
+    it('label inherits auto-generated BFormSelect id when no id prop', async () => {
+      const wrapper = mount(BFormGroup, {
+        props: {label: 'foo'},
+        slots: {
+          default: h(BFormSelect),
+        },
+      })
+      await nextTick()
+      const select = wrapper.find('select')
+      expect(select.exists()).toBe(true)
+      const selectId = select.attributes('id')
+      expect(selectId).toBeDefined()
+      // Label should use label tag (not legend) and have for attribute matching the select
+      expect(wrapper.find('label').exists()).toBe(true)
+      expect(wrapper.get('label').attributes('for')).toBe(selectId)
+    })
+
     it('uses prop labelFor over input id', async () => {
       const wrapper = mount(BFormGroup, {
         props: {label: 'foo', labelFor: 'spam and eggs'},


### PR DESCRIPTION
## What it does

Adds test coverage for `BFormGroup` + `BFormSelect` label association. The existing test suite only covered `BFormInput` and `BFormTextarea` — `BFormSelect` had zero coverage for the provide/inject chain that links the label's `for` attribute to the child's ID.

Verifies that:
- The label's `for` attribute matches an explicit `id` prop on BFormSelect
- The label's `for` attribute matches the auto-generated ID when no `id` is provided

Ref #2779

## Manual verification

Tested manually with these two scenarios. Clicking the label focuses the select in both cases.

### Scenario A — Explicit `label-for`

```vue
<template>
  <BFormGroup label="Select a fruit" label-for="my-select">
    <BFormSelect
      id="my-select"
      v-model="selected"
      :options="['Apple', 'Banana', 'Cherry']"
    />
  </BFormGroup>
  <p>Selected: {{ selected }}</p>
</template>

<script setup lang="ts">
import {ref} from 'vue'
const selected = ref(null)
</script>
```

### Scenario B — Auto-generated ID

```vue
<template>
  <BFormGroup label="Select a fruit">
    <BFormSelect
      v-model="selected"
      :options="['Apple', 'Banana', 'Cherry']"
    />
  </BFormGroup>
  <p>Selected: {{ selected }}</p>
</template>

<script setup lang="ts">
import {ref} from 'vue'
const selected = ref(null)
</script>
```

In both cases, clicking the "Select a fruit" label focuses the select element. The provide/inject chain between `BFormGroup` and `BFormSelectBase` correctly propagates the ID.

## PR type

- [x] Other — test-only change (no runtime behavior changes)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for form group label and select element ID inheritance behavior to ensure proper accessibility attributes are correctly applied in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->