### PR TITLE
Fix various bugs around BFormGroup's auto label-for handling.

### DIFF
--- a/apps/docs/src/docs/components/demo/FormGroupMultipleInputs.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupMultipleInputs.vue
@@ -1,0 +1,10 @@
+<template>
+  <!-- #region template -->
+  <BFormGroup label="Enter your name">
+    <BInputGroup>
+      <BFormInput aria-label="Forename" placeholder="Forename" />
+      <BFormInput aria-label="Surname" placeholder="Surname" />
+    </BInputGroup>
+  </BFormGroup>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -21,8 +21,9 @@ contained within the `BFormGroup`. When specifying the id, **do not** prepend it
 component. Do not set the `label-for` prop when using `BFormRadioGroup`, `BFormCheckboxGroup`,
 `BFormRadio`, `BFormCheckbox` or `BFormFile` components (or when placing multiple inputs in
 the same form group) — these inputs include integrated label element(s) and the `<legend>`
-element is more suitable. When `label-for` is not set, `BFormGroup` automatically falls back
-to `<legend>` for these cases.
+element is more suitable. With `label-for` unset, auto-detection only claims `<label for>`
+when there is exactly one slot input without its own integrated label, so these cases render
+as `<fieldset>` + `<legend>`.
 
 You can also apply additional classes to the label via the `label-class` prop, such as responsive
 padding and text alignment utility classes. The `label-class` prop accepts either a string or array

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -10,17 +10,19 @@ Use the prop `label` to set the content of the generated `<legend>` or `<label>`
 using the named slot `label`, You may optionally visually hide the label text while still making it
 available to screen readers by setting the prop `label-visually-hidden`.
 
