### PR TITLE
docs(BCarouselSlide): add imgSrcset prop description and example

### DIFF
--- a/apps/docs/src/data/components/carousel.data.ts
+++ b/apps/docs/src/data/components/carousel.data.ts
@@ -13,8 +13,8 @@ import {
   type SlotRecord,
   StyleKind,
 } from '../../types'
-import {pick} from '../../utils/objectUtils'
-import {buildCommonProps} from '../../utils/commonProps'
+import { pick } from '../../utils/objectUtils'
+import { buildCommonProps } from '../../utils/commonProps'
 
 export default {
   load: (): ComponentReference => ({
@@ -136,7 +136,7 @@ export default {
             },
           },
         },
-        'slide': {
+        slide: {
           description: 'Fires immediately when the carousel starts its slide transition.',
           args: {
             value: {
@@ -145,7 +145,7 @@ export default {
             },
           },
         },
-        'slid': {
+        slid: {
           description: 'Fired when the carousel has completed its slide transition.',
           args: {
             value: {
@@ -198,7 +198,7 @@ export default {
       } satisfies ExposedRecord,
     },
     BCarouselSlide: {
-      styleSpec: {kind: StyleKind.OverrideClass, value: '.carousel-item'},
+      styleSpec: { kind: StyleKind.OverrideClass, value: '.carousel-item' },
       props: {
         ...pick(buildCommonProps(), ['id']),
         background: {
@@ -257,7 +257,7 @@ export default {
         imgSrcset: {
           type: 'string | string[]',
           default: undefined,
-          // description: 'Sets the srcset attribute for the image' // TODO missing description
+          description: 'Sets the srcset attribute for the image',
         },
         imgWidth: {
           type: 'Numberish',

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -27,6 +27,14 @@ of its parent container.
 Internally, `<BCarouselSlide>` uses the [`<BImg>`](/docs/components/image) component to render
 the images. The `img-*` props map to the corresponding props available to `<BImg>`.
 
+### Responsive images
+
+Use the `img-srcset` prop on `<BCarouselSlide>` to provide a comma-separated list of candidate
+image sources, letting the browser pick the best fit for the current viewport and pixel density.
+This pairs naturally with `img-src` (which acts as the fallback).
+
+<<< DEMO ./demo/CarouselResponsiveImages.vue#template{vue-html}
+
 ### Indicators
 
 With the `indicators` prop, can add indicators to the Carousel, along side the previous/next controls. The indicators let users jump to a particular slide.

--- a/apps/docs/src/docs/components/demo/CarouselResponsiveImages.vue
+++ b/apps/docs/src/docs/components/demo/CarouselResponsiveImages.vue
@@ -1,0 +1,27 @@
+<template>
+  <!-- #region template -->
+  <BCarousel controls indicators :interval="0">
+    <BCarouselSlide
+      caption="First slide"
+      img-src="https://picsum.photos/1200/480?image=40"
+      img-srcset="https://picsum.photos/400/160?image=40 400w,
+                  https://picsum.photos/800/320?image=40 800w,
+                  https://picsum.photos/1200/480?image=40 1200w"
+    />
+    <BCarouselSlide
+      caption="Second slide"
+      img-src="https://picsum.photos/1200/480?image=41"
+      img-srcset="https://picsum.photos/400/160?image=41 400w,
+                  https://picsum.photos/800/320?image=41 800w,
+                  https://picsum.photos/1200/480?image=41 1200w"
+    />
+    <BCarouselSlide
+      caption="Third slide"
+      img-src="https://picsum.photos/1200/480?image=42"
+      img-srcset="https://picsum.photos/400/160?image=42 400w,
+                  https://picsum.photos/800/320?image=42 800w,
+                  https://picsum.photos/1200/480?image=42 1200w"
+    />
+  </BCarousel>
+  <!-- #endregion template -->
+</template>


### PR DESCRIPTION
## Summary
- Fills in the previously-missing \`description\` for the \`imgSrcset\` prop in \`apps/docs/src/data/components/carousel.data.ts\` (was a \`// TODO missing description\` comment)
- Adds a new \`Responsive images\` section to the BCarousel docs page with a small demo (\`CarouselResponsiveImages.vue\`) showing candidate sources via the \`img-srcset\` prop

## Why
The \`imgSrcset\` prop on \`<BCarouselSlide>\` existed but was undocumented — no description in the Component Reference table and no example anywhere on the page. This PR fills both gaps. Prop behavior is already covered by \`carousel-slide.spec.ts:113\` so no test changes are needed.

## Test plan
- [x] Docs dev server renders the new \`Responsive images\` section with a working 3-slide carousel
- [x] BCarouselSlide Properties table shows a non-empty description for \`img-srcset\`
- [x] No lint / type-check regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation and interactive demo for responsive images in carousel components, including the `img-srcset` prop for adaptive image selection across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->