### PR TITLE
feat: add activeNavLinkClass and inactiveNavLinkClass props to BTabs

### DIFF
--- a/apps/docs/src/data/components/tabs.data.ts
+++ b/apps/docs/src/data/components/tabs.data.ts
@@ -28,6 +28,11 @@ export default {
           default: undefined,
           description: 'Sets the CSS class(es) for the active nav item tab control.',
         },
+        activeNavLinkClass: {
+          type: 'ClassValue',
+          default: undefined,
+          description: 'Sets the CSS class(es) for the active nav link element.',
+        },
         activeTabClass: {
           type: 'ClassValue',
           default: undefined,
@@ -65,6 +70,11 @@ export default {
           type: 'ClassValue',
           default: undefined,
           description: 'Sets the CSS class(es) for inactive nav item tab controls.',
+        },
+        inactiveNavLinkClass: {
+          type: 'ClassValue',
+          default: undefined,
+          description: 'Sets the CSS class(es) for inactive nav link elements.',
         },
         inactiveTabClass: {
           type: 'ClassValue',

--- a/packages/bootstrap-vue-next/src/components/BTabs/BTabs.vue
+++ b/packages/bootstrap-vue-next/src/components/BTabs/BTabs.vue
@@ -38,7 +38,7 @@
           <button
             :id="tab.buttonId"
             class="nav-link"
-            :class="[tab.navItemClasses, tab.titleLinkClass]"
+            :class="[tab.navItemClasses, tab.titleLinkClass, tab.active ? props.activeNavLinkClass : props.inactiveNavLinkClass]"
             role="tab"
             :aria-controls="tab.id"
             :aria-selected="tab.active"
@@ -99,6 +99,7 @@ import BTab from './BTab.vue'
 
 const _props = withDefaults(defineProps<Omit<BTabsProps, 'modelValue' | 'activeIndex'>>(), {
   activeNavItemClass: undefined,
+  activeNavLinkClass: undefined,
   activeTabClass: undefined,
   align: undefined,
   card: false,
@@ -107,6 +108,7 @@ const _props = withDefaults(defineProps<Omit<BTabsProps, 'modelValue' | 'activeI
   fill: false,
   id: undefined,
   inactiveNavItemClass: undefined,
+  inactiveNavLinkClass: undefined,
   inactiveTabClass: undefined,
   justified: false,
   lazy: false,

--- a/packages/bootstrap-vue-next/src/components/BTabs/tabs.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BTabs/tabs.spec.ts
@@ -1012,6 +1012,38 @@ describe('tabs', () => {
     expect(buttons[1].classes()).toContain('all-nav')
   })
 
+  // --- activeNavLinkClass / inactiveNavLinkClass ---
+
+  it('active tab button has activeNavLinkClass', () => {
+    const wrapper = mount(BTabs, {
+      props: {activeNavLinkClass: 'link-active'},
+      slots: {
+        default: () => [
+          h(BTab, {id: 'tab-1', title: 'First'}, () => 'one'),
+          h(BTab, {id: 'tab-2', title: 'Second'}, () => 'two'),
+        ],
+      },
+    })
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0].classes()).toContain('link-active')
+    expect(buttons[1].classes()).not.toContain('link-active')
+  })
+
+  it('inactive tab button has inactiveNavLinkClass', () => {
+    const wrapper = mount(BTabs, {
+      props: {inactiveNavLinkClass: 'link-inactive'},
+      slots: {
+        default: () => [
+          h(BTab, {id: 'tab-1', title: 'First'}, () => 'one'),
+          h(BTab, {id: 'tab-2', title: 'Second'}, () => 'two'),
+        ],
+      },
+    })
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0].classes()).not.toContain('link-inactive')
+    expect(buttons[1].classes()).toContain('link-inactive')
+  })
+
   // --- Tab click to activate ---
 
   it('clicking tab button activates the tab', async () => {

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -976,6 +976,7 @@ export interface BTabProps {
 
 export interface BTabsProps {
   activeNavItemClass?: ClassValue
+  activeNavLinkClass?: ClassValue
   activeTabClass?: ClassValue
   align?: AlignmentJustifyContent
   card?: boolean
@@ -985,6 +986,7 @@ export interface BTabsProps {
   id?: string
   index?: number
   inactiveNavItemClass?: ClassValue
+  inactiveNavLinkClass?: ClassValue
   inactiveTabClass?: ClassValue
   justified?: boolean
   lazy?: boolean


### PR DESCRIPTION
Closes #2375

# Describe the PR

A clear and concise description of what the pull request does.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs component now supports two new optional props: `activeNavLinkClass` and `inactiveNavLinkClass`. These enable customization of CSS classes applied to navigation links based on their active or inactive state, providing enhanced styling flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->