### PR TITLE
docs(BCollapse): add horizontal prop description and example

### DIFF
--- a/apps/docs/src/data/components/collapse.data.ts
+++ b/apps/docs/src/data/components/collapse.data.ts
@@ -43,7 +43,7 @@ export default {
         horizontal: {
           type: 'boolean',
           default: false, // TODO item not in string format
-          // description: 'When set, collapses horizontally instead of vertically' // TODO missing description
+          description: 'When set, collapses horizontally instead of vertically',
         },
         isNav: {
           type: 'boolean',

--- a/apps/docs/src/docs/components/collapse.md
+++ b/apps/docs/src/docs/components/collapse.md
@@ -35,6 +35,14 @@ set the `initial-animation` prop on `<BCollapse>` and leave the `visible` prop a
 
 <<< DEMO ./demo/CollapseModel.vue
 
+## Horizontal collapse
+
+Set the `horizontal` prop on `BCollapse` to collapse along the horizontal axis instead of the
+default vertical axis. The element still animates between collapsed and expanded states, but its
+width is what transitions rather than its height.
+
+<<< DEMO ./demo/CollapseHorizontal.vue#template{vue-html}
+
 ## Trigger multiple collapse elements
 
 You can even collapse multiple `BCollapse` components via a single `v-b-toggle` by providing

--- a/apps/docs/src/docs/components/demo/CollapseHorizontal.vue
+++ b/apps/docs/src/docs/components/demo/CollapseHorizontal.vue
@@ -1,0 +1,20 @@
+<template>
+  <!-- #region template -->
+  <BButton
+    v-b-toggle.collapse-horizontal
+    class="m-1"
+    >Toggle Horizontal Collapse</BButton
+  >
+
+  <div style="min-height: 120px">
+    <BCollapse
+      id="collapse-horizontal"
+      horizontal
+    >
+      <BCard style="width: 300px">
+        I collapse horizontally instead of vertically.
+      </BCard>
+    </BCollapse>
+  </div>
+  <!-- #endregion template -->
+</template>


### PR DESCRIPTION
## Summary
- Fills in the previously-missing `description` for the `horizontal` prop in `apps/docs/src/data/components/collapse.data.ts` (was a `// TODO missing description` comment)
- Adds a new `Horizontal collapse` section to the BCollapse docs page with a small demo (`CollapseHorizontal.vue`)

## Why
The `horizontal` prop existed on `BCollapse` but was undocumented — no description in the Component Reference table and no example on the page. This PR fills both gaps.

## Test plan
- [x] Docs dev server renders the new `Horizontal collapse` section with working demo (toggle button expands/collapses the card horizontally)
- [x] Component Reference Properties table shows a non-empty description for `horizontal`
- [x] No lint / type-check regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added description for the `horizontal` prop, clarifying that it collapses along the horizontal axis with animated width transitions
  * Introduced new "Horizontal collapse" documentation section with interactive demo example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->