### PR TITLE
docs(BFormSelect): clarify that option groups require an array

### DIFF
--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -31,7 +31,10 @@ options specified by the `options` prop, use the named slot `first`.
 
 ### Options groups
 
-To define option groups, just add an object with a `label` prop as the groups name and a `options` property with the array of options of the group.
+To define option groups, add an object with a `label` prop as the group's name and an `options`
+property set to an **array** of options for that group. An entry is only treated as a group when
+its `options` field is an array — entries whose `options` field is missing, `null`, a string, or
+any other non-array value are rendered as normal options.
 
 <<< FRAGMENT ./demo/OptionsGroups.ts#snippet{ts}
 


### PR DESCRIPTION
## Summary
Clarifies in the BFormSelect docs that an entry in the `options` prop is only treated as an `<optgroup>` when its `options` field is an **array**. Entries whose `options` field is missing, `null`, a string, or any other non-array value are rendered as normal options.

## Why
This matches the behavior restored by #3161 (closes #2661). Before that fix, `BFormSelect` would incorrectly render plain option objects as `<optgroup>` whenever they happened to have a property named `options` that wasn't an array. The code is now correct, but the docs still described the feature as if the `options` field just needed to be "the array of options" — which is ambiguous. This PR makes the rule explicit so future readers aren't surprised.

## Scope
One-line rewording in `apps/docs/src/docs/components/form-select.md` under `### Options groups`. No demo, no code, no test changes.

## Test plan
- [x] Docs dev server renders the updated paragraph under "Options groups"
- [x] Existing Options groups demo (`OptionsGroups.ts` fragment) still renders as before
- [x] No lint / type-check regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Options groups" documentation to clarify the expected behavior. Option-group objects are treated as groups only when their `options` field is an array. Entries with missing, null, or any non-array `options` values are now explicitly documented as rendering as normal options instead of option groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->