-`BFormGroup` will render a `<fieldset>` with `<legend>` if the `label-for` prop is not set. If
-an input Id is provided to the `label-for` prop, then a `<div>` with `<label>` will be rendered.
+`BFormGroup` always renders a `<fieldset>` element. By default the label is placed inside a
+`<legend>`; when a label target is known (either via the `label-for` prop, or auto-detected
+from a single child input — see [Automatic Inheriting of id](#automatic-inheriting-of-id)), a
+`<label>` element with the `for` attribute is rendered instead.
 
-If you provide an input `id` value to the `label-for` prop (the `id` must exist on the input
-contained within the `BFormGroup`), a `<label>` element will be rendered instead of a `<legend>`
-element, and will have the `for` attribute set to the `id` specified. When specifying the id, **do
-not** prepend it with `#`. The `label-for` prop should only be used when you have a single form
-input inside the `BFormGroup` component. Do not set the `label-for` prop when using
-`BFormRadioGroup`, `BFormCheckboxGroup`, `BFormRadio`, `BFormCheckbox` or
-`BFormFile` components (or when placing multiple inputs in the same form group), as these inputs
-include integrated label element(s) and the `<legend>` element is more suitable.
+If you provide an input `id` value to the `label-for` prop, the `id` must exist on the input
+contained within the `BFormGroup`. When specifying the id, **do not** prepend it with `#`. The
+`label-for` prop should only be used when you have a single form input inside the `BFormGroup`
+component. Do not set the `label-for` prop when using `BFormRadioGroup`, `BFormCheckboxGroup`,
+`BFormRadio`, `BFormCheckbox` or `BFormFile` components (or when placing multiple inputs in
+the same form group) — these inputs include integrated label element(s) and the `<legend>`
+element is more suitable. When `label-for` is not set, `BFormGroup` automatically falls back
+to `<legend>` for these cases.
 
 You can also apply additional classes to the label via the `label-class` prop, such as responsive
 padding and text alignment utility classes. The `label-class` prop accepts either a string or array
@@ -31,6 +33,15 @@ of strings.
 The `BFormGroup` component automatically inherits the id of its child input components, such as BFormInput and BFormTextarea. This functionality ensures that the label element's for attribute is correctly set to match the id of the input component, providing proper association between the label and the input field.
 
 <<< DEMO ./demo/FormGroupId.vue#template{vue-html}
+
+### Multiple inputs in one form group
+
+When more than one input registers inside a `BFormGroup` (for example, a `BInputGroup` with
+two `BFormInput`s), the label `for` association is ambiguous, so `BFormGroup` keeps the
+label as a `<legend>` instead of auto-binding it to one input. Give each child input its own
+accessible name via `aria-label` (or a visually hidden `<label>`).
+
+<<< DEMO ./demo/FormGroupMultipleInputs.vue#template{vue-html}
 
 ### Horizontal layout
 
@@ -121,9 +132,8 @@ of related form controls:
 ## Disabled form group
 
 Setting the `disabled` prop will disable the rendered `<fieldset>` and, on most browsers, will
-disable all the input elements contained within the fieldset.
-
-`disabled` has no effect when `label-for` is set (as a `<fieldset>` element is not rendered).
+disable all the input elements contained within the fieldset, regardless of whether `label-for`
+is set.
 
 ## Validation state feedback
 
@@ -213,10 +223,10 @@ There are restrictions on the use of floating labels.
 
 ## Accessibility
 
-By default, when no `label-for` value is provided, `BFormGroup` renders the input control(s)
-inside an HTML `<fieldset>` element with the label content placed inside the fieldset's `<legend>`
-element. By nature of this markup, the legend content is automatically associated to the containing
-input control(s).
+`BFormGroup` always renders the input control(s) inside an HTML `<fieldset>` element. When no
+label target is known (no `label-for`, and not auto-detected from a single child input), the
+label content is placed inside the fieldset's `<legend>` element. By nature of this markup,
+the legend content is automatically associated to the containing input control(s).
 
 It is **highly recommended** that you provide a unique `id` prop on your input element and set the
 `label-for` prop to this Id, when you have only a single input in the `BFormGroup`.

--- a/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
@@ -11,7 +11,10 @@
 
 <script setup lang="ts">
 import type {BFormFloatingLabelProps, BFormFloatingLabelSlots} from '../../types'
+import {inject} from 'vue'
 import {useDefaults} from '../../composables/useDefaults'
+import {useProvideFormGroupData} from '../../composables/useProvideFormGroupData'
+import {formGroupKey} from '../../utils/keys'
 
 const _props = withDefaults(defineProps<BFormFloatingLabelProps>(), {
   label: undefined,
@@ -20,4 +23,10 @@ const _props = withDefaults(defineProps<BFormFloatingLabelProps>(), {
 })
 const props = useDefaults(_props, 'BFormFloatingLabel')
 defineSlots<BFormFloatingLabelSlots>()
+
+// Boundary: BFormFloatingLabel renders its own <label for>. State/disabled forward through
+// from the outer BFormGroup; the isolated label-target registry isn't read, so descendant
+// claims never reach the outer group.
+const parentFormGroupData = inject(formGroupKey, null)?.()
+if (parentFormGroupData) useProvideFormGroupData(parentFormGroupData)
 </script>

--- a/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
@@ -27,6 +27,6 @@ defineSlots<BFormFloatingLabelSlots>()
 // Boundary: BFormFloatingLabel renders its own <label for>. State/disabled forward through
 // from the outer BFormGroup; the isolated label-target registry isn't read, so descendant
 // claims never reach the outer group.
-const parentFormGroupData = inject(formGroupKey, null)?.()
+const parentFormGroupData = inject(formGroupKey, null)?.(null)
 if (parentFormGroupData) useProvideFormGroupData(parentFormGroupData)
 </script>

--- a/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
@@ -27,6 +27,6 @@ defineSlots<BFormFloatingLabelSlots>()
 // Boundary: BFormFloatingLabel renders its own <label for>. State/disabled forward through
 // from the outer BFormGroup; the isolated label-target registry isn't read, so descendant
 // claims never reach the outer group.
-const parentFormGroupData = inject(formGroupKey, null)?.(null)
+const parentFormGroupData = inject(formGroupKey, null)?.()
 if (parentFormGroupData) useProvideFormGroupData(parentFormGroupData)
 </script>

--- a/packages/bootstrap-vue-next/src/components/BForm/form-floating-label.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BForm/form-floating-label.spec.ts
@@ -1,6 +1,9 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
+import {h, nextTick, ref} from 'vue'
 import BFormFloatingLabel from './BFormFloatingLabel.vue'
+import BFormInput from '../BFormInput/BFormInput.vue'
+import {provideFormGroupStub} from '../../../tests/utils'
 
 describe('form-floating-label', () => {
   enableAutoUnmount(afterEach)
@@ -106,5 +109,21 @@ describe('form-floating-label', () => {
       slots: {default: 'default', label: 'label'},
     })
     expect(wrapper.text()).toBe('defaultlabel')
+  })
+
+  it('forwards outer formGroup state/disabled to descendants through the boundary', async () => {
+    const state = ref<boolean | undefined>(false)
+    const disabled = ref(true)
+    const wrapper = mount(BFormFloatingLabel, {
+      props: {label: 'Email', labelFor: 'email'},
+      slots: {default: () => h(BFormInput, {id: 'email'})},
+      global: {
+        provide: provideFormGroupStub(state, disabled),
+      },
+    })
+    await nextTick()
+    const input = wrapper.get('input')
+    expect(input.attributes('disabled')).toBeDefined()
+    expect(input.classes()).toContain('is-invalid')
   })
 })

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -23,7 +23,7 @@
       :indeterminate="indeterminate || undefined"
       v-bind="processedAttrs.inputAttrs"
     />
-    <label v-if="hasDefaultSlot || !resolvedPlain" :for="computedId" :class="labelClasses">
+    <label v-if="hasOwnLabel" :for="computedId" :class="labelClasses">
       <slot />
     </label>
   </ConditionalWrapper>
@@ -92,7 +92,6 @@ const processedAttrs = computed(() => {
 const computedId = useId(() => props.id, 'form-check')
 
 const parentData = inject(checkboxGroupKey, null)
-const formGroupData = inject(formGroupKey, null)?.(computedId)
 
 const input = useTemplateRef('_input')
 
@@ -129,6 +128,10 @@ const resolvedProps = computed(() => ({
 
 // Shorthand for template usage
 const resolvedPlain = computed(() => resolvedProps.value.plain)
+const hasOwnLabel = computed(() => hasDefaultSlot.value || !resolvedPlain.value)
+
+const labelTargetId = computed(() => (hasOwnLabel.value ? null : computedId.value))
+const formGroupData = inject(formGroupKey, null)?.(labelTargetId)
 
 const localValue = computed({
   get: () => (parentData ? parentData.modelValue.value : modelValue.value),

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -131,7 +131,8 @@ const resolvedPlain = computed(() => resolvedProps.value.plain)
 const hasOwnLabel = computed(() => hasDefaultSlot.value || !resolvedPlain.value)
 
 const labelTargetId = computed(() => (hasOwnLabel.value ? null : computedId.value))
-const formGroupData = inject(formGroupKey, null)?.(labelTargetId)
+const formGroupData = inject(formGroupKey, null)?.()
+formGroupData?.track(labelTargetId)
 
 const localValue = computed({
   get: () => (parentData ? parentData.modelValue.value : modelValue.value),

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -3,7 +3,8 @@ import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {ref} from 'vue'
 import BFormCheckbox from './BFormCheckbox.vue'
 import BFormCheckboxGroup from './BFormCheckboxGroup.vue'
-import {checkboxGroupKey, formGroupKey} from '../../utils/keys'
+import {checkboxGroupKey} from '../../utils/keys'
+import {provideFormGroupStub} from '../../../tests/utils'
 import type {CheckboxValue} from '../../types/CheckboxTypes'
 
 describe('form-checkbox', () => {
@@ -1431,10 +1432,7 @@ describe('form-checkbox', () => {
       const disabled = ref(true)
       const state = ref<boolean | undefined>(undefined)
       const wrapper = mount(BFormCheckbox, {
-        global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+        global: {provide: provideFormGroupStub(state, disabled),
         },
       })
       const $input = wrapper.get('input')
@@ -1447,9 +1445,7 @@ describe('form-checkbox', () => {
       const wrapper = mount(BFormCheckbox, {
         props: {disabled: false},
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       const $input = wrapper.get('input')

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
@@ -1,11 +1,9 @@
 <template>
-  <component
-    :is="isFieldset ? 'fieldset' : 'div'"
+  <fieldset
     :id="computedId"
-    :disabled="isFieldset ? props.disabled : null"
-    :role="isFieldset ? null : 'group'"
+    :disabled="props.disabled"
     :aria-invalid="computedAriaInvalid"
-    :aria-labelledby="isFieldset && isHorizontal ? labelId : null"
+    :aria-labelledby="isFieldset && isHorizontal ? labelId : undefined"
     v-bind="$attrs"
     :class="[stateClass, {'was-validated': props.validated}]"
     class="b-form-group"
@@ -99,11 +97,11 @@
         </BFormGroupContent>
       </template>
     </template>
-  </component>
+  </fieldset>
 </template>
 
 <script setup lang="ts">
-import {computed, provide, type Ref, ref, toRef, useTemplateRef} from 'vue'
+import {computed, toRef, useTemplateRef} from 'vue'
 import {useAriaInvalid} from '../../composables/useAriaInvalid'
 import {attemptFocus, isVisible} from '../../utils/dom'
 import BCol from '../BContainer/BCol.vue'
@@ -113,7 +111,7 @@ import {useStateClass} from '../../composables/useStateClass'
 import {useId} from '../../composables/useId'
 import type {BFormGroupProps, BFormGroupSlots} from '../../types'
 import {useDefaults} from '../../composables/useDefaults'
-import {formGroupKey} from '../../utils/keys'
+import {useProvideFormGroupData} from '../../composables/useProvideFormGroupData'
 import BFormGroupContent from '../BFormGroupContent.vue'
 import BFormGroupLabel from '../BFormGroupLabel.vue'
 
@@ -161,20 +159,11 @@ const slots = defineSlots<BFormGroupSlots>()
 
 const computedState = toRef(() => props.state)
 const computedDisabled = toRef(() => props.disabled)
-const childId = ref<Ref<string>[]>([])
-provide(formGroupKey, (id) => {
-  childId.value = [id]
-
-  return {
-    state: computedState,
-    disabled: computedDisabled,
-  }
+const {singleLabelTargetId} = useProvideFormGroupData({
+  state: computedState,
+  disabled: computedDisabled,
 })
-const computedLabelFor = computed(() => {
-  if (props.labelFor !== undefined) return props.labelFor
-  if (childId.value[0] && childId.value[0].value) return childId.value[0].value
-  return null
-})
+const computedLabelFor = computed(() => props.labelFor ?? singleLabelTargetId.value)
 
 const breakPoints = ['xs', 'sm', 'md', 'lg', 'xl']
 

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -7,6 +7,7 @@ import BFormTextarea from '../BFormTextarea/BFormTextarea.vue'
 import BFormSelect from '../BFormSelect/BFormSelect.vue'
 import BFormCheckbox from '../BFormCheckbox/BFormCheckbox.vue'
 import BFormRadio from '../BFormRadio/BFormRadio.vue'
+import BFormFloatingLabel from '../BForm/BFormFloatingLabel.vue'
 
 describe('form-group', () => {
   enableAutoUnmount(afterEach)
@@ -652,6 +653,21 @@ describe('form-group', () => {
         expect(wrapper.find('label.form-label').exists()).toBe(false)
         expect(wrapper.find('label.form-check-label').exists()).toBe(true)
       })
+    })
+
+    it('falls back to legend when BFormFloatingLabel intervenes between group and input', async () => {
+      const wrapper = mount(BFormGroup, {
+        props: {label: 'Email'},
+        slots: {
+          default: () =>
+            h(BFormFloatingLabel, {label: 'Address', labelFor: 'email'}, () =>
+              h(BFormInput, {id: 'email'})
+            ),
+        },
+      })
+      await nextTick()
+      expect(wrapper.find('legend').exists()).toBe(true)
+      expect(wrapper.find('label.form-label').exists()).toBe(false)
     })
   })
 

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -28,11 +28,11 @@ describe('form-group', () => {
     expect(wrapper.element.tagName).toBe('FIELDSET')
   })
 
-  it('tag is default div', () => {
+  it('tag is fieldset even when labelFor is set', () => {
     const wrapper = mount(BFormGroup, {
       props: {labelFor: 'foobar'},
     })
-    expect(wrapper.element.tagName).toBe('DIV')
+    expect(wrapper.element.tagName).toBe('FIELDSET')
   })
 
   it('has class is-valid when prop state is true', () => {
@@ -138,30 +138,19 @@ describe('form-group', () => {
     expect(wrapper.attributes('disabled')).toBe('')
   })
 
-  it('attr disabled is undefined when disabled true but prop labelFor exists', () => {
+  it('attr disabled is true when prop disabled and labelFor is set', () => {
+    // Root is always <fieldset>, so disabled cascades to all descendants regardless of mode.
     const wrapper = mount(BFormGroup, {
       props: {disabled: true, labelFor: 'foo'},
     })
-    expect(wrapper.attributes('disabled')).toBeUndefined()
+    expect(wrapper.attributes('disabled')).toBe('')
   })
 
-  it('attr disabled is undefined when disabled false but prop labelFor exists', () => {
+  it('attr disabled is undefined when disabled false and labelFor is set', () => {
     const wrapper = mount(BFormGroup, {
       props: {disabled: false, labelFor: 'foo'},
     })
     expect(wrapper.attributes('disabled')).toBeUndefined()
-  })
-
-  it('attr role is undefined by default', () => {
-    const wrapper = mount(BFormGroup)
-    expect(wrapper.attributes('role')).toBeUndefined()
-  })
-
-  it('attr role is group when prop labelFor', () => {
-    const wrapper = mount(BFormGroup, {
-      props: {labelFor: 'foo'},
-    })
-    expect(wrapper.attributes('role')).toBe('group')
   })
 
   it('attr aria-invalid is undefined by default', () => {
@@ -588,6 +577,82 @@ describe('form-group', () => {
         expect(wrapper.get('#foobar').attributes('disabled')).toBeDefined()
       })
     })
+
+    describe('labelFor is not hijacked by descendant form controls', () => {
+      // Pre-fix bug: register-callback overwrote on every call, so multiple inputs collapsed
+      // to "last id wins" and the group rendered <label for="lastId">. We now bind label[for]
+      // only when exactly one input registers; anything else stays <legend>.
+      it('falls back to legend when multiple inputs register (e.g. inside a BInputGroup)', async () => {
+        const wrapper = mount(BFormGroup, {
+          props: {label: 'Range'},
+          slots: {
+            default: () => [
+              h(BFormInput, {id: 'range-start'}),
+              h(BFormInput, {id: 'range-end'}),
+            ],
+          },
+        })
+        await nextTick()
+
+        expect(wrapper.find('legend').exists()).toBe(true)
+        expect(wrapper.find('label.form-label').exists()).toBe(false)
+      })
+    })
+
+    // BFormCheckbox renders its own <label v-if="hasDefaultSlot || !resolvedPlain">. The
+    // claim on BFormGroup's label[for] only happens in the negative case (plain + no slot
+    // content), where no own label is rendered.
+    describe('BFormCheckbox label-for claim depends on own label', () => {
+      it('claims label-for when plain and no slot (no own label)', async () => {
+        const wrapper = mount(BFormGroup, {
+          props: {label: 'Agreement'},
+          slots: {default: () => h(BFormCheckbox, {id: 'agree', plain: true})},
+        })
+        await nextTick()
+        const label = wrapper.find('label.form-label')
+        expect(label.exists()).toBe(true)
+        expect(label.attributes('for')).toBe('agree')
+        expect(wrapper.find('label.form-check-label').exists()).toBe(false)
+      })
+
+      it('does not claim when checkbox has a default slot (own label rendered)', async () => {
+        const wrapper = mount(BFormGroup, {
+          props: {label: 'Agreement'},
+          slots: {default: () => h(BFormCheckbox, {id: 'agree'}, () => 'I accept the terms')},
+        })
+        await nextTick()
+        expect(wrapper.find('legend').exists()).toBe(true)
+        expect(wrapper.find('label.form-label').exists()).toBe(false)
+        expect(wrapper.find('label.form-check-label').exists()).toBe(true)
+      })
+    })
+
+    // Mirror of the BFormCheckbox tests: BFormRadio uses the same own-label template
+    // condition (`hasDefaultSlot || !resolvedPlain`), so the claim logic is identical.
+    describe('BFormRadio label-for claim depends on own label', () => {
+      it('claims label-for when plain and no slot (no own label)', async () => {
+        const wrapper = mount(BFormGroup, {
+          props: {label: 'Pick one'},
+          slots: {default: () => h(BFormRadio, {id: 'opt', plain: true})},
+        })
+        await nextTick()
+        const label = wrapper.find('label.form-label')
+        expect(label.exists()).toBe(true)
+        expect(label.attributes('for')).toBe('opt')
+        expect(wrapper.find('label.form-check-label').exists()).toBe(false)
+      })
+
+      it('does not claim when radio has a default slot (own label rendered)', async () => {
+        const wrapper = mount(BFormGroup, {
+          props: {label: 'Pick one'},
+          slots: {default: () => h(BFormRadio, {id: 'opt'}, () => 'Option A')},
+        })
+        await nextTick()
+        expect(wrapper.find('legend').exists()).toBe(true)
+        expect(wrapper.find('label.form-label').exists()).toBe(false)
+        expect(wrapper.find('label.form-check-label').exists()).toBe(true)
+      })
+    })
   })
 
   describe('horizontal layout', () => {
@@ -752,9 +817,7 @@ describe('form-group', () => {
       expect(label.exists()).toBe(true)
       expect(wrapper.find('legend').exists()).toBe(false)
 
-      // Should be a div with role="group", not a fieldset
-      expect(wrapper.element.tagName).toBe('DIV')
-      expect(wrapper.attributes('role')).toBe('group')
+      expect(wrapper.element.tagName).toBe('FIELDSET')
 
       wrapper.unmount()
     })

--- a/packages/bootstrap-vue-next/src/components/BFormInput/form-input.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/form-input.spec.ts
@@ -2,7 +2,8 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {nextTick, ref} from 'vue'
 import BFormInput from './BFormInput.vue'
-import {formGroupKey, inputGroupKey} from '../../utils/keys'
+import {inputGroupKey} from '../../utils/keys'
+import {provideFormGroupStub} from '../../../tests/utils'
 
 describe('form-input', () => {
   enableAutoUnmount(afterEach)
@@ -504,9 +505,7 @@ describe('form-input', () => {
       const state = ref<boolean | undefined>(undefined)
       const wrapper = mount(BFormInput, {
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.attributes('disabled')).toBeDefined()
@@ -517,9 +516,7 @@ describe('form-input', () => {
       const state = ref<boolean | undefined>(false)
       const wrapper = mount(BFormInput, {
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.classes()).toContain('is-invalid')
@@ -531,9 +528,7 @@ describe('form-input', () => {
       const wrapper = mount(BFormInput, {
         props: {state: true},
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.classes()).toContain('is-valid')
@@ -546,9 +541,7 @@ describe('form-input', () => {
       const wrapper = mount(BFormInput, {
         props: {disabled: false},
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.attributes('disabled')).toBeDefined()

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
@@ -103,7 +103,8 @@ const resolvedPlain = computed(() => resolvedProps.value.plain)
 const hasOwnLabel = computed(() => hasDefaultSlot.value || !resolvedPlain.value)
 
 const labelTargetId = computed(() => (hasOwnLabel.value ? null : computedId.value))
-const formGroupData = inject(formGroupKey, null)?.(labelTargetId)
+const formGroupData = inject(formGroupKey, null)?.()
+formGroupData?.track(labelTargetId)
 
 const localValue = computed({
   get: () => (parentData ? parentData.modelValue.value : modelValue.value),

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
@@ -16,7 +16,7 @@
       :value="props.value"
       :aria-required="computedRequired || undefined"
     />
-    <label v-if="hasDefaultSlot || !resolvedPlain" :for="computedId" :class="labelClasses">
+    <label v-if="hasOwnLabel" :for="computedId" :class="labelClasses">
       <slot />
     </label>
   </ConditionalWrapper>
@@ -66,7 +66,6 @@ const modelValue = defineModel<BFormRadioProps['modelValue']>({
 const computedId = useId(() => props.id, 'form-check')
 
 const parentData = inject(radioGroupKey, null)
-const formGroupData = inject(formGroupKey, null)?.(computedId)
 
 const input = useTemplateRef('_input')
 
@@ -101,6 +100,10 @@ const resolvedProps = computed(() => ({
 
 // Shorthand for template usage
 const resolvedPlain = computed(() => resolvedProps.value.plain)
+const hasOwnLabel = computed(() => hasDefaultSlot.value || !resolvedPlain.value)
+
+const labelTargetId = computed(() => (hasOwnLabel.value ? null : computedId.value))
+const formGroupData = inject(formGroupKey, null)?.(labelTargetId)
 
 const localValue = computed({
   get: () => (parentData ? parentData.modelValue.value : modelValue.value),

--- a/packages/bootstrap-vue-next/src/components/BFormSelect/BFormSelectBase.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormSelect/BFormSelectBase.vue
@@ -79,7 +79,8 @@ const modelValue = defineModel<unknown>({
 
 const computedId = useId(() => props.id, 'input')
 
-const formGroupData = inject(formGroupKey, null)?.(computedId)
+const formGroupData = inject(formGroupKey, null)?.()
+formGroupData?.track(computedId)
 const isDisabled = computed(() => props.disabled || (formGroupData?.disabled.value ?? false))
 
 const selectSizeNumber = useToNumber(() => props.selectSize)

--- a/packages/bootstrap-vue-next/src/components/BFormSelect/form-select-base.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormSelect/form-select-base.spec.ts
@@ -2,7 +2,7 @@ import {afterEach, describe, expect, it} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {h, ref} from 'vue'
 import BFormSelectBase from './BFormSelectBase.vue'
-import {formGroupKey} from '../../utils/keys'
+import {provideFormGroupStub} from '../../../tests/utils'
 
 describe('form-select-base', () => {
   enableAutoUnmount(afterEach)
@@ -616,9 +616,7 @@ describe('form-select-base', () => {
     const state = ref<boolean | undefined>(undefined)
     const wrapper = mount(BFormSelectBase, {
       global: {
-        provide: {
-          [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-        },
+        provide: provideFormGroupStub(state, disabled),
       },
     })
     expect(wrapper.attributes('disabled')).toBeDefined()
@@ -630,9 +628,7 @@ describe('form-select-base', () => {
     const wrapper = mount(BFormSelectBase, {
       props: {disabled: false},
       global: {
-        provide: {
-          [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-        },
+        provide: provideFormGroupStub(state, disabled),
       },
     })
     expect(wrapper.attributes('disabled')).toBeDefined()
@@ -644,9 +640,7 @@ describe('form-select-base', () => {
     const wrapper = mount(BFormSelectBase, {
       props: {disabled: false},
       global: {
-        provide: {
-          [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-        },
+        provide: provideFormGroupStub(state, disabled),
       },
     })
     expect(wrapper.attributes('disabled')).toBeUndefined()

--- a/packages/bootstrap-vue-next/src/components/BFormTextarea/form-textarea.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormTextarea/form-textarea.spec.ts
@@ -2,7 +2,7 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {nextTick, ref} from 'vue'
 import BFormTextarea from './BFormTextarea.vue'
-import {formGroupKey} from '../../utils/keys'
+import {provideFormGroupStub} from '../../../tests/utils'
 
 describe('form-textarea', () => {
   enableAutoUnmount(afterEach)
@@ -415,9 +415,7 @@ describe('form-textarea', () => {
       const state = ref<boolean | undefined>(undefined)
       const wrapper = mount(BFormTextarea, {
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.attributes('disabled')).toBeDefined()
@@ -428,9 +426,7 @@ describe('form-textarea', () => {
       const state = ref<boolean | undefined>(false)
       const wrapper = mount(BFormTextarea, {
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.classes()).toContain('is-invalid')
@@ -442,9 +438,7 @@ describe('form-textarea', () => {
       const wrapper = mount(BFormTextarea, {
         props: {state: true},
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.classes()).toContain('is-valid')
@@ -457,9 +451,7 @@ describe('form-textarea', () => {
       const wrapper = mount(BFormTextarea, {
         props: {disabled: false},
         global: {
-          provide: {
-            [formGroupKey as unknown as symbol]: () => ({state, disabled}),
-          },
+          provide: provideFormGroupStub(state, disabled),
         },
       })
       expect(wrapper.attributes('disabled')).toBeDefined()

--- a/packages/bootstrap-vue-next/src/composables/useFormInput.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormInput.ts
@@ -21,7 +21,8 @@ export const useFormInput = (
   const debounceMaxWaitNumber = useToNumber(() => props.debounceMaxWait ?? Number.NaN)
 
   // This automatically adds the appropriate "for" attribute to a BFormGroup label
-  const formGroupData = inject(formGroupKey, null)?.(computedId)
+  const formGroupData = inject(formGroupKey, null)?.()
+  formGroupData?.track(computedId)
   const computedState = computed(() =>
     props.state !== undefined ? props.state : (formGroupData?.state.value ?? null)
   )

--- a/packages/bootstrap-vue-next/src/composables/useProvideFormGroupData.ts
+++ b/packages/bootstrap-vue-next/src/composables/useProvideFormGroupData.ts
@@ -1,4 +1,4 @@
-import {computed, onUnmounted, provide, type Ref, ref, watch} from 'vue'
+import {computed, onUnmounted, provide, type Ref, shallowRef} from 'vue'
 import type {ValidationState} from '../types/CommonTypes'
 import {formGroupKey} from '../utils/keys'
 
@@ -9,44 +9,36 @@ import {formGroupKey} from '../utils/keys'
  * passed-through state/disabled, acting as a boundary — their registry exists but is unused,
  * so descendant claims never reach an outer BFormGroup.
  */
-export const useProvideFormGroupData = (opts: {
+export const useProvideFormGroupData = ({
+  state,
+  disabled,
+}: {
   state: Readonly<Ref<ValidationState | undefined>>
   disabled: Readonly<Ref<boolean>>
 }) => {
-  const {state, disabled} = opts
-  const labelTargetIds = ref<string[]>([])
-  const registerLabelTarget = (id: string) => {
-    labelTargetIds.value.push(id)
-  }
-  const unregisterLabelTarget = (id: string) => {
-    const idx = labelTargetIds.value.indexOf(id)
-    if (idx !== -1) labelTargetIds.value.splice(idx, 1)
-  }
+  const labelTargetIds = shallowRef<Readonly<Ref<string | null>>[]>([])
 
-  // The callback runs in the descendant's setup, so watch/onUnmounted bind to the descendant.
+  // The callback runs in the descendant's setup, so onUnmounted binds to the descendant.
   provide(formGroupKey, (idRef) => {
     if (idRef) {
-      watch(
-        idRef,
-        (curr, prev) => {
-          if (prev) unregisterLabelTarget(prev)
-          if (curr) registerLabelTarget(curr)
-        },
-        {immediate: true}
-      )
+      labelTargetIds.value = [...labelTargetIds.value, idRef]
       onUnmounted(() => {
-        if (idRef.value) unregisterLabelTarget(idRef.value)
+        labelTargetIds.value = labelTargetIds.value.filter((r) => r !== idRef)
       })
     }
     return {state, disabled}
   })
 
-  // null unless exactly one distinct id is registered.
+  // null unless exactly one distinct non-empty id is currently registered.
   const singleLabelTargetId = computed<string | null>(() => {
-    const ids = labelTargetIds.value
-    if (!ids.length) return null
-    const first = ids[0]
-    return ids.every((id) => id === first) ? first || null : null
+    let single: string | null = null
+    for (const r of labelTargetIds.value) {
+      const v = r.value
+      if (!v) continue
+      if (single !== null && single !== v) return null
+      single = v
+    }
+    return single
   })
 
   return {singleLabelTargetId}

--- a/packages/bootstrap-vue-next/src/composables/useProvideFormGroupData.ts
+++ b/packages/bootstrap-vue-next/src/composables/useProvideFormGroupData.ts
@@ -1,0 +1,53 @@
+import {computed, onUnmounted, provide, type Ref, ref, watch} from 'vue'
+import type {ValidationState} from '../types/CommonTypes'
+import {formGroupKey} from '../utils/keys'
+
+/**
+ * Provides formGroupKey for descendant form controls. Each provider has its own isolated
+ * label-target registry: BFormGroup uses the resulting `singleLabelTargetId` to drive its
+ * label/legend rendering. Intermediate components (e.g. BFormFloatingLabel) call this with
+ * passed-through state/disabled, acting as a boundary — their registry exists but is unused,
+ * so descendant claims never reach an outer BFormGroup.
+ */
+export const useProvideFormGroupData = (opts: {
+  state: Readonly<Ref<ValidationState | undefined>>
+  disabled: Readonly<Ref<boolean>>
+}) => {
+  const {state, disabled} = opts
+  const labelTargetIds = ref<string[]>([])
+  const registerLabelTarget = (id: string) => {
+    labelTargetIds.value.push(id)
+  }
+  const unregisterLabelTarget = (id: string) => {
+    const idx = labelTargetIds.value.indexOf(id)
+    if (idx !== -1) labelTargetIds.value.splice(idx, 1)
+  }
+
+  // The callback runs in the descendant's setup, so watch/onUnmounted bind to the descendant.
+  provide(formGroupKey, (idRef) => {
+    if (idRef) {
+      watch(
+        idRef,
+        (curr, prev) => {
+          if (prev) unregisterLabelTarget(prev)
+          if (curr) registerLabelTarget(curr)
+        },
+        {immediate: true}
+      )
+      onUnmounted(() => {
+        if (idRef.value) unregisterLabelTarget(idRef.value)
+      })
+    }
+    return {state, disabled}
+  })
+
+  // null unless exactly one distinct id is registered.
+  const singleLabelTargetId = computed<string | null>(() => {
+    const ids = labelTargetIds.value
+    if (!ids.length) return null
+    const first = ids[0]
+    return ids.every((id) => id === first) ? first || null : null
+  })
+
+  return {singleLabelTargetId}
+}

--- a/packages/bootstrap-vue-next/src/composables/useProvideFormGroupData.ts
+++ b/packages/bootstrap-vue-next/src/composables/useProvideFormGroupData.ts
@@ -2,6 +2,20 @@ import {computed, onUnmounted, provide, type Ref, shallowRef} from 'vue'
 import type {ValidationState} from '../types/CommonTypes'
 import {formGroupKey} from '../utils/keys'
 
+const useLabelTargetRegistry = () => {
+  const labelTargetIds = shallowRef<Readonly<Ref<string | null>>[]>([])
+
+  // Track runs in the descendant's setup, so onUnmounted binds to the descendant.
+  const track = (idRef: Readonly<Ref<string | null>>) => {
+    labelTargetIds.value = [...labelTargetIds.value, idRef]
+    onUnmounted(() => {
+      labelTargetIds.value = labelTargetIds.value.filter((r: Readonly<Ref<string | null>>) => r !== idRef)
+    })
+  }
+
+  return {labelTargetIds, track}
+}
+
 /**
  * Provides formGroupKey for descendant form controls. Each provider has its own isolated
  * label-target registry: BFormGroup uses the resulting `singleLabelTargetId` to drive its
@@ -16,18 +30,9 @@ export const useProvideFormGroupData = ({
   state: Readonly<Ref<ValidationState | undefined>>
   disabled: Readonly<Ref<boolean>>
 }) => {
-  const labelTargetIds = shallowRef<Readonly<Ref<string | null>>[]>([])
+  const {labelTargetIds, track} = useLabelTargetRegistry()
 
-  // The callback runs in the descendant's setup, so onUnmounted binds to the descendant.
-  provide(formGroupKey, (idRef) => {
-    if (idRef) {
-      labelTargetIds.value = [...labelTargetIds.value, idRef]
-      onUnmounted(() => {
-        labelTargetIds.value = labelTargetIds.value.filter((r) => r !== idRef)
-      })
-    }
-    return {state, disabled}
-  })
+  provide(formGroupKey, () => ({state, disabled, track}))
 
   // null unless exactly one distinct non-empty id is currently registered.
   const singleLabelTargetId = computed<string | null>(() => {

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -225,17 +225,18 @@ export const orchestratorRegistryKey: InjectionKey<{
 
 /**
  * Provided by an ancestor BFormGroup (or boundary like BFormFloatingLabel). Called once at
- * descendant setup to obtain state/disabled. The optional `idRef` claims the group's
- * `<label for="...">` target — supply it from a form control without its own label
- * (BFormInput, BFormTextarea, BFormSelect, or a plain BFormCheckbox/BFormRadio with no
- * slot). Pass null when the consumer only needs state/disabled and must not claim
- * label-for (BFormCheckbox/BFormRadio that render their own label, BFormFloatingLabel
+ * descendant setup to obtain state/disabled and a `track` callback. Call `track(idRef)` to
+ * claim the group's `<label for="...">` target — used by form controls without their own
+ * label (BFormInput, BFormTextarea, BFormSelect, or a plain BFormCheckbox/BFormRadio with
+ * no slot). Skip `track` entirely when the consumer only needs state/disabled and must not
+ * claim label-for (BFormCheckbox/BFormRadio that render their own label, BFormFloatingLabel
  * acting as a boundary, ARIA-role custom widgets).
  */
 export const formGroupKey: InjectionKey<
-  (idRef: Readonly<Ref<string | null>> | null) => {
+  () => {
     state: Readonly<Ref<ValidationState | undefined>>
     disabled: Readonly<Ref<boolean>>
+    track: (idRef: Readonly<Ref<string | null>>) => void
   }
 > = createBvnInjectionKey('formGroupPlugin')
 

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -223,8 +223,17 @@ export const orchestratorRegistryKey: InjectionKey<{
   _isOrchestratorInstalled: Ref<boolean>
 }> = createBvnRegistryInjectionKey('orchestrator')
 
+/**
+ * Provided by an ancestor BFormGroup (or boundary like BFormFloatingLabel). Called once at
+ * descendant setup to obtain state/disabled. The optional `idRef` claims the group's
+ * `<label for="...">` target — supply it from a form control without its own label
+ * (BFormInput, BFormTextarea, BFormSelect, or a plain BFormCheckbox/BFormRadio with no
+ * slot). Pass null when the consumer only needs state/disabled and must not claim
+ * label-for (BFormCheckbox/BFormRadio that render their own label, BFormFloatingLabel
+ * acting as a boundary, ARIA-role custom widgets).
+ */
 export const formGroupKey: InjectionKey<
-  (idRef?: Readonly<Ref<string | null>>) => {
+  (idRef: Readonly<Ref<string | null>> | null) => {
     state: Readonly<Ref<ValidationState | undefined>>
     disabled: Readonly<Ref<boolean>>
   }

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -224,7 +224,7 @@ export const orchestratorRegistryKey: InjectionKey<{
 }> = createBvnRegistryInjectionKey('orchestrator')
 
 export const formGroupKey: InjectionKey<
-  (id: Ref<string>) => {
+  (idRef?: Readonly<Ref<string | null>>) => {
     state: Readonly<Ref<ValidationState | undefined>>
     disabled: Readonly<Ref<boolean>>
   }

--- a/packages/bootstrap-vue-next/tests/utils.ts
+++ b/packages/bootstrap-vue-next/tests/utils.ts
@@ -1,5 +1,7 @@
-import {defineComponent, h} from 'vue'
+import {defineComponent, h, type Ref} from 'vue'
 import {mount} from '@vue/test-utils'
+import {formGroupKey} from '../src/utils/keys'
+import type {ValidationState} from '../src/types/CommonTypes'
 
 export const createContainer = (tag = 'div'): HTMLElement => {
   const container = document.createElement(tag)
@@ -20,3 +22,10 @@ export const useSetup = <V>(setup: () => V) => {
 
   return mount(Comp)
 }
+
+export const provideFormGroupStub = (
+  state: Ref<ValidationState | undefined>,
+  disabled: Ref<boolean>
+) => ({
+  [formGroupKey as unknown as symbol]: () => ({state, disabled, track: () => {}}),
+})


### PR DESCRIPTION
# Describe the PR

Issues before our changes
- Auto label-for picked the last ID it saw if there were one or more inputs.
- Despite the docs saying about leaving the label-for prop empty for multiple inputs, because of the auto label-for behaviour, that was impossible.
- The last wins behaviour of auto label-for could lead to various undesirable situations: Wrong field focused (if any field was to be focused by clicking the label, only the first field makes sense). Where a checkbox/radio was the last field, this is even worse because a click on the form group's label would lead to a selection being made that seems arbitrary to the user.
- Differentiating between fieldset and div[role=group] is pointless. A fieldset implies ARIA role=group. Fieldsets are legal with only 1 input and no legend. So there's no benefit to div[role=group] that I can come up with.
- Auto for-label on the form group was applied even for BFormCheckbox/BFormRadio, which had their own labels already.
- BFormFloatingLabel could be used to label an input already, but that input would still be eligible for auto label-for if contained within a form group.
- BootstrapVue didn't have this auto label-for behaviour, it's a BootstrapVueNext improvement (ce016480358f50653354d27b3d4ad59db58a221f) that happens to have also caused a regression. So in BootstrapVue, if you didn't set label-for you'd unconditionally get fieldset/legend.

Implementation details regarding the proposed fix:
- Implements a register/unregister pattern using provide/inject, similar to what's already used in BTabs and BAccordion. Triggered during initial setup, by ID changes and when unmounted.
- A new `useProvideFormGroupData` composable encapsulates the provide-side machinery (registry, watch, onUnmounted) and is used by both BFormGroup and BFormFloatingLabel - boundaries are just re-providing with passed-through state/disabled and a fresh isolated registry that nothing reads.
- The injection contract is a callback. The arg is an optional `Readonly<Ref<string | null>>`: pass an id-ref to claim label-for; pass nothing to consume state/disabled without claiming. That's how checkbox/radio opt out when they render their own label - the ref resolves to null, the watch sees null, no claim.
- BFormFloatingLabel properly stops the propagation of the inputs for auto label-for purposes.
- Checkboxes/radios with their own internal label do not attempt to register.
- Eliminating the switching between fieldset and div[role=group] is necessary because the :is="..." causes unmount/mount of the children in the default slot - which creates a feedback loop of the children being unregistered/registered again that would never settle.
- The documented behaviour of the disabled prop on BFormGroup was presumably a consequence of toggling between fieldset/div - I saw no reason to preserve this detail, the disabled prop now works everywhere.
- Tests expanded: multi-input fallback to legend, BFormCheckbox/BFormRadio claim-vs-skip cases (one positive, one negative each).
- Docs updated, including multi-input example in the BFormGroup docs.

This is a larger first PR than I'd ideally contribute for the first time, but it all needed to be tackled together.

## Small replication

Before this PR, with no `label-for` set:

```vue
<BFormGroup label="Range">
  <BInputGroup>
    <BFormInput placeholder="Start" />
    <BFormInput placeholder="End" />
  </BInputGroup>
</BFormGroup>
```

BFormGroup rendered `<label for="end-input-id">Range</label>` - pointing at whichever input registered last. Clicking the label focused the wrong field. The docs claimed leaving `label-for` empty for multi-input groups would render `<legend>`, but auto label-for made that impossible. After this PR the same markup renders `<fieldset><legend>Range</legend>...</fieldset>`.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a demo showing a form group with multiple input fields.

* **Bug Fixes**
  * Improved label association for grouped/multi-input controls; falls back to a legend when association is ambiguous.
  * Ensured form groups consistently render as fieldsets and correctly propagate disabled state, including when floating labels or controls provide their own labels.

* **Documentation**
  * Clarified form-group labeling, accessibility guidance, and recommendations for multi-input scenarios.

* **Tests**
  * Updated tests to match new DOM/labeling and disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->