### PR TITLE
docs(BBadge): add missing description for default slot

### DIFF
--- a/apps/docs/src/data/components/badge.data.ts
+++ b/apps/docs/src/data/components/badge.data.ts
@@ -1,13 +1,13 @@
-import type {BBadgeProps, BBadgeSlots} from 'bootstrap-vue-next'
+import type { BBadgeProps, BBadgeSlots } from 'bootstrap-vue-next'
 import {
   type ComponentReference,
   defaultPropSectionSymbol,
   type PropRecord,
   type SlotRecord,
 } from '../../types'
-import {linkedBLinkSection, linkProps} from '../../utils/linkProps'
-import {pick} from '../../utils/objectUtils'
-import {buildCommonProps} from '../../utils/commonProps'
+import { linkedBLinkSection, linkProps } from '../../utils/linkProps'
+import { pick } from '../../utils/objectUtils'
+import { buildCommonProps } from '../../utils/commonProps'
 
 export default {
   load: (): ComponentReference => ({
@@ -20,7 +20,7 @@ export default {
                 default: 'secondary',
               },
             }),
-            ['bgVariant', 'variant', 'textVariant']
+            ['bgVariant', 'variant', 'textVariant'],
           ),
           dotIndicator: {
             type: 'boolean',
@@ -49,7 +49,7 @@ export default {
       emits: {},
       slots: {
         default: {
-          description: '', // TODO missing description
+          description: 'Content to place in the badge',
           scope: {},
         },
       } satisfies SlotRecord<keyof BBadgeSlots>,


### PR DESCRIPTION
## Summary
Fills in the previously-missing \`description\` for the default slot of BBadge in \`apps/docs/src/data/components/badge.data.ts\` (was \`description: '', // TODO missing description\`).

## Why
The Component Reference Slots table on the BBadge docs page showed an empty description cell for the default slot. This PR fills it with "Content to place in the badge".

No new demo is needed — every existing BBadge demo already uses the default slot, so usage is fully covered.

## Test plan
- [x] BBadge Slots table on \`/docs/components/badge\` shows a non-empty description for the \`default\` slot
- [x] No lint / type-check regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced badge component documentation with clearer descriptions for slot content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->