### PR TITLE
docs(BAlert): document title slot and add example

### DIFF
--- a/apps/docs/src/data/components/alert.data.ts
+++ b/apps/docs/src/data/components/alert.data.ts
@@ -1,4 +1,4 @@
-import type {BAlertEmits, BAlertProps, BAlertSlots} from 'bootstrap-vue-next'
+import type { BAlertEmits, BAlertProps, BAlertSlots } from 'bootstrap-vue-next'
 import {
   type ComponentReference,
   defaultPropSectionSymbol,
@@ -7,10 +7,10 @@ import {
   type PropRecord,
   type SlotRecord,
 } from '../../types'
-import {linkedBLinkSection, type linkProps} from '../../utils/linkProps'
-import {buildDismissibleEmits, showHideProps} from '../../utils/showHideData'
-import {buildCommonProps} from '../../utils/commonProps'
-import {omit, pick} from '../../utils/objectUtils'
+import { linkedBLinkSection, type linkProps } from '../../utils/linkProps'
+import { buildDismissibleEmits, showHideProps } from '../../utils/showHideData'
+import { buildCommonProps } from '../../utils/commonProps'
+import { omit, pick } from '../../utils/objectUtils'
 
 export default {
   load: (): ComponentReference => ({
@@ -66,8 +66,8 @@ export default {
           description: 'Content to place in the close button',
         },
         title: {
-          description: '',
-          scope: {}, // TODO
+          description:
+            'Custom heading content for the alert. When provided, overrides the `title` prop.',
         },
       } satisfies SlotRecord<keyof BAlertSlots>,
       emits: {

--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -35,6 +35,14 @@ Use the `.alert-link` utility CSS class to quickly provide matching colored link
 
 <<< DEMO ./demo/AlertLinkColors.vue#template{vue-html}
 
+### Custom title
+
+Use the `title` slot to render custom markup (icons, badges, styled text) in the alert heading.
+When provided, the slot overrides the `title` prop. If neither the `title` slot nor the `title`
+prop is set, the heading element is not rendered.
+
+<<< DEMO ./demo/AlertTitleSlot.vue#template{vue-html}
+
 ## Dismissible Alerts
 
 Using the `dismissible` prop it is possible to dismiss any `BAlert` inline. The alert must be v-modeled to a reactive value. This will add a close `X` button. Use the `dismiss-label` prop to change the hidden aria-label text associated with the dismiss button.

--- a/apps/docs/src/docs/components/demo/AlertTitleSlot.vue
+++ b/apps/docs/src/docs/components/demo/AlertTitleSlot.vue
@@ -1,0 +1,13 @@
+<template>
+  <!-- #region template -->
+  <BAlert :model-value="true" variant="warning" dismissible>
+    <template #title>
+      <span class="fw-bold">⚠️ Heads up!</span>
+    </template>
+    <p class="mb-0">
+      The <code>title</code> slot lets you render custom markup in the alert heading — icons,
+      badges, or any components you like.
+    </p>
+  </BAlert>
+  <!-- #endregion template -->
+</template>


### PR DESCRIPTION
## Summary
- Fills in the previously-missing `description` for the BAlert `title` slot in `apps/docs/src/data/components/alert.data.ts` (was `description: '', scope: {}, // TODO`)
- Adds a new `Custom title` section to the BAlert docs page with a demo (`AlertTitleSlot.vue`) that renders a warning alert with a custom-styled title (icon + bold text) using the slot

## Why
The `title` slot on `BAlert` existed in the component and was fully tested, but was completely undocumented — no description in the Component Reference Slots table and no example anywhere on the page. This PR fills both gaps.

## Tests
No new tests needed — the `title` slot is already covered by two existing specs in `packages/bootstrap-vue-next/src/components/BAlert/alert.spec.ts`:
- L550 `renders title slot content`
- L558 `title slot overrides title prop`

Both pass locally (`pnpm vitest run alert.spec.ts -t "title slot"` → 2 passed).

## Test plan
- [x] Docs dev server renders the new `Custom title` section with the warning alert and custom heading
- [x] BAlert Slots table on `/docs/components/alert` shows a non-empty description for the `title` slot
- [x] No lint / type-check regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation and example for the Alert component's custom title slot feature, demonstrating how to render custom markup in alert headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